### PR TITLE
Issue 94 datastore fix release criteria

### DIFF
--- a/.github/workflows/datastore-publish-package.yml
+++ b/.github/workflows/datastore-publish-package.yml
@@ -78,7 +78,7 @@ jobs:
           find . -maxdepth 2 -type f -o -type d | head -20
           
           # Validate required directories exist before cleanup
-          if [ ! -d "./datastore" ] || [ ! -d "./nachet" ]; then
+          if [ ! -d "./datastore" ] ]; then
             echo "Error: Required directories (datastore or nachet) not found"
             exit 1
           fi

--- a/datastore/pyproject.toml
+++ b/datastore/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nachet_datastore"
-version = "1.1.7"
+version = "1.1.8"
 authors = [
   { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" },
   { name="Sylvanie You", email="Sylvanie.You@inspection.gc.ca"}

--- a/datastore/uv.lock
+++ b/datastore/uv.lock
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "nachet-datastore"
-version = "1.1.7"
+version = "1.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
closes #94

This pull request includes a version bump for the `nachet_datastore` package and a minor fix to the GitHub Actions workflow script. The workflow script now only checks for the existence of the `datastore` directory, not both `datastore` and `nachet`.

Version update:

* Bumped the `nachet_datastore` package version from `1.1.7` to `1.1.8` in `datastore/pyproject.toml`.

CI/CD workflow fix:

* Updated `.github/workflows/datastore-publish-package.yml` to only require the `datastore` directory to exist before cleanup, removing the check for the `nachet` directory.