### PR TITLE
Issue 98 frontend workflow fix permissions

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -2,7 +2,7 @@ name: Frontend Lint
 permissions:
   contents: write
   pull-requests: write
-  actions: read
+  actions: write
 
 on:
   pull_request:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.12",
+  "version": "0.9.13",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a version bump for the frontend package, updating it from 0.9.12 to 0.9.13. Additionally, it modifies GitHub Actions permissions for the frontend lint workflow.

Version bump:

* Updated the `version` field from 0.9.12 to 0.9.13 in both `frontend/package.json` and `frontend/package-lock.json` to reflect a new release. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)

CI/CD workflow permissions:

* Changed the `actions` permission from `read` to `write` in `.github/workflows/frontend-lint.yml`, which may be required for certain workflow operations.