### PR TITLE
Issue 125 backend update workflow sha refs

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Install uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        uses: astral-sh/setup-uv@142240426d0e82f3e584603c3aa194c582f5aed3
         with:
           version: "latest"
       

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -94,7 +94,7 @@ jobs:
           echo "Files and directories after cleanup:"
           find . -maxdepth 2 -type f -o -type d | head -20
 
-      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
+      - uses: EndBug/add-and-commit@af62f267410b647327457e1a82a6686727fcb8a0
         with:
           message: "Release nachet-backend-v${{ steps.versions.outputs.app-version }}"
           add: "."

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        uses: astral-sh/setup-uv@142240426d0e82f3e584603c3aa194c582f5aed3
 
       - name: Install dependencies
         run: |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "1.0.0"
+version = "1.0.1"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "nachet-datastore @ git+https://github.com/ai-cfia/nachet.git@nachet-datastore-v1.1.3#subdirectory=datastore",
+    "nachet-datastore @ git+https://github.com/ai-cfia/nachet.git@nachet-datastore-v1.1.10#subdirectory=datastore",
     # "nachet-datastore @ file:///home/path/to/nachet/datastore",
     "numpy==1.26.4",
     "azure-storage-blob",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "azure-identity"
-version = "1.23.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -45,14 +45,14 @@ dependencies = [
     { name = "msal-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/52/458c1be17a5d3796570ae2ed3c6b7b55b134b22d5ef8132b4f97046a9051/azure_identity-1.23.0.tar.gz", hash = "sha256:d9cdcad39adb49d4bb2953a217f62aec1f65bbb3c63c9076da2be2a47e53dde4", size = 265280 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/29/1201ffbb6a57a16524dd91f3e741b4c828a70aaba436578bdcb3fbcb438c/azure_identity-1.23.1.tar.gz", hash = "sha256:226c1ef982a9f8d5dcf6e0f9ed35eaef2a4d971e7dd86317e9b9d52e70a035e4", size = 266185 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/16/a51d47780f41e4b87bb2d454df6aea90a44a346e918ac189d3700f3d728d/azure_identity-1.23.0-py3-none-any.whl", hash = "sha256:dbbeb64b8e5eaa81c44c565f264b519ff2de7ff0e02271c49f3cb492762a50b0", size = 186097 },
+    { url = "https://files.pythonhosted.org/packages/99/b3/e2d7ab810eb68575a5c7569b03c0228b8f4ce927ffa6211471b526f270c9/azure_identity-1.23.1-py3-none-any.whl", hash = "sha256:7eed28baa0097a47e3fb53bd35a63b769e6b085bb3cb616dfce2b67f28a004a1", size = 186810 },
 ]
 
 [[package]]
 name = "azure-storage-blob"
-version = "12.25.1"
+version = "12.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -60,9 +60,9 @@ dependencies = [
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/f764536c25cc3829d36857167f03933ce9aee2262293179075439f3cd3ad/azure_storage_blob-12.25.1.tar.gz", hash = "sha256:4f294ddc9bc47909ac66b8934bd26b50d2000278b10ad82cc109764fdc6e0e3b", size = 570541 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/95/3e3414491ce45025a1cde107b6ae72bf72049e6021597c201cd6a3029b9a/azure_storage_blob-12.26.0.tar.gz", hash = "sha256:5dd7d7824224f7de00bfeb032753601c982655173061e242f13be6e26d78d71f", size = 583332 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/33/085d9352d416e617993821b9d9488222fbb559bc15c3641d6cbd6d16d236/azure_storage_blob-12.25.1-py3-none-any.whl", hash = "sha256:1f337aab12e918ec3f1b638baada97550673911c4ceed892acc8e4e891b74167", size = 406990 },
+    { url = "https://files.pythonhosted.org/packages/5b/64/63dbfdd83b31200ac58820a7951ddfdeed1fbee9285b0f3eae12d1357155/azure_storage_blob-12.26.0-py3-none-any.whl", hash = "sha256:8c5631b8b22b4f53ec5fff2f3bededf34cfef111e2af613ad42c9e6de00a77fe", size = 412907 },
 ]
 
 [[package]]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
@@ -468,7 +468,7 @@ requires-dist = [
     { name = "cryptography" },
     { name = "flask", specifier = "==3.0.3" },
     { name = "hypercorn" },
-    { name = "nachet-datastore", git = "https://github.com/ai-cfia/nachet.git?subdirectory=datastore&rev=nachet-datastore-v1.1.3" },
+    { name = "nachet-datastore", git = "https://github.com/ai-cfia/nachet.git?subdirectory=datastore&rev=nachet-datastore-v1.1.10" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "pillow", specifier = "==10.3.0" },
     { name = "pydantic", specifier = "==2.7.1" },
@@ -490,8 +490,8 @@ dev = [
 
 [[package]]
 name = "nachet-datastore"
-version = "1.1.3"
-source = { git = "https://github.com/ai-cfia/nachet.git?subdirectory=datastore&rev=nachet-datastore-v1.1.3#75cecbc7e35489b8329ea404dcc49f1b1d8e7e70" }
+version = "1.1.10"
+source = { git = "https://github.com/ai-cfia/nachet.git?subdirectory=datastore&rev=nachet-datastore-v1.1.10#93e4db5dfa8ed1173227f2b474d9eaa435bc0e67" }
 dependencies = [
     { name = "azure-core" },
     { name = "azure-identity" },


### PR DESCRIPTION
closes #125

This pull request includes minor dependency updates and version bumps for both the backend Python package and several GitHub Actions workflows. These changes help keep the project up to date with the latest compatible versions and ensure ongoing stability and security.

Dependency updates:

* Updated the `nachet-datastore` dependency in `backend/pyproject.toml` from version `v1.1.3` to `v1.1.10`.

Version bumps:

* Bumped the backend package version from `1.0.0` to `1.0.1` in `backend/pyproject.toml`.

CI/CD workflow updates:

* Updated the `astral-sh/setup-uv` GitHub Action to a newer commit in both `.github/workflows/backend-lint.yml` and `.github/workflows/backend-tests.yml`. [[1]](diffhunk://#diff-d1836c9e27a56587a10191b9264d5c8e19cdfd0c22744eff951769083843a698L70-R70) [[2]](diffhunk://#diff-9c6cf26586ede5c13edc79888921fe097b68599bd9ec24ef2d4500bc8ba346cdL59-R59)
* Updated the `EndBug/add-and-commit` GitHub Action to a newer commit in `.github/workflows/backend-release.yml`.