### PR TITLE
Issue 125 frontend update workflow sha references

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -113,7 +113,7 @@ jobs:
           echo "Files and directories after cleanup:"
           find . -maxdepth 2 -type f -o -type d | head -20
 
-      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
+      - uses: EndBug/add-and-commit@af62f267410b647327457e1a82a6686727fcb8a0
         with:
           message: "Release frontend nachet-frontend-v${{ steps.versions.outputs.app-version }}"
           add: "."

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.9.21",
+      "version": "0.9.22",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.9.21",
+  "version": "0.9.22",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
ref #125

This pull request includes a version bump for the frontend package and updates the GitHub Actions workflow to use a newer commit of the `EndBug/add-and-commit` action.

Version update:

* Bumped the frontend package version from `0.9.21` to `0.9.22` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)

CI/CD workflow update:

* Updated the `EndBug/add-and-commit` GitHub Action to a newer commit in `.github/workflows/frontend-release.yml`.