### PR TITLE
Issue 98 frontend workflow fix release trigger

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -56,20 +56,36 @@ jobs:
           echo "PR version: $PR_VERSION"
           echo "version=$PR_VERSION" >> $GITHUB_OUTPUT
       
-      - name: Get target branch version
-        id: target-version
-        if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.merged
+      - name: Get latest version
+        id: get_latest_version
         run: |
-          git fetch origin ${{ github.base_ref }}
-          TARGET_VERSION=$(git show origin/${{ github.base_ref }}:frontend/package.json | jq -r '.version')
+          package_name="nachet-frontend"
+          if [ -z "$package_name" ]; then
+            tags=$(git tag --list "v*" --sort=-creatordate | head -n 10)
+          else
+            tags=$(git tag --list "${package_name}-v*" --sort=-creatordate | head -n 10)
+          fi
+          
+          latest_version=""
+          for tag in $tags; do
+            version=$(echo "$tag" | grep -oP '(?<=-v)[0-9]+\.[0-9]+\.[0-9]+')
+            if [ -n "$version" ]; then
+              latest_version="$version"
+              break
+            fi
+          done
+          
+          if [ -z "$latest_version" ]; then
+            latest_version="0.0.0"
+          fi
+          echo "latest_version=$latest_version" >> $GITHUB_OUTPUT
           echo "Target branch version: $TARGET_VERSION"
-          echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
       
       - name: Compare versions
         if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.merged
         run: |
           PR_VERSION="${{ steps.pr-version.outputs.version }}"
-          TARGET_VERSION="${{ steps.target-version.outputs.version }}"
+          TARGET_VERSION="${{ steps.get_latest_version.outputs.latest_version }}"
           
           echo "Comparing versions:"
           echo "  Target branch (${{ github.base_ref }}): $TARGET_VERSION"


### PR DESCRIPTION
This pull request updates the version comparison logic in the `frontend-lint` GitHub Actions workflow. Instead of fetching the version from the target branch's `package.json`, the workflow now determines the latest published version by scanning Git tags, improving reliability and accuracy in version detection.

**Workflow improvements:**

* Changed the step for determining the target version to scan Git tags for the latest version of the `nachet-frontend` package, rather than fetching and parsing `package.json` from the target branch.
* Updated subsequent steps to use the new output (`latest_version`) for version comparison in the workflow.