### PR TITLE
Issue 98 frontend workflow fix version check logic

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -58,7 +58,7 @@ jobs:
       
       - name: Get target branch version
         id: target-version
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
         run: |
           git fetch origin ${{ github.base_ref }}
           TARGET_VERSION=$(git show origin/${{ github.base_ref }}:frontend/package.json | jq -r '.version')
@@ -66,7 +66,7 @@ jobs:
           echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
       
       - name: Compare versions
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
         run: |
           PR_VERSION="${{ steps.pr-version.outputs.version }}"
           TARGET_VERSION="${{ steps.target-version.outputs.version }}"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.11",
+  "version": "0.9.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request makes a small update to the frontend package version, incrementing it from 0.9.11 to 0.9.12, and improves the frontend lint workflow by ensuring version checks only run for open pull requests.

Version bump:

* Updated `version` field from `0.9.11` to `0.9.12` in both `frontend/package.json` and `frontend/package-lock.json` to reflect a new release. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)

CI workflow improvement:

* Modified `.github/workflows/frontend-lint.yml` to skip version comparison steps when a pull request is closed, preventing unnecessary CI runs.