### PR TITLE
Issue 197 auto label pull requests

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,84 @@
+---
+name: Auto Label PR
+
+'on':
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changed files
+        id: changed-files
+        run: |
+          # Get changed files between base and head
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+
+          # Check for frontend changes
+          if echo "$CHANGED_FILES" | grep -q "^frontend/"; then
+            echo "frontend_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "frontend_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check for backend changes
+          if echo "$CHANGED_FILES" | grep -q "^backend/"; then
+            echo "backend_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "backend_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check for datastore changes
+          if echo "$CHANGED_FILES" | grep -q "^datastore/"; then
+            echo "datastore_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "datastore_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add frontend label
+        if: steps.changed-files.outputs.frontend_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['frontend']
+            })
+
+      - name: Add backend label
+        if: steps.changed-files.outputs.backend_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['backend']
+            })
+
+      - name: Add datastore label
+        if: steps.changed-files.outputs.datastore_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['datastore']
+            })


### PR DESCRIPTION
closes #195

This pull request introduces a new GitHub Actions workflow to automatically label pull requests based on which parts of the codebase are modified. This helps streamline the review process by making it clear which areas (frontend, backend, datastore) are affected by each PR.

Automation and labeling improvements:

* Added a new workflow file `.github/workflows/auto-label-pr.yml` that checks for changes in the `frontend/`, `backend/`, and `datastore/` directories and automatically applies the corresponding labels to pull requests when they are opened or updated.