### PR TITLE
Issue 106 frontend update typescript

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",
@@ -36,7 +36,7 @@
         "react-webcam": "^7.1.1",
         "serve": "^14.2.4",
         "styled-components": "^6.0.3",
-        "typescript": "^5.8.2",
+        "typescript": "^5.9.2",
         "utif": "^3.1.0",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
@@ -11204,9 +11204,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.16",
+  "version": "0.9.17",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -46,7 +46,7 @@
     "react-webcam": "^7.1.1",
     "serve": "^14.2.4",
     "styled-components": "^6.0.3",
-    "typescript": "^5.8.2",
+    "typescript": "^5.9.2",
     "utif": "^3.1.0",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"


### PR DESCRIPTION
closes #106 

This pull request updates the frontend dependencies to use the latest version of TypeScript. The `typescript` package is upgraded from version 5.8.x to 5.9.2, and the project version is incremented to 0.9.17 to reflect this change.

Dependency updates:

* Upgraded the `typescript` dependency from `^5.8.2` to `^5.9.2` in both `package.json` and `package-lock.json` to use the latest TypeScript features and bug fixes. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L49-R49) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL39-R39) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL11207-R11209)

Project versioning:

* Bumped the project version from `0.9.16` to `0.9.17` in both `package.json` and `package-lock.json` to reflect the dependency update. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)