### PR TITLE
issue #191: backend and frontend prod dockerfile + prod gh workflow

### DIFF
--- a/.github/workflows/prod-build-sign-deploy.yml
+++ b/.github/workflows/prod-build-sign-deploy.yml
@@ -1,0 +1,185 @@
+name: Build, Push and Sign Container Images
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Trigger on version tags like v1.0.0
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}
+
+jobs:
+  build-and-sign-backend:
+    runs-on: on-prem-gh-runners
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # Important for keyless signing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-backend
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.3'
+
+      - name: Sign backend container image
+        env:
+          COSIGN_EXPERIMENTAL: 1  # Enable keyless signing
+        run: |
+          # Sign all the backend tags
+          echo "${{ steps.meta-backend.outputs.tags }}" | while read -r tag; do
+            echo "Signing backend image: $tag"
+            cosign sign --yes "$tag"
+          done
+
+      - name: Verify backend signature
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          # Verify the backend signature
+          echo "${{ steps.meta-backend.outputs.tags }}" | while read -r tag; do
+            echo "Verifying backend image: $tag"
+            cosign verify \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              "$tag"
+          done
+
+  build-and-sign-frontend:
+    runs-on: on-prem-gh-runners
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # Important for keyless signing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-frontend
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.3'
+
+      - name: Sign frontend container image
+        env:
+          COSIGN_EXPERIMENTAL: 1  # Enable keyless signing
+        run: |
+          # Sign all the frontend tags
+          echo "${{ steps.meta-frontend.outputs.tags }}" | while read -r tag; do
+            echo "Signing frontend image: $tag"
+            cosign sign --yes "$tag"
+          done
+
+      - name: Verify frontend signature
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          # Verify the frontend signature
+          echo "${{ steps.meta-frontend.outputs.tags }}" | while read -r tag; do
+            echo "Verifying frontend image: $tag"
+            cosign verify \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              "$tag"
+          done
+
+  create-release:
+    needs: [build-and-sign-backend, build-and-sign-frontend]
+    runs-on: on-prem-gh-runners
+    permissions:
+      contents: write
+      
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+            ## Release ${{ github.ref_name }}
+            
+            ### Container Images
+            - Frontend: `${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-frontend:${{ github.ref_name }}`
+            - Backend: `${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-backend:${{ github.ref_name }}`
+            
+            ### Security
+            - ✅ Images signed with Cosign (keyless)
+            - ✅ Multi-stage builds (no dev dependencies)
+            - ✅ Signatures verified with Sigstore
+            
+            ### Verification
+            ```bash
+            # Set experimental mode for keyless verification
+            export COSIGN_EXPERIMENTAL=1
+            
+            # Verify frontend signature
+            cosign verify \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-frontend:${{ github.ref_name }}
+            
+            # Verify backend signature
+            cosign verify \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-backend:${{ github.ref_name }}
+            ```

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,69 @@
+# Build stage
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN pip install --no-cache-dir uv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install production dependencies only
+RUN uv sync --frozen --no-dev
+
+# Production stage - Option 1: python:slim (recommended)
+FROM python:3.11-slim AS production
+
+WORKDIR /app
+
+# Install runtime dependencies only
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Copy application code
+COPY . .
+
+# Create non-root user
+RUN useradd -m -u 1000 -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
+# Set Python path
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
+
+CMD ["hypercorn", "-b", ":8080", "app:app"]
+
+# Production stage - Option 2: distroless (more secure, smaller)
+# FROM gcr.io/distroless/python3-debian12 AS production-distroless
+# 
+# WORKDIR /app
+# 
+# # Copy virtual environment and app
+# COPY --from=builder /app/.venv/lib/python3.11/site-packages /usr/local/lib/python3.11/dist-packages
+# COPY --from=builder /app /app
+# 
+# ENV PYTHONPATH=/app
+# ENV PYTHONUNBUFFERED=1
+# 
+# EXPOSE 8080
+# 
+# ENTRYPOINT ["python", "-m", "hypercorn", "-b", ":8080", "app:app"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,57 @@
+# Build stage
+FROM node:24.5.0-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+COPY tsconfig.json ./
+
+# Install ALL dependencies (including dev) for build
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage - Option 1: nginx:alpine (recommended)
+FROM nginx:alpine AS production
+
+# Install curl for healthchecks
+RUN apk add --no-cache curl
+
+# Copy built files from builder
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx config if you have one
+# COPY nginx.conf /etc/nginx/nginx.conf
+
+# Create non-root user
+RUN adduser -D -H -s /sbin/nologin nginx-user
+
+# Set proper permissions
+RUN chown -R nginx-user:nginx-user /usr/share/nginx/html && \
+    chown -R nginx-user:nginx-user /var/cache/nginx && \
+    chown -R nginx-user:nginx-user /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown -R nginx-user:nginx-user /var/run/nginx.pid
+
+USER nginx-user
+
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/ || exit 1
+
+# Production stage - Option 2: FROM scratch (ultra-minimal, more complex)
+# FROM scratch AS production-scratch
+# 
+# # Copy only the static files
+# COPY --from=builder /app/dist /www
+# 
+# # You would need a static file server binary compiled for scratch
+# # This is much more complex and requires a custom server
+# # Example with a Go static server or similar


### PR DESCRIPTION
- Closes #191 
- Closes #215 

### TL;DR

This policy enforces that, in labeled Kubernetes namespaces, only container images signed via Sigstore’s keyless method by GitHub Actions workflows from the ai-cfia organization can be deployed. It blocks all unsigned images and any signed by other entities, ensuring production workloads only run verified, organization-controlled builds.

## Cosign policy

See: https://github.com/ai-cfia/howard-on-prem/blob/main/security/cosign/base/policy.yaml

This policy enforces strict container image signature validation across the Kubernetes cluster with the following requirements:

#### Scope

- Images: Applies to ALL container images (glob: "**")
- Activation: Only enforced in namespaces labeled with policy.sigstore.dev/include: "true"

#### Signature Requirements

- Keyless Signing: Uses Sigstore's keyless signature method (no private keys to manage)
- Certificate Authority: Fulcio (https://fulcio.sigstore.dev) - public Sigstore CA
- Transparency Log: Rekor (https://rekor.sigstore.dev) - ensures signatures are publicly logged

#### Identity Validation

- Issuer: Must be GitHub Actions (https://token.actions.githubusercontent.com)
- Subject: Must match ^https://github.com/ai-cfia/.*$ (only workflows from ai-cfia organization)

#### Enforcement Mechanism

To activate this policy on a namespace:

```bash
kubectl label namespace nachet-prod policy.sigstore.dev/include=true
```

#### Once labeled, the namespace will:
  - ✅ ALLOW: Only images signed by ai-cfia gitHub actions workflows
  - ❌ BLOCK: All unsigned images
  - ❌ BLOCK: Images signed by other organizations or entities
  - ❌ BLOCK: Images signed outside GitHub Actions

This provides supply chain security by ensuring only verified, organization-controlled images can be
deployed in production environments.