### PR TITLE
Issue 98 frontend workflow fix renovate trigger release

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -58,7 +58,7 @@ jobs:
       
       - name: Get target branch version
         id: target-version
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.merged
         run: |
           git fetch origin ${{ github.base_ref }}
           TARGET_VERSION=$(git show origin/${{ github.base_ref }}:frontend/package.json | jq -r '.version')
@@ -66,7 +66,7 @@ jobs:
           echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
       
       - name: Compare versions
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.merged
         run: |
           PR_VERSION="${{ steps.pr-version.outputs.version }}"
           TARGET_VERSION="${{ steps.target-version.outputs.version }}"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.14",
+      "version": "0.9.15",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.14",
+  "version": "0.9.15",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes a version bump for the frontend package and a minor update to the GitHub Actions workflow for linting. The workflow now ensures that certain steps only run when the pull request is open and not yet merged.

Version update:

* Bumped the `nachet-frontend` package version from `0.9.14` to `0.9.15` in both `frontend/package.json` and `frontend/package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)

CI workflow improvement:

* Updated `.github/workflows/frontend-lint.yml` to skip the "Get target branch version" and "Compare versions" steps if the pull request has already been merged, preventing unnecessary execution.