### PR TITLE
Issue 112 frontend update axios

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.18",
+      "version": "0.9.19",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",
@@ -17,7 +17,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
-        "axios": "^1.6.0",
+        "axios": "^1.11.0",
         "browser-image-compression": "^2.0.2",
         "express": "^4.18.2",
         "file-saver": "^2.0.5",
@@ -4744,12 +4744,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.18",
+  "version": "0.9.19",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -27,7 +27,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
-    "axios": "^1.6.0",
+    "axios": "^1.11.0",
     "browser-image-compression": "^2.0.2",
     "express": "^4.18.2",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
closes #112

This pull request updates the frontend dependencies, primarily focusing on upgrading the `axios` library to a newer version. The changes also include a minor version bump for the frontend application.

Dependency updates:

* Upgraded `axios` from version `1.6.0` to `1.11.0` in both `package.json` and `package-lock.json`, which may include bug fixes, security patches, and new features. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L30-R30) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL20-R20) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL4747-R4752)
* Updated the `form-data` dependency used by `axios` from `^4.0.0` to `^4.0.4` in `package-lock.json`.

Version bump:

* Incremented the frontend application version from `0.9.18` to `0.9.19` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)