### PR TITLE
Issue 123 datastore update azure deps

### DIFF
--- a/datastore/pyproject.toml
+++ b/datastore/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nachet_datastore"
-version = "1.1.8"
+version = "1.1.9"
 authors = [
   { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" },
   { name="Sylvanie You", email="Sylvanie.You@inspection.gc.ca"}
@@ -19,8 +19,8 @@ classifiers = [
 ]
 dependencies = [
     "azure-core==1.35.0",
-    "azure-identity==1.23.0",
-    "azure-storage-blob==12.25.1",
+    "azure-identity==1.23.1",
+    "azure-storage-blob==12.26.0",
     "numpy==1.26.4",
     "pillow==10.3.0",
     "psycopg==3.1.19",

--- a/datastore/uv.lock
+++ b/datastore/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "azure-identity"
-version = "1.23.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -36,14 +36,14 @@ dependencies = [
     { name = "msal-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/52/458c1be17a5d3796570ae2ed3c6b7b55b134b22d5ef8132b4f97046a9051/azure_identity-1.23.0.tar.gz", hash = "sha256:d9cdcad39adb49d4bb2953a217f62aec1f65bbb3c63c9076da2be2a47e53dde4", size = 265280 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/29/1201ffbb6a57a16524dd91f3e741b4c828a70aaba436578bdcb3fbcb438c/azure_identity-1.23.1.tar.gz", hash = "sha256:226c1ef982a9f8d5dcf6e0f9ed35eaef2a4d971e7dd86317e9b9d52e70a035e4", size = 266185 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/16/a51d47780f41e4b87bb2d454df6aea90a44a346e918ac189d3700f3d728d/azure_identity-1.23.0-py3-none-any.whl", hash = "sha256:dbbeb64b8e5eaa81c44c565f264b519ff2de7ff0e02271c49f3cb492762a50b0", size = 186097 },
+    { url = "https://files.pythonhosted.org/packages/99/b3/e2d7ab810eb68575a5c7569b03c0228b8f4ce927ffa6211471b526f270c9/azure_identity-1.23.1-py3-none-any.whl", hash = "sha256:7eed28baa0097a47e3fb53bd35a63b769e6b085bb3cb616dfce2b67f28a004a1", size = 186810 },
 ]
 
 [[package]]
 name = "azure-storage-blob"
-version = "12.25.1"
+version = "12.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -51,9 +51,9 @@ dependencies = [
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/f764536c25cc3829d36857167f03933ce9aee2262293179075439f3cd3ad/azure_storage_blob-12.25.1.tar.gz", hash = "sha256:4f294ddc9bc47909ac66b8934bd26b50d2000278b10ad82cc109764fdc6e0e3b", size = 570541 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/95/3e3414491ce45025a1cde107b6ae72bf72049e6021597c201cd6a3029b9a/azure_storage_blob-12.26.0.tar.gz", hash = "sha256:5dd7d7824224f7de00bfeb032753601c982655173061e242f13be6e26d78d71f", size = 583332 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/33/085d9352d416e617993821b9d9488222fbb559bc15c3641d6cbd6d16d236/azure_storage_blob-12.25.1-py3-none-any.whl", hash = "sha256:1f337aab12e918ec3f1b638baada97550673911c4ceed892acc8e4e891b74167", size = 406990 },
+    { url = "https://files.pythonhosted.org/packages/5b/64/63dbfdd83b31200ac58820a7951ddfdeed1fbee9285b0f3eae12d1357155/azure_storage_blob-12.26.0-py3-none-any.whl", hash = "sha256:8c5631b8b22b4f53ec5fff2f3bededf34cfef111e2af613ad42c9e6de00a77fe", size = 412907 },
 ]
 
 [[package]]
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "nachet-datastore"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },
@@ -367,8 +367,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "azure-core", specifier = "==1.35.0" },
-    { name = "azure-identity", specifier = "==1.23.0" },
-    { name = "azure-storage-blob", specifier = "==12.25.1" },
+    { name = "azure-identity", specifier = "==1.23.1" },
+    { name = "azure-storage-blob", specifier = "==12.26.0" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "pillow", specifier = "==10.3.0" },
     { name = "psycopg", specifier = "==3.1.19" },


### PR DESCRIPTION
closes #123 

This pull request makes minor updates to the `nachet_datastore` Python package, primarily updating its version and upgrading two Azure-related dependencies.

- Version bump:
  * Increased the package version from `1.1.8` to `1.1.9` in `pyproject.toml`.

- Dependency updates:
  * Upgraded `azure-identity` from version `1.23.0` to `1.23.1` in `pyproject.toml`.
  * Upgraded `azure-storage-blob` from version `12.25.1` to `12.26.0` in `pyproject.toml`.