### PR TITLE
Issue 98 frontend workflow fix release trigger

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -7,8 +7,8 @@ permissions:
 on:
   pull_request:
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-*.yml'
+      - "frontend/**"
+      - ".github/workflows/frontend-*.yml"
     types:
       - opened
       - closed
@@ -17,8 +17,8 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-*.yml'
+      - "frontend/**"
+      - ".github/workflows/frontend-*.yml"
 
 concurrency:
   group: frontend-lint-${{ github.ref }}
@@ -48,14 +48,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Get PR branch version
         id: pr-version
         run: |
           PR_VERSION=$(jq -r '.version' package.json)
           echo "PR version: $PR_VERSION"
           echo "version=$PR_VERSION" >> $GITHUB_OUTPUT
-      
+
       - name: Get latest version
         id: get_latest_version
         run: |
@@ -65,7 +65,7 @@ jobs:
           else
             tags=$(git tag --list "${package_name}-v*" --sort=-creatordate | head -n 10)
           fi
-          
+
           latest_version=""
           for tag in $tags; do
             version=$(echo "$tag" | grep -oP '(?<=-v)[0-9]+\.[0-9]+\.[0-9]+')
@@ -74,23 +74,23 @@ jobs:
               break
             fi
           done
-          
+
           if [ -z "$latest_version" ]; then
             latest_version="0.0.0"
           fi
           echo "latest_version=$latest_version" >> $GITHUB_OUTPUT
           echo "Target branch version: $TARGET_VERSION"
-      
+
       - name: Compare versions
         if: github.event_name == 'pull_request' && github.event.action != 'closed' && !github.event.pull_request.merged
         run: |
           PR_VERSION="${{ steps.pr-version.outputs.version }}"
           TARGET_VERSION="${{ steps.get_latest_version.outputs.latest_version }}"
-          
+
           echo "Comparing versions:"
           echo "  Target branch (${{ github.base_ref }}): $TARGET_VERSION"
           echo "  PR branch: $PR_VERSION"
-          
+
           # Function to compare semantic versions
           compare_versions() {
             local version1=$1
@@ -114,7 +114,7 @@ jobs:
             
             return 1  # versions are equal
           }
-          
+
           if [ "$PR_VERSION" = "$TARGET_VERSION" ]; then
             echo "❌ Version has not been incremented!"
             echo "The version in frontend/package.json ($PR_VERSION) is the same as in the target branch."
@@ -129,7 +129,7 @@ jobs:
             echo "Please ensure the version is incremented properly."
             exit 1
           fi
-      
+
       - name: Extract versions from package.json
         id: versions
         run: |
@@ -149,27 +149,27 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.versions.outputs.node-version }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
-            
+
       - name: Install specific npm version
         run: npm install -g npm@${{ needs.versions.outputs.npm-version }}
-      
+
       - name: Check if package-lock.json is up to date
         run: |
           echo "🔍 Checking if package-lock.json needs updating..."
-          
+
           # Create a backup of the current package-lock.json
           cp package-lock.json package-lock.json.backup
-          
+
           # Run npm install to regenerate package-lock.json
           npm install --package-lock-only
-          
+
           # Compare the files
           if ! cmp -s package-lock.json package-lock.json.backup; then
             echo "❌ package-lock.json is out of date!"
@@ -205,7 +205,7 @@ jobs:
     name: Trigger release workflow
     # This job triggers the publish workflow automatically when a PR is merged to main
     # The publish workflow can also be triggered manually via workflow_dispatch
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.15",
+      "version": "0.9.16",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",
@@ -36,7 +36,7 @@
         "react-webcam": "^7.1.1",
         "serve": "^14.2.4",
         "styled-components": "^6.0.3",
-        "typescript": "^5.8.3",
+        "typescript": "^5.8.2",
         "utif": "^3.1.0",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.15",
+  "version": "0.9.16",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -46,7 +46,7 @@
     "react-webcam": "^7.1.1",
     "serve": "^14.2.4",
     "styled-components": "^6.0.3",
-    "typescript": "^5.8.3",
+    "typescript": "^5.8.2",
     "utif": "^3.1.0",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"


### PR DESCRIPTION
This pull request includes minor updates to the frontend workflow configuration and dependency management. The main changes are adjustments to workflow trigger conditions, a dependency downgrade, and a version bump for the frontend package.

**Workflow configuration updates:**

* The release workflow in `.github/workflows/frontend-lint.yml` now triggers not only on pushes to `main`, but also when pull requests are closed and merged, improving automation for releases.
* Standardized the use of double quotes for path patterns and cache keys in the workflow file for consistency. [[1]](diffhunk://#diff-9d842324f08ec30f144896391dbc94cec01f7b351cb561d8611f7ae3925ad41eL10-R11) [[2]](diffhunk://#diff-9d842324f08ec30f144896391dbc94cec01f7b351cb561d8611f7ae3925ad41eL20-R21) [[3]](diffhunk://#diff-9d842324f08ec30f144896391dbc94cec01f7b351cb561d8611f7ae3925ad41eL157-R157)

**Dependency and version management:**

* Downgraded the `typescript` dependency from `^5.8.3` to `^5.8.2` in both `frontend/package.json` and `frontend/package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L49-R49) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL39-R39)
* Bumped the frontend package version from `0.9.15` to `0.9.16` in both `frontend/package.json` and `frontend/package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)