### PR TITLE
Issue 125 datastore update workflow sha refs

### DIFF
--- a/.github/workflows/datastore-lint.yml
+++ b/.github/workflows/datastore-lint.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Install uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        uses: astral-sh/setup-uv@142240426d0e82f3e584603c3aa194c582f5aed3
         with:
           version: "latest"
       

--- a/.github/workflows/datastore-publish-package.yml
+++ b/.github/workflows/datastore-publish-package.yml
@@ -94,7 +94,7 @@ jobs:
           echo "Files and directories after cleanup:"
           find . -maxdepth 2 -type f -o -type d | head -20
 
-      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
+      - uses: EndBug/add-and-commit@af62f267410b647327457e1a82a6686727fcb8a0
         with:
           message: "Release nachet-datastore-v${{ steps.versions.outputs.app-version }}"
           add: "."

--- a/.github/workflows/datastore-tests.yml
+++ b/.github/workflows/datastore-tests.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        uses: astral-sh/setup-uv@142240426d0e82f3e584603c3aa194c582f5aed3
 
       - name: Install dependencies
         run: |

--- a/datastore/pyproject.toml
+++ b/datastore/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nachet_datastore"
-version = "1.1.9"
+version = "1.1.10"
 authors = [
   { name="Francois Werbrouck", email="francois.werbrouck@inspection.gc.ca" },
   { name="Sylvanie You", email="Sylvanie.You@inspection.gc.ca"}

--- a/datastore/uv.lock
+++ b/datastore/uv.lock
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "nachet-datastore"
-version = "1.1.9"
+version = "1.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
ref #125

This pull request includes minor updates focused on dependency and workflow maintenance, as well as a version bump for the `nachet_datastore` package.

- Version Update:
  * Bumped the `nachet_datastore` package version from `1.1.9` to `1.1.10` in `pyproject.toml` to prepare for a new release.

- GitHub Actions Maintenance:
  * Updated the `astral-sh/setup-uv` action to a newer commit hash in both `.github/workflows/datastore-lint.yml` and `.github/workflows/datastore-tests.yml` to ensure up-to-date dependency management tooling. [[1]](diffhunk://#diff-cd3f6248d26dd8bf74ac51826311a89a2afeed10a941196cd8d451b15b7cf4aeL70-R70) [[2]](diffhunk://#diff-a1a1c0ade5d6daf5776d127538e5b4218e6afd4ab5f0401c676028c5cf127c2fL58-R58)
  * Updated the `EndBug/add-and-commit` action to a newer commit hash in `.github/workflows/datastore-publish-package.yml` for improved reliability and security in the release workflow.