### PR TITLE
Issue 98 frontend fox workflow version check

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -58,6 +58,7 @@ jobs:
       
       - name: Get target branch version
         id: target-version
+        if: github.event_name == 'pull_request'
         run: |
           git fetch origin ${{ github.base_ref }}
           TARGET_VERSION=$(git show origin/${{ github.base_ref }}:frontend/package.json | jq -r '.version')
@@ -65,6 +66,7 @@ jobs:
           echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
       
       - name: Compare versions
+        if: github.event_name == 'pull_request'
         run: |
           PR_VERSION="${{ steps.pr-version.outputs.version }}"
           TARGET_VERSION="${{ steps.target-version.outputs.version }}"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.10",
+  "version": "0.9.11",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
closes #98

This pull request includes a version bump for the frontend package and a minor update to the frontend lint workflow. The version is incremented from 0.9.10 to 0.9.11, and the workflow is improved to ensure certain steps only run for pull request events.

Version updates:

* Bumped the version of the frontend package from 0.9.10 to 0.9.11 in both `frontend/package.json` and `frontend/package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)

CI workflow improvements:

* Updated `.github/workflows/frontend-lint.yml` to add a conditional so that the "Get target branch version" and "Compare versions" steps only run when the event is a pull request.