### PR TITLE
Issue 322 frontend bump package deps

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -243,7 +243,7 @@ jobs:
             echo "No SBOM file found" > sbom-scan-skip.log
             exit 0
           fi
-      - uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e
+      - uses: anchore/scan-action@dc00f97ec900ac3c2c1b47c2d9d500aeab99cc14
         name: SBOM Security Scan
         id: scan
         with:

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -113,7 +113,7 @@ jobs:
           echo "Files and directories after cleanup:"
           find . -maxdepth 2 -type f -o -type d | head -20
 
-      - uses: EndBug/add-and-commit@af62f267410b647327457e1a82a6686727fcb8a0
+      - uses: EndBug/add-and-commit@396414845612f3d50a93ddf57ff3ba0b3df58d89
         with:
           message: "Release frontend nachet-frontend-v${{ steps.versions.outputs.app-version }}"
           add: "."
@@ -202,7 +202,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
         with:
           tag: "nachet-frontend-v${{ steps.versions.outputs.app-version }}"
           name: "nachet-frontend v${{ steps.versions.outputs.app-version }}"

--- a/.github/workflows/prod-build-sign-deploy.yml
+++ b/.github/workflows/prod-build-sign-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           labels: ${{ steps.meta-backend.outputs.labels }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62
         with:
           cosign-release: "v2.2.3"
 
@@ -117,7 +117,7 @@ jobs:
           labels: ${{ steps.meta-frontend.outputs.labels }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62
         with:
           cosign-release: "v2.2.3"
 
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Create Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
+        uses: softprops/action-gh-release@19cd0bcd2b95a5f9e0aab8377b3cae33e51c2234
         with:
           body: |
             ## Release ${{ github.ref_name }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trufflehog
-        uses: trufflesecurity/trufflehog@0f58ae7c5036094a1e3e750d18772af92821b503
+        uses: trufflesecurity/trufflehog@bd45a706e14dfe1909578fc62285fbe31a1e5312
         with:
           base: ""
           head: ${{ github.ref_name }}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@emotion/react": "^11.14.0",
@@ -46,7 +46,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@babel/preset-env": "^7.28.0",
+        "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@cyclonedx/cyclonedx-npm": "^4.0.0",
@@ -57,10 +57,10 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/file-saver": "^2.0.7",
         "@types/js-cookie": "^3.0.6",
-        "@types/node": "^22.18.4",
+        "@types/node": "^22.18.5",
         "@types/pako": "^2.0.3",
-        "@types/react": "^19.1.9",
-        "@types/react-dom": "^19.1.7",
+        "@types/react": "^19.1.13",
+        "@types/react-dom": "^19.1.9",
         "@types/sanitize-html": "^2.16.0",
         "@types/utif": "^3.0.5",
         "@types/uuid": "^10.0.0",
@@ -3934,10 +3934,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.18.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.4.tgz",
-      "integrity": "sha512-UJdblFqXymSBhmZf96BnbisoFIr8ooiiBRMolQgg77Ea+VM37jXw76C2LQr9n8wm9+i/OvlUlW6xSvqwzwqznw==",
+      "version": "22.18.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.5.tgz",
+      "integrity": "sha512-g9BpPfJvxYBXUWI9bV37j6d6LTMNQ88hPwdWWUeYZnMhlo66FIg9gCc1/DZb15QylJSKwOZjwrckvOTWpOiChg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "0.10.3",
+  "version": "0.10.4",
   "acia-cfia": {
     "backend-version": "1.10.1"
   },
@@ -72,7 +72,7 @@
     ]
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.28.0",
+    "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@cyclonedx/cyclonedx-npm": "^4.0.0",
@@ -83,10 +83,10 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/file-saver": "^2.0.7",
     "@types/js-cookie": "^3.0.6",
-    "@types/node": "^22.18.4",
+    "@types/node": "^22.18.5",
     "@types/pako": "^2.0.3",
-    "@types/react": "^19.1.9",
-    "@types/react-dom": "^19.1.7",
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
     "@types/sanitize-html": "^2.16.0",
     "@types/utif": "^3.0.5",
     "@types/uuid": "^10.0.0",

--- a/frontend/sbom.json
+++ b/frontend/sbom.json
@@ -80,9 +80,9 @@
     "component": {
       "type": "application",
       "name": "nachet-frontend",
-      "version": "0.10.3",
-      "bom-ref": "nachet-frontend@0.10.3",
-      "purl": "pkg:npm/nachet-frontend@0.10.3",
+      "version": "0.10.4",
+      "bom-ref": "nachet-frontend@0.10.4",
+      "purl": "pkg:npm/nachet-frontend@0.10.4",
       "properties": [
         {
           "name": "cdx:npm:package:path",
@@ -101,7 +101,7 @@
       "name": "css-tools",
       "group": "@adobe",
       "version": "4.4.4",
-      "bom-ref": "nachet-frontend@0.10.3|@adobe/css-tools@4.4.4",
+      "bom-ref": "nachet-frontend@0.10.4|@adobe/css-tools@4.4.4",
       "purl": "pkg:npm/%40adobe/css-tools@4.4.4",
       "externalReferences": [
         {
@@ -128,7 +128,7 @@
       "name": "remapping",
       "group": "@ampproject",
       "version": "2.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|@ampproject/remapping@2.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|@ampproject/remapping@2.3.0",
       "purl": "pkg:npm/%40ampproject/remapping@2.3.0",
       "externalReferences": [
         {
@@ -159,7 +159,7 @@
       "name": "css-color",
       "group": "@asamuzakjp",
       "version": "3.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|@asamuzakjp/css-color@3.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|@asamuzakjp/css-color@3.2.0",
       "purl": "pkg:npm/%40asamuzakjp/css-color@3.2.0",
       "externalReferences": [
         {
@@ -189,7 +189,7 @@
           "type": "library",
           "name": "lru-cache",
           "version": "10.4.3",
-          "bom-ref": "nachet-frontend@0.10.3|@asamuzakjp/css-color@3.2.0|lru-cache@10.4.3",
+          "bom-ref": "nachet-frontend@0.10.4|@asamuzakjp/css-color@3.2.0|lru-cache@10.4.3",
           "purl": "pkg:npm/lru-cache@10.4.3",
           "externalReferences": [
             {
@@ -222,7 +222,7 @@
       "name": "code-frame",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
       "purl": "pkg:npm/%40babel/code-frame@7.27.1",
       "externalReferences": [
         {
@@ -249,7 +249,7 @@
       "name": "compat-data",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/compat-data@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/compat-data@7.28.4",
       "purl": "pkg:npm/%40babel/compat-data@7.28.4",
       "externalReferences": [
         {
@@ -276,7 +276,7 @@
       "name": "core",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/core@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/core@7.28.4",
       "purl": "pkg:npm/%40babel/core@7.28.4",
       "externalReferences": [
         {
@@ -303,7 +303,7 @@
       "name": "generator",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/generator@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/generator@7.28.3",
       "purl": "pkg:npm/%40babel/generator@7.28.3",
       "externalReferences": [
         {
@@ -330,7 +330,7 @@
       "name": "helper-annotate-as-pure",
       "group": "@babel",
       "version": "7.27.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
       "purl": "pkg:npm/%40babel/helper-annotate-as-pure@7.27.3",
       "externalReferences": [
         {
@@ -357,7 +357,7 @@
       "name": "helper-compilation-targets",
       "group": "@babel",
       "version": "7.27.2",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
       "purl": "pkg:npm/%40babel/helper-compilation-targets@7.27.2",
       "externalReferences": [
         {
@@ -384,7 +384,7 @@
       "name": "helper-create-class-features-plugin",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
       "purl": "pkg:npm/%40babel/helper-create-class-features-plugin@7.28.3",
       "externalReferences": [
         {
@@ -411,7 +411,7 @@
       "name": "helper-create-regexp-features-plugin",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
       "purl": "pkg:npm/%40babel/helper-create-regexp-features-plugin@7.27.1",
       "externalReferences": [
         {
@@ -442,7 +442,7 @@
       "name": "helper-define-polyfill-provider",
       "group": "@babel",
       "version": "0.6.5",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-define-polyfill-provider@0.6.5",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-define-polyfill-provider@0.6.5",
       "purl": "pkg:npm/%40babel/helper-define-polyfill-provider@0.6.5",
       "externalReferences": [
         {
@@ -473,7 +473,7 @@
       "name": "helper-globals",
       "group": "@babel",
       "version": "7.28.0",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-globals@7.28.0",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-globals@7.28.0",
       "purl": "pkg:npm/%40babel/helper-globals@7.28.0",
       "externalReferences": [
         {
@@ -500,7 +500,7 @@
       "name": "helper-member-expression-to-functions",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-member-expression-to-functions@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-member-expression-to-functions@7.27.1",
       "purl": "pkg:npm/%40babel/helper-member-expression-to-functions@7.27.1",
       "externalReferences": [
         {
@@ -527,7 +527,7 @@
       "name": "helper-module-imports",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-module-imports@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-module-imports@7.27.1",
       "purl": "pkg:npm/%40babel/helper-module-imports@7.27.1",
       "externalReferences": [
         {
@@ -554,7 +554,7 @@
       "name": "helper-module-transforms",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
       "purl": "pkg:npm/%40babel/helper-module-transforms@7.28.3",
       "externalReferences": [
         {
@@ -581,7 +581,7 @@
       "name": "helper-optimise-call-expression",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-optimise-call-expression@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-optimise-call-expression@7.27.1",
       "purl": "pkg:npm/%40babel/helper-optimise-call-expression@7.27.1",
       "externalReferences": [
         {
@@ -608,7 +608,7 @@
       "name": "helper-plugin-utils",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
       "purl": "pkg:npm/%40babel/helper-plugin-utils@7.27.1",
       "externalReferences": [
         {
@@ -635,7 +635,7 @@
       "name": "helper-remap-async-to-generator",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-remap-async-to-generator@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-remap-async-to-generator@7.27.1",
       "purl": "pkg:npm/%40babel/helper-remap-async-to-generator@7.27.1",
       "externalReferences": [
         {
@@ -666,7 +666,7 @@
       "name": "helper-replace-supers",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-replace-supers@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-replace-supers@7.27.1",
       "purl": "pkg:npm/%40babel/helper-replace-supers@7.27.1",
       "externalReferences": [
         {
@@ -693,7 +693,7 @@
       "name": "helper-skip-transparent-expression-wrappers",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
       "purl": "pkg:npm/%40babel/helper-skip-transparent-expression-wrappers@7.27.1",
       "externalReferences": [
         {
@@ -720,7 +720,7 @@
       "name": "helper-string-parser",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-string-parser@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-string-parser@7.27.1",
       "purl": "pkg:npm/%40babel/helper-string-parser@7.27.1",
       "externalReferences": [
         {
@@ -747,7 +747,7 @@
       "name": "helper-validator-identifier",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-validator-identifier@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-validator-identifier@7.27.1",
       "purl": "pkg:npm/%40babel/helper-validator-identifier@7.27.1",
       "externalReferences": [
         {
@@ -774,7 +774,7 @@
       "name": "helper-validator-option",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-validator-option@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-validator-option@7.27.1",
       "purl": "pkg:npm/%40babel/helper-validator-option@7.27.1",
       "externalReferences": [
         {
@@ -801,7 +801,7 @@
       "name": "helper-wrap-function",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helper-wrap-function@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helper-wrap-function@7.28.3",
       "purl": "pkg:npm/%40babel/helper-wrap-function@7.28.3",
       "externalReferences": [
         {
@@ -832,7 +832,7 @@
       "name": "helpers",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/helpers@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/helpers@7.28.4",
       "purl": "pkg:npm/%40babel/helpers@7.28.4",
       "externalReferences": [
         {
@@ -859,7 +859,7 @@
       "name": "parser",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/parser@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/parser@7.28.4",
       "purl": "pkg:npm/%40babel/parser@7.28.4",
       "externalReferences": [
         {
@@ -886,7 +886,7 @@
       "name": "plugin-bugfix-firefox-class-in-computed-class-key",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
       "externalReferences": [
         {
@@ -917,7 +917,7 @@
       "name": "plugin-bugfix-safari-class-field-initializer-scope",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
       "externalReferences": [
         {
@@ -948,7 +948,7 @@
       "name": "plugin-bugfix-safari-id-destructuring-collision-in-function-expression",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
       "externalReferences": [
         {
@@ -979,7 +979,7 @@
       "name": "plugin-bugfix-v8-spread-parameters-in-optional-chaining",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
       "externalReferences": [
         {
@@ -1010,7 +1010,7 @@
       "name": "plugin-bugfix-v8-static-class-fields-redefine-readonly",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
       "purl": "pkg:npm/%40babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
       "externalReferences": [
         {
@@ -1041,7 +1041,7 @@
       "name": "plugin-proposal-private-property-in-object",
       "group": "@babel",
       "version": "7.21.0-placeholder-for-preset-env.2",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
       "purl": "pkg:npm/%40babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
       "externalReferences": [
         {
@@ -1072,7 +1072,7 @@
       "name": "plugin-syntax-import-assertions",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-import-assertions@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-import-assertions@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-syntax-import-assertions@7.27.1",
       "externalReferences": [
         {
@@ -1103,7 +1103,7 @@
       "name": "plugin-syntax-import-attributes",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-import-attributes@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-import-attributes@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-syntax-import-attributes@7.27.1",
       "externalReferences": [
         {
@@ -1134,7 +1134,7 @@
       "name": "plugin-syntax-jsx",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-jsx@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-jsx@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-syntax-jsx@7.27.1",
       "externalReferences": [
         {
@@ -1165,7 +1165,7 @@
       "name": "plugin-syntax-typescript",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-typescript@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-typescript@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-syntax-typescript@7.27.1",
       "externalReferences": [
         {
@@ -1196,7 +1196,7 @@
       "name": "plugin-syntax-unicode-sets-regex",
       "group": "@babel",
       "version": "7.18.6",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-unicode-sets-regex@7.18.6",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-unicode-sets-regex@7.18.6",
       "purl": "pkg:npm/%40babel/plugin-syntax-unicode-sets-regex@7.18.6",
       "externalReferences": [
         {
@@ -1227,7 +1227,7 @@
       "name": "plugin-transform-arrow-functions",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-arrow-functions@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-arrow-functions@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-arrow-functions@7.27.1",
       "externalReferences": [
         {
@@ -1258,7 +1258,7 @@
       "name": "plugin-transform-async-generator-functions",
       "group": "@babel",
       "version": "7.28.0",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-async-generator-functions@7.28.0",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-async-generator-functions@7.28.0",
       "purl": "pkg:npm/%40babel/plugin-transform-async-generator-functions@7.28.0",
       "externalReferences": [
         {
@@ -1289,7 +1289,7 @@
       "name": "plugin-transform-async-to-generator",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-async-to-generator@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-async-to-generator@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-async-to-generator@7.27.1",
       "externalReferences": [
         {
@@ -1320,7 +1320,7 @@
       "name": "plugin-transform-block-scoped-functions",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-block-scoped-functions@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-block-scoped-functions@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-block-scoped-functions@7.27.1",
       "externalReferences": [
         {
@@ -1351,7 +1351,7 @@
       "name": "plugin-transform-block-scoping",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-block-scoping@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-block-scoping@7.28.4",
       "purl": "pkg:npm/%40babel/plugin-transform-block-scoping@7.28.4",
       "externalReferences": [
         {
@@ -1382,7 +1382,7 @@
       "name": "plugin-transform-class-properties",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-class-properties@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-class-properties@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-class-properties@7.27.1",
       "externalReferences": [
         {
@@ -1413,7 +1413,7 @@
       "name": "plugin-transform-class-static-block",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-class-static-block@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-class-static-block@7.28.3",
       "purl": "pkg:npm/%40babel/plugin-transform-class-static-block@7.28.3",
       "externalReferences": [
         {
@@ -1444,7 +1444,7 @@
       "name": "plugin-transform-classes",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-classes@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-classes@7.28.4",
       "purl": "pkg:npm/%40babel/plugin-transform-classes@7.28.4",
       "externalReferences": [
         {
@@ -1475,7 +1475,7 @@
       "name": "plugin-transform-computed-properties",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-computed-properties@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-computed-properties@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-computed-properties@7.27.1",
       "externalReferences": [
         {
@@ -1506,7 +1506,7 @@
       "name": "plugin-transform-destructuring",
       "group": "@babel",
       "version": "7.28.0",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-destructuring@7.28.0",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-destructuring@7.28.0",
       "purl": "pkg:npm/%40babel/plugin-transform-destructuring@7.28.0",
       "externalReferences": [
         {
@@ -1537,7 +1537,7 @@
       "name": "plugin-transform-dotall-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-dotall-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-dotall-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-dotall-regex@7.27.1",
       "externalReferences": [
         {
@@ -1568,7 +1568,7 @@
       "name": "plugin-transform-duplicate-keys",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-duplicate-keys@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-duplicate-keys@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-duplicate-keys@7.27.1",
       "externalReferences": [
         {
@@ -1599,7 +1599,7 @@
       "name": "plugin-transform-duplicate-named-capturing-groups-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
       "externalReferences": [
         {
@@ -1630,7 +1630,7 @@
       "name": "plugin-transform-dynamic-import",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-dynamic-import@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-dynamic-import@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-dynamic-import@7.27.1",
       "externalReferences": [
         {
@@ -1661,7 +1661,7 @@
       "name": "plugin-transform-explicit-resource-management",
       "group": "@babel",
       "version": "7.28.0",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-explicit-resource-management@7.28.0",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-explicit-resource-management@7.28.0",
       "purl": "pkg:npm/%40babel/plugin-transform-explicit-resource-management@7.28.0",
       "externalReferences": [
         {
@@ -1692,7 +1692,7 @@
       "name": "plugin-transform-exponentiation-operator",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-exponentiation-operator@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-exponentiation-operator@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-exponentiation-operator@7.27.1",
       "externalReferences": [
         {
@@ -1723,7 +1723,7 @@
       "name": "plugin-transform-export-namespace-from",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-export-namespace-from@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-export-namespace-from@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-export-namespace-from@7.27.1",
       "externalReferences": [
         {
@@ -1754,7 +1754,7 @@
       "name": "plugin-transform-for-of",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-for-of@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-for-of@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-for-of@7.27.1",
       "externalReferences": [
         {
@@ -1785,7 +1785,7 @@
       "name": "plugin-transform-function-name",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-function-name@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-function-name@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-function-name@7.27.1",
       "externalReferences": [
         {
@@ -1816,7 +1816,7 @@
       "name": "plugin-transform-json-strings",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-json-strings@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-json-strings@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-json-strings@7.27.1",
       "externalReferences": [
         {
@@ -1847,7 +1847,7 @@
       "name": "plugin-transform-literals",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-literals@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-literals@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-literals@7.27.1",
       "externalReferences": [
         {
@@ -1878,7 +1878,7 @@
       "name": "plugin-transform-logical-assignment-operators",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-logical-assignment-operators@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-logical-assignment-operators@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-logical-assignment-operators@7.27.1",
       "externalReferences": [
         {
@@ -1909,7 +1909,7 @@
       "name": "plugin-transform-member-expression-literals",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-member-expression-literals@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-member-expression-literals@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-member-expression-literals@7.27.1",
       "externalReferences": [
         {
@@ -1940,7 +1940,7 @@
       "name": "plugin-transform-modules-amd",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-amd@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-amd@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-modules-amd@7.27.1",
       "externalReferences": [
         {
@@ -1971,7 +1971,7 @@
       "name": "plugin-transform-modules-commonjs",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-commonjs@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-commonjs@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-modules-commonjs@7.27.1",
       "externalReferences": [
         {
@@ -2002,7 +2002,7 @@
       "name": "plugin-transform-modules-systemjs",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-systemjs@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-systemjs@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-modules-systemjs@7.27.1",
       "externalReferences": [
         {
@@ -2033,7 +2033,7 @@
       "name": "plugin-transform-modules-umd",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-umd@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-umd@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-modules-umd@7.27.1",
       "externalReferences": [
         {
@@ -2064,7 +2064,7 @@
       "name": "plugin-transform-named-capturing-groups-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-named-capturing-groups-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-named-capturing-groups-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-named-capturing-groups-regex@7.27.1",
       "externalReferences": [
         {
@@ -2095,7 +2095,7 @@
       "name": "plugin-transform-new-target",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-new-target@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-new-target@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-new-target@7.27.1",
       "externalReferences": [
         {
@@ -2126,7 +2126,7 @@
       "name": "plugin-transform-nullish-coalescing-operator",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-nullish-coalescing-operator@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-nullish-coalescing-operator@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-nullish-coalescing-operator@7.27.1",
       "externalReferences": [
         {
@@ -2157,7 +2157,7 @@
       "name": "plugin-transform-numeric-separator",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-numeric-separator@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-numeric-separator@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-numeric-separator@7.27.1",
       "externalReferences": [
         {
@@ -2188,7 +2188,7 @@
       "name": "plugin-transform-object-rest-spread",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-object-rest-spread@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-object-rest-spread@7.28.4",
       "purl": "pkg:npm/%40babel/plugin-transform-object-rest-spread@7.28.4",
       "externalReferences": [
         {
@@ -2219,7 +2219,7 @@
       "name": "plugin-transform-object-super",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-object-super@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-object-super@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-object-super@7.27.1",
       "externalReferences": [
         {
@@ -2250,7 +2250,7 @@
       "name": "plugin-transform-optional-catch-binding",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-optional-catch-binding@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-optional-catch-binding@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-optional-catch-binding@7.27.1",
       "externalReferences": [
         {
@@ -2281,7 +2281,7 @@
       "name": "plugin-transform-optional-chaining",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-optional-chaining@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-optional-chaining@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-optional-chaining@7.27.1",
       "externalReferences": [
         {
@@ -2312,7 +2312,7 @@
       "name": "plugin-transform-parameters",
       "group": "@babel",
       "version": "7.27.7",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-parameters@7.27.7",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-parameters@7.27.7",
       "purl": "pkg:npm/%40babel/plugin-transform-parameters@7.27.7",
       "externalReferences": [
         {
@@ -2343,7 +2343,7 @@
       "name": "plugin-transform-private-methods",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-private-methods@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-private-methods@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-private-methods@7.27.1",
       "externalReferences": [
         {
@@ -2374,7 +2374,7 @@
       "name": "plugin-transform-private-property-in-object",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-private-property-in-object@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-private-property-in-object@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-private-property-in-object@7.27.1",
       "externalReferences": [
         {
@@ -2401,7 +2401,7 @@
       "name": "plugin-transform-property-literals",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-property-literals@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-property-literals@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-property-literals@7.27.1",
       "externalReferences": [
         {
@@ -2432,7 +2432,7 @@
       "name": "plugin-transform-react-display-name",
       "group": "@babel",
       "version": "7.28.0",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-display-name@7.28.0",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-display-name@7.28.0",
       "purl": "pkg:npm/%40babel/plugin-transform-react-display-name@7.28.0",
       "externalReferences": [
         {
@@ -2463,7 +2463,7 @@
       "name": "plugin-transform-react-jsx-development",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx-development@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx-development@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-react-jsx-development@7.27.1",
       "externalReferences": [
         {
@@ -2494,7 +2494,7 @@
       "name": "plugin-transform-react-jsx",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-react-jsx@7.27.1",
       "externalReferences": [
         {
@@ -2525,7 +2525,7 @@
       "name": "plugin-transform-react-pure-annotations",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-pure-annotations@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-pure-annotations@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-react-pure-annotations@7.27.1",
       "externalReferences": [
         {
@@ -2556,7 +2556,7 @@
       "name": "plugin-transform-regenerator",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-regenerator@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-regenerator@7.28.4",
       "purl": "pkg:npm/%40babel/plugin-transform-regenerator@7.28.4",
       "externalReferences": [
         {
@@ -2587,7 +2587,7 @@
       "name": "plugin-transform-regexp-modifiers",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-regexp-modifiers@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-regexp-modifiers@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-regexp-modifiers@7.27.1",
       "externalReferences": [
         {
@@ -2618,7 +2618,7 @@
       "name": "plugin-transform-reserved-words",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-reserved-words@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-reserved-words@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-reserved-words@7.27.1",
       "externalReferences": [
         {
@@ -2649,7 +2649,7 @@
       "name": "plugin-transform-shorthand-properties",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-shorthand-properties@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-shorthand-properties@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-shorthand-properties@7.27.1",
       "externalReferences": [
         {
@@ -2680,7 +2680,7 @@
       "name": "plugin-transform-spread",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-spread@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-spread@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-spread@7.27.1",
       "externalReferences": [
         {
@@ -2711,7 +2711,7 @@
       "name": "plugin-transform-sticky-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-sticky-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-sticky-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-sticky-regex@7.27.1",
       "externalReferences": [
         {
@@ -2742,7 +2742,7 @@
       "name": "plugin-transform-template-literals",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-template-literals@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-template-literals@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-template-literals@7.27.1",
       "externalReferences": [
         {
@@ -2773,7 +2773,7 @@
       "name": "plugin-transform-typeof-symbol",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-typeof-symbol@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-typeof-symbol@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-typeof-symbol@7.27.1",
       "externalReferences": [
         {
@@ -2804,7 +2804,7 @@
       "name": "plugin-transform-typescript",
       "group": "@babel",
       "version": "7.28.0",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-typescript@7.28.0",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-typescript@7.28.0",
       "purl": "pkg:npm/%40babel/plugin-transform-typescript@7.28.0",
       "externalReferences": [
         {
@@ -2835,7 +2835,7 @@
       "name": "plugin-transform-unicode-escapes",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-escapes@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-escapes@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-unicode-escapes@7.27.1",
       "externalReferences": [
         {
@@ -2866,7 +2866,7 @@
       "name": "plugin-transform-unicode-property-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-property-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-property-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-unicode-property-regex@7.27.1",
       "externalReferences": [
         {
@@ -2897,7 +2897,7 @@
       "name": "plugin-transform-unicode-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-unicode-regex@7.27.1",
       "externalReferences": [
         {
@@ -2928,7 +2928,7 @@
       "name": "plugin-transform-unicode-sets-regex",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-sets-regex@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-sets-regex@7.27.1",
       "purl": "pkg:npm/%40babel/plugin-transform-unicode-sets-regex@7.27.1",
       "externalReferences": [
         {
@@ -2959,7 +2959,7 @@
       "name": "preset-env",
       "group": "@babel",
       "version": "7.28.3",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/preset-env@7.28.3",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/preset-env@7.28.3",
       "purl": "pkg:npm/%40babel/preset-env@7.28.3",
       "externalReferences": [
         {
@@ -2990,7 +2990,7 @@
       "name": "preset-modules",
       "group": "@babel",
       "version": "0.1.6-no-external-plugins",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/preset-modules@0.1.6-no-external-plugins",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/preset-modules@0.1.6-no-external-plugins",
       "purl": "pkg:npm/%40babel/preset-modules@0.1.6-no-external-plugins",
       "externalReferences": [
         {
@@ -3021,7 +3021,7 @@
       "name": "preset-react",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/preset-react@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/preset-react@7.27.1",
       "purl": "pkg:npm/%40babel/preset-react@7.27.1",
       "externalReferences": [
         {
@@ -3052,7 +3052,7 @@
       "name": "preset-typescript",
       "group": "@babel",
       "version": "7.27.1",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/preset-typescript@7.27.1",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/preset-typescript@7.27.1",
       "purl": "pkg:npm/%40babel/preset-typescript@7.27.1",
       "externalReferences": [
         {
@@ -3083,7 +3083,7 @@
       "name": "runtime",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
       "purl": "pkg:npm/%40babel/runtime@7.28.4",
       "externalReferences": [
         {
@@ -3110,7 +3110,7 @@
       "name": "template",
       "group": "@babel",
       "version": "7.27.2",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/template@7.27.2",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/template@7.27.2",
       "purl": "pkg:npm/%40babel/template@7.27.2",
       "externalReferences": [
         {
@@ -3137,7 +3137,7 @@
       "name": "traverse",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
       "purl": "pkg:npm/%40babel/traverse@7.28.4",
       "externalReferences": [
         {
@@ -3164,7 +3164,7 @@
       "name": "types",
       "group": "@babel",
       "version": "7.28.4",
-      "bom-ref": "nachet-frontend@0.10.3|@babel/types@7.28.4",
+      "bom-ref": "nachet-frontend@0.10.4|@babel/types@7.28.4",
       "purl": "pkg:npm/%40babel/types@7.28.4",
       "externalReferences": [
         {
@@ -3191,7 +3191,7 @@
       "name": "v8-coverage",
       "group": "@bcoe",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|@bcoe/v8-coverage@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|@bcoe/v8-coverage@1.0.2",
       "purl": "pkg:npm/%40bcoe/v8-coverage@1.0.2",
       "externalReferences": [
         {
@@ -3222,7 +3222,7 @@
       "name": "color-helpers",
       "group": "@csstools",
       "version": "5.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|@csstools/color-helpers@5.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|@csstools/color-helpers@5.1.0",
       "purl": "pkg:npm/%40csstools/color-helpers@5.1.0",
       "externalReferences": [
         {
@@ -3253,7 +3253,7 @@
       "name": "css-calc",
       "group": "@csstools",
       "version": "2.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|@csstools/css-calc@2.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|@csstools/css-calc@2.1.4",
       "purl": "pkg:npm/%40csstools/css-calc@2.1.4",
       "externalReferences": [
         {
@@ -3284,7 +3284,7 @@
       "name": "css-color-parser",
       "group": "@csstools",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|@csstools/css-color-parser@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|@csstools/css-color-parser@3.1.0",
       "purl": "pkg:npm/%40csstools/css-color-parser@3.1.0",
       "externalReferences": [
         {
@@ -3315,7 +3315,7 @@
       "name": "css-parser-algorithms",
       "group": "@csstools",
       "version": "3.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|@csstools/css-parser-algorithms@3.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|@csstools/css-parser-algorithms@3.0.5",
       "purl": "pkg:npm/%40csstools/css-parser-algorithms@3.0.5",
       "externalReferences": [
         {
@@ -3346,7 +3346,7 @@
       "name": "css-tokenizer",
       "group": "@csstools",
       "version": "3.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|@csstools/css-tokenizer@3.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|@csstools/css-tokenizer@3.0.4",
       "purl": "pkg:npm/%40csstools/css-tokenizer@3.0.4",
       "externalReferences": [
         {
@@ -3377,7 +3377,7 @@
       "name": "cyclonedx-library",
       "group": "@cyclonedx",
       "version": "9.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|@cyclonedx/cyclonedx-library@9.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|@cyclonedx/cyclonedx-library@9.0.0",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-library@9.0.0",
       "externalReferences": [
         {
@@ -3408,7 +3408,7 @@
       "name": "cyclonedx-npm",
       "group": "@cyclonedx",
       "version": "4.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|@cyclonedx/cyclonedx-npm@4.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|@cyclonedx/cyclonedx-npm@4.0.2",
       "purl": "pkg:npm/%40cyclonedx/cyclonedx-npm@4.0.2",
       "externalReferences": [
         {
@@ -3439,7 +3439,7 @@
       "name": "babel-plugin",
       "group": "@emotion",
       "version": "11.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5",
       "purl": "pkg:npm/%40emotion/babel-plugin@11.13.5",
       "externalReferences": [
         {
@@ -3465,7 +3465,7 @@
           "type": "library",
           "name": "convert-source-map",
           "version": "1.9.0",
-          "bom-ref": "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5|convert-source-map@1.9.0",
+          "bom-ref": "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5|convert-source-map@1.9.0",
           "purl": "pkg:npm/convert-source-map@1.9.0",
           "externalReferences": [
             {
@@ -3494,7 +3494,7 @@
       "name": "cache",
       "group": "@emotion",
       "version": "11.14.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/cache@11.14.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/cache@11.14.0",
       "purl": "pkg:npm/%40emotion/cache@11.14.0",
       "externalReferences": [
         {
@@ -3521,7 +3521,7 @@
       "name": "hash",
       "group": "@emotion",
       "version": "0.9.2",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/hash@0.9.2",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/hash@0.9.2",
       "purl": "pkg:npm/%40emotion/hash@0.9.2",
       "externalReferences": [
         {
@@ -3548,7 +3548,7 @@
       "name": "is-prop-valid",
       "group": "@emotion",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/is-prop-valid@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/is-prop-valid@1.4.0",
       "purl": "pkg:npm/%40emotion/is-prop-valid@1.4.0",
       "externalReferences": [
         {
@@ -3575,7 +3575,7 @@
       "name": "memoize",
       "group": "@emotion",
       "version": "0.9.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/memoize@0.9.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/memoize@0.9.0",
       "purl": "pkg:npm/%40emotion/memoize@0.9.0",
       "externalReferences": [
         {
@@ -3602,7 +3602,7 @@
       "name": "react",
       "group": "@emotion",
       "version": "11.14.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/react@11.14.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/react@11.14.0",
       "purl": "pkg:npm/%40emotion/react@11.14.0",
       "externalReferences": [
         {
@@ -3629,7 +3629,7 @@
       "name": "serialize",
       "group": "@emotion",
       "version": "1.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/serialize@1.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/serialize@1.3.3",
       "purl": "pkg:npm/%40emotion/serialize@1.3.3",
       "externalReferences": [
         {
@@ -3656,7 +3656,7 @@
       "name": "sheet",
       "group": "@emotion",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/sheet@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/sheet@1.4.0",
       "purl": "pkg:npm/%40emotion/sheet@1.4.0",
       "externalReferences": [
         {
@@ -3683,7 +3683,7 @@
       "name": "styled",
       "group": "@emotion",
       "version": "11.14.1",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/styled@11.14.1",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/styled@11.14.1",
       "purl": "pkg:npm/%40emotion/styled@11.14.1",
       "externalReferences": [
         {
@@ -3710,7 +3710,7 @@
       "name": "unitless",
       "group": "@emotion",
       "version": "0.10.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/unitless@0.10.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/unitless@0.10.0",
       "purl": "pkg:npm/%40emotion/unitless@0.10.0",
       "externalReferences": [
         {
@@ -3737,7 +3737,7 @@
       "name": "use-insertion-effect-with-fallbacks",
       "group": "@emotion",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
       "purl": "pkg:npm/%40emotion/use-insertion-effect-with-fallbacks@1.2.0",
       "externalReferences": [
         {
@@ -3764,7 +3764,7 @@
       "name": "utils",
       "group": "@emotion",
       "version": "1.4.2",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/utils@1.4.2",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/utils@1.4.2",
       "purl": "pkg:npm/%40emotion/utils@1.4.2",
       "externalReferences": [
         {
@@ -3791,7 +3791,7 @@
       "name": "weak-memoize",
       "group": "@emotion",
       "version": "0.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|@emotion/weak-memoize@0.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|@emotion/weak-memoize@0.4.0",
       "purl": "pkg:npm/%40emotion/weak-memoize@0.4.0",
       "externalReferences": [
         {
@@ -3818,7 +3818,7 @@
       "name": "aix-ppc64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/aix-ppc64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/aix-ppc64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/aix-ppc64@0.25.9",
       "externalReferences": [
@@ -3850,7 +3850,7 @@
       "name": "android-arm",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/android-arm@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/android-arm@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/android-arm@0.25.9",
       "externalReferences": [
@@ -3882,7 +3882,7 @@
       "name": "android-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/android-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/android-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/android-arm64@0.25.9",
       "externalReferences": [
@@ -3914,7 +3914,7 @@
       "name": "android-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/android-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/android-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/android-x64@0.25.9",
       "externalReferences": [
@@ -3946,7 +3946,7 @@
       "name": "darwin-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/darwin-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/darwin-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/darwin-arm64@0.25.9",
       "externalReferences": [
@@ -3978,7 +3978,7 @@
       "name": "darwin-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/darwin-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/darwin-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/darwin-x64@0.25.9",
       "externalReferences": [
@@ -4010,7 +4010,7 @@
       "name": "freebsd-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/freebsd-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/freebsd-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/freebsd-arm64@0.25.9",
       "externalReferences": [
@@ -4042,7 +4042,7 @@
       "name": "freebsd-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/freebsd-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/freebsd-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/freebsd-x64@0.25.9",
       "externalReferences": [
@@ -4074,7 +4074,7 @@
       "name": "linux-arm",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-arm@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-arm@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-arm@0.25.9",
       "externalReferences": [
@@ -4106,7 +4106,7 @@
       "name": "linux-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-arm64@0.25.9",
       "externalReferences": [
@@ -4138,7 +4138,7 @@
       "name": "linux-ia32",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-ia32@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-ia32@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-ia32@0.25.9",
       "externalReferences": [
@@ -4170,7 +4170,7 @@
       "name": "linux-loong64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-loong64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-loong64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-loong64@0.25.9",
       "externalReferences": [
@@ -4202,7 +4202,7 @@
       "name": "linux-mips64el",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-mips64el@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-mips64el@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-mips64el@0.25.9",
       "externalReferences": [
@@ -4234,7 +4234,7 @@
       "name": "linux-ppc64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-ppc64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-ppc64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-ppc64@0.25.9",
       "externalReferences": [
@@ -4266,7 +4266,7 @@
       "name": "linux-riscv64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-riscv64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-riscv64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-riscv64@0.25.9",
       "externalReferences": [
@@ -4298,7 +4298,7 @@
       "name": "linux-s390x",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-s390x@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-s390x@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-s390x@0.25.9",
       "externalReferences": [
@@ -4330,7 +4330,7 @@
       "name": "linux-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/linux-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/linux-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/linux-x64@0.25.9",
       "externalReferences": [
@@ -4362,7 +4362,7 @@
       "name": "netbsd-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/netbsd-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/netbsd-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/netbsd-arm64@0.25.9",
       "externalReferences": [
@@ -4394,7 +4394,7 @@
       "name": "netbsd-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/netbsd-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/netbsd-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/netbsd-x64@0.25.9",
       "externalReferences": [
@@ -4426,7 +4426,7 @@
       "name": "openbsd-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/openbsd-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/openbsd-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/openbsd-arm64@0.25.9",
       "externalReferences": [
@@ -4458,7 +4458,7 @@
       "name": "openbsd-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/openbsd-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/openbsd-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/openbsd-x64@0.25.9",
       "externalReferences": [
@@ -4490,7 +4490,7 @@
       "name": "openharmony-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/openharmony-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/openharmony-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/openharmony-arm64@0.25.9",
       "externalReferences": [
@@ -4522,7 +4522,7 @@
       "name": "sunos-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/sunos-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/sunos-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/sunos-x64@0.25.9",
       "externalReferences": [
@@ -4554,7 +4554,7 @@
       "name": "win32-arm64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/win32-arm64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/win32-arm64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/win32-arm64@0.25.9",
       "externalReferences": [
@@ -4586,7 +4586,7 @@
       "name": "win32-ia32",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/win32-ia32@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/win32-ia32@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/win32-ia32@0.25.9",
       "externalReferences": [
@@ -4618,7 +4618,7 @@
       "name": "win32-x64",
       "group": "@esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|@esbuild/win32-x64@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|@esbuild/win32-x64@0.25.9",
       "scope": "optional",
       "purl": "pkg:npm/%40esbuild/win32-x64@0.25.9",
       "externalReferences": [
@@ -4650,7 +4650,7 @@
       "name": "eslint-utils",
       "group": "@eslint-community",
       "version": "4.9.0",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint-community/eslint-utils@4.9.0",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint-community/eslint-utils@4.9.0",
       "purl": "pkg:npm/%40eslint-community/eslint-utils@4.9.0",
       "externalReferences": [
         {
@@ -4681,7 +4681,7 @@
       "name": "regexpp",
       "group": "@eslint-community",
       "version": "4.12.1",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint-community/regexpp@4.12.1",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint-community/regexpp@4.12.1",
       "purl": "pkg:npm/%40eslint-community/regexpp@4.12.1",
       "externalReferences": [
         {
@@ -4712,7 +4712,7 @@
       "name": "compat",
       "group": "@eslint",
       "version": "1.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/compat@1.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/compat@1.3.2",
       "purl": "pkg:npm/%40eslint/compat@1.3.2",
       "externalReferences": [
         {
@@ -4743,7 +4743,7 @@
       "name": "config-array",
       "group": "@eslint",
       "version": "0.21.0",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/config-array@0.21.0",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/config-array@0.21.0",
       "purl": "pkg:npm/%40eslint/config-array@0.21.0",
       "externalReferences": [
         {
@@ -4774,7 +4774,7 @@
       "name": "config-helpers",
       "group": "@eslint",
       "version": "0.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/config-helpers@0.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/config-helpers@0.3.1",
       "purl": "pkg:npm/%40eslint/config-helpers@0.3.1",
       "externalReferences": [
         {
@@ -4805,7 +4805,7 @@
       "name": "core",
       "group": "@eslint",
       "version": "0.15.2",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/core@0.15.2",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/core@0.15.2",
       "purl": "pkg:npm/%40eslint/core@0.15.2",
       "externalReferences": [
         {
@@ -4836,7 +4836,7 @@
       "name": "eslintrc",
       "group": "@eslint",
       "version": "3.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1",
       "purl": "pkg:npm/%40eslint/eslintrc@3.3.1",
       "externalReferences": [
         {
@@ -4866,7 +4866,7 @@
           "type": "library",
           "name": "ajv",
           "version": "6.12.6",
-          "bom-ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|ajv@6.12.6",
+          "bom-ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|ajv@6.12.6",
           "purl": "pkg:npm/ajv@6.12.6",
           "externalReferences": [
             {
@@ -4896,7 +4896,7 @@
           "type": "library",
           "name": "globals",
           "version": "14.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|globals@14.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|globals@14.0.0",
           "purl": "pkg:npm/globals@14.0.0",
           "externalReferences": [
             {
@@ -4926,7 +4926,7 @@
           "type": "library",
           "name": "json-schema-traverse",
           "version": "0.4.1",
-          "bom-ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|json-schema-traverse@0.4.1",
+          "bom-ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|json-schema-traverse@0.4.1",
           "purl": "pkg:npm/json-schema-traverse@0.4.1",
           "externalReferences": [
             {
@@ -4959,7 +4959,7 @@
       "name": "js",
       "group": "@eslint",
       "version": "9.35.0",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/js@9.35.0",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/js@9.35.0",
       "purl": "pkg:npm/%40eslint/js@9.35.0",
       "externalReferences": [
         {
@@ -4990,7 +4990,7 @@
       "name": "object-schema",
       "group": "@eslint",
       "version": "2.1.6",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/object-schema@2.1.6",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/object-schema@2.1.6",
       "purl": "pkg:npm/%40eslint/object-schema@2.1.6",
       "externalReferences": [
         {
@@ -5021,7 +5021,7 @@
       "name": "plugin-kit",
       "group": "@eslint",
       "version": "0.3.5",
-      "bom-ref": "nachet-frontend@0.10.3|@eslint/plugin-kit@0.3.5",
+      "bom-ref": "nachet-frontend@0.10.4|@eslint/plugin-kit@0.3.5",
       "purl": "pkg:npm/%40eslint/plugin-kit@0.3.5",
       "externalReferences": [
         {
@@ -5052,7 +5052,7 @@
       "name": "core",
       "group": "@humanfs",
       "version": "0.19.1",
-      "bom-ref": "nachet-frontend@0.10.3|@humanfs/core@0.19.1",
+      "bom-ref": "nachet-frontend@0.10.4|@humanfs/core@0.19.1",
       "purl": "pkg:npm/%40humanfs/core@0.19.1",
       "externalReferences": [
         {
@@ -5083,7 +5083,7 @@
       "name": "node",
       "group": "@humanfs",
       "version": "0.16.7",
-      "bom-ref": "nachet-frontend@0.10.3|@humanfs/node@0.16.7",
+      "bom-ref": "nachet-frontend@0.10.4|@humanfs/node@0.16.7",
       "purl": "pkg:npm/%40humanfs/node@0.16.7",
       "externalReferences": [
         {
@@ -5114,7 +5114,7 @@
       "name": "module-importer",
       "group": "@humanwhocodes",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|@humanwhocodes/module-importer@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|@humanwhocodes/module-importer@1.0.1",
       "purl": "pkg:npm/%40humanwhocodes/module-importer@1.0.1",
       "externalReferences": [
         {
@@ -5145,7 +5145,7 @@
       "name": "retry",
       "group": "@humanwhocodes",
       "version": "0.4.3",
-      "bom-ref": "nachet-frontend@0.10.3|@humanwhocodes/retry@0.4.3",
+      "bom-ref": "nachet-frontend@0.10.4|@humanwhocodes/retry@0.4.3",
       "purl": "pkg:npm/%40humanwhocodes/retry@0.4.3",
       "externalReferences": [
         {
@@ -5176,7 +5176,7 @@
       "name": "cliui",
       "group": "@isaacs",
       "version": "8.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|@isaacs/cliui@8.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|@isaacs/cliui@8.0.2",
       "purl": "pkg:npm/%40isaacs/cliui@8.0.2",
       "externalReferences": [
         {
@@ -5207,7 +5207,7 @@
       "name": "fs-minipass",
       "group": "@isaacs",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|@isaacs/fs-minipass@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|@isaacs/fs-minipass@4.0.1",
       "scope": "optional",
       "purl": "pkg:npm/%40isaacs/fs-minipass@4.0.1",
       "externalReferences": [
@@ -5239,7 +5239,7 @@
       "name": "schema",
       "group": "@istanbuljs",
       "version": "0.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|@istanbuljs/schema@0.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|@istanbuljs/schema@0.1.3",
       "purl": "pkg:npm/%40istanbuljs/schema@0.1.3",
       "externalReferences": [
         {
@@ -5270,7 +5270,7 @@
       "name": "environment-jsdom-abstract",
       "group": "@jest",
       "version": "30.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|@jest/environment-jsdom-abstract@30.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|@jest/environment-jsdom-abstract@30.1.2",
       "purl": "pkg:npm/%40jest/environment-jsdom-abstract@30.1.2",
       "externalReferences": [
         {
@@ -5301,7 +5301,7 @@
       "name": "environment",
       "group": "@jest",
       "version": "30.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|@jest/environment@30.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|@jest/environment@30.1.2",
       "purl": "pkg:npm/%40jest/environment@30.1.2",
       "externalReferences": [
         {
@@ -5332,7 +5332,7 @@
       "name": "fake-timers",
       "group": "@jest",
       "version": "30.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|@jest/fake-timers@30.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|@jest/fake-timers@30.1.2",
       "purl": "pkg:npm/%40jest/fake-timers@30.1.2",
       "externalReferences": [
         {
@@ -5363,7 +5363,7 @@
       "name": "pattern",
       "group": "@jest",
       "version": "30.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|@jest/pattern@30.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|@jest/pattern@30.0.1",
       "purl": "pkg:npm/%40jest/pattern@30.0.1",
       "externalReferences": [
         {
@@ -5394,7 +5394,7 @@
       "name": "schemas",
       "group": "@jest",
       "version": "30.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|@jest/schemas@30.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|@jest/schemas@30.0.5",
       "purl": "pkg:npm/%40jest/schemas@30.0.5",
       "externalReferences": [
         {
@@ -5425,7 +5425,7 @@
       "name": "types",
       "group": "@jest",
       "version": "30.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|@jest/types@30.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|@jest/types@30.0.5",
       "purl": "pkg:npm/%40jest/types@30.0.5",
       "externalReferences": [
         {
@@ -5456,7 +5456,7 @@
       "name": "gen-mapping",
       "group": "@jridgewell",
       "version": "0.3.13",
-      "bom-ref": "nachet-frontend@0.10.3|@jridgewell/gen-mapping@0.3.13",
+      "bom-ref": "nachet-frontend@0.10.4|@jridgewell/gen-mapping@0.3.13",
       "purl": "pkg:npm/%40jridgewell/gen-mapping@0.3.13",
       "externalReferences": [
         {
@@ -5483,7 +5483,7 @@
       "name": "remapping",
       "group": "@jridgewell",
       "version": "2.3.5",
-      "bom-ref": "nachet-frontend@0.10.3|@jridgewell/remapping@2.3.5",
+      "bom-ref": "nachet-frontend@0.10.4|@jridgewell/remapping@2.3.5",
       "purl": "pkg:npm/%40jridgewell/remapping@2.3.5",
       "externalReferences": [
         {
@@ -5510,7 +5510,7 @@
       "name": "resolve-uri",
       "group": "@jridgewell",
       "version": "3.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|@jridgewell/resolve-uri@3.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|@jridgewell/resolve-uri@3.1.2",
       "purl": "pkg:npm/%40jridgewell/resolve-uri@3.1.2",
       "externalReferences": [
         {
@@ -5537,7 +5537,7 @@
       "name": "sourcemap-codec",
       "group": "@jridgewell",
       "version": "1.5.5",
-      "bom-ref": "nachet-frontend@0.10.3|@jridgewell/sourcemap-codec@1.5.5",
+      "bom-ref": "nachet-frontend@0.10.4|@jridgewell/sourcemap-codec@1.5.5",
       "purl": "pkg:npm/%40jridgewell/sourcemap-codec@1.5.5",
       "externalReferences": [
         {
@@ -5564,7 +5564,7 @@
       "name": "trace-mapping",
       "group": "@jridgewell",
       "version": "0.3.31",
-      "bom-ref": "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31",
+      "bom-ref": "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31",
       "purl": "pkg:npm/%40jridgewell/trace-mapping@0.3.31",
       "externalReferences": [
         {
@@ -5591,7 +5591,7 @@
       "name": "core-downloads-tracker",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/core-downloads-tracker@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/core-downloads-tracker@7.3.2",
       "purl": "pkg:npm/%40mui/core-downloads-tracker@7.3.2",
       "externalReferences": [
         {
@@ -5618,7 +5618,7 @@
       "name": "icons-material",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/icons-material@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/icons-material@7.3.2",
       "purl": "pkg:npm/%40mui/icons-material@7.3.2",
       "externalReferences": [
         {
@@ -5645,7 +5645,7 @@
       "name": "material",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/material@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/material@7.3.2",
       "purl": "pkg:npm/%40mui/material@7.3.2",
       "externalReferences": [
         {
@@ -5672,7 +5672,7 @@
       "name": "private-theming",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/private-theming@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/private-theming@7.3.2",
       "purl": "pkg:npm/%40mui/private-theming@7.3.2",
       "externalReferences": [
         {
@@ -5699,7 +5699,7 @@
       "name": "styled-engine",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/styled-engine@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/styled-engine@7.3.2",
       "purl": "pkg:npm/%40mui/styled-engine@7.3.2",
       "externalReferences": [
         {
@@ -5726,7 +5726,7 @@
       "name": "system",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/system@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/system@7.3.2",
       "purl": "pkg:npm/%40mui/system@7.3.2",
       "externalReferences": [
         {
@@ -5753,7 +5753,7 @@
       "name": "types",
       "group": "@mui",
       "version": "7.4.6",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/types@7.4.6",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/types@7.4.6",
       "purl": "pkg:npm/%40mui/types@7.4.6",
       "externalReferences": [
         {
@@ -5780,7 +5780,7 @@
       "name": "utils",
       "group": "@mui",
       "version": "7.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|@mui/utils@7.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|@mui/utils@7.3.2",
       "purl": "pkg:npm/%40mui/utils@7.3.2",
       "externalReferences": [
         {
@@ -5807,7 +5807,7 @@
       "name": "fs.scandir",
       "group": "@nodelib",
       "version": "2.1.5",
-      "bom-ref": "nachet-frontend@0.10.3|@nodelib/fs.scandir@2.1.5",
+      "bom-ref": "nachet-frontend@0.10.4|@nodelib/fs.scandir@2.1.5",
       "purl": "pkg:npm/%40nodelib/fs.scandir@2.1.5",
       "externalReferences": [
         {
@@ -5838,7 +5838,7 @@
       "name": "fs.stat",
       "group": "@nodelib",
       "version": "2.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|@nodelib/fs.stat@2.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|@nodelib/fs.stat@2.0.5",
       "purl": "pkg:npm/%40nodelib/fs.stat@2.0.5",
       "externalReferences": [
         {
@@ -5869,7 +5869,7 @@
       "name": "fs.walk",
       "group": "@nodelib",
       "version": "1.2.8",
-      "bom-ref": "nachet-frontend@0.10.3|@nodelib/fs.walk@1.2.8",
+      "bom-ref": "nachet-frontend@0.10.4|@nodelib/fs.walk@1.2.8",
       "purl": "pkg:npm/%40nodelib/fs.walk@1.2.8",
       "externalReferences": [
         {
@@ -5900,7 +5900,7 @@
       "name": "agent",
       "group": "@npmcli",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|@npmcli/agent@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|@npmcli/agent@3.0.0",
       "scope": "optional",
       "purl": "pkg:npm/%40npmcli/agent@3.0.0",
       "externalReferences": [
@@ -5931,7 +5931,7 @@
           "type": "library",
           "name": "lru-cache",
           "version": "10.4.3",
-          "bom-ref": "nachet-frontend@0.10.3|@npmcli/agent@3.0.0|lru-cache@10.4.3",
+          "bom-ref": "nachet-frontend@0.10.4|@npmcli/agent@3.0.0|lru-cache@10.4.3",
           "scope": "optional",
           "purl": "pkg:npm/lru-cache@10.4.3",
           "externalReferences": [
@@ -5965,7 +5965,7 @@
       "name": "fs",
       "group": "@npmcli",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|@npmcli/fs@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|@npmcli/fs@4.0.0",
       "scope": "optional",
       "purl": "pkg:npm/%40npmcli/fs@4.0.0",
       "externalReferences": [
@@ -5996,7 +5996,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|@npmcli/fs@4.0.0|semver@7.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|@npmcli/fs@4.0.0|semver@7.7.2",
           "scope": "optional",
           "purl": "pkg:npm/semver@7.7.2",
           "externalReferences": [
@@ -6030,7 +6030,7 @@
       "name": "dom",
       "group": "@oozcitak",
       "version": "1.15.10",
-      "bom-ref": "nachet-frontend@0.10.3|@oozcitak/dom@1.15.10",
+      "bom-ref": "nachet-frontend@0.10.4|@oozcitak/dom@1.15.10",
       "purl": "pkg:npm/%40oozcitak/dom@1.15.10",
       "externalReferences": [
         {
@@ -6061,7 +6061,7 @@
       "name": "infra",
       "group": "@oozcitak",
       "version": "1.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|@oozcitak/infra@1.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|@oozcitak/infra@1.0.8",
       "purl": "pkg:npm/%40oozcitak/infra@1.0.8",
       "externalReferences": [
         {
@@ -6092,7 +6092,7 @@
       "name": "url",
       "group": "@oozcitak",
       "version": "1.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|@oozcitak/url@1.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|@oozcitak/url@1.0.4",
       "purl": "pkg:npm/%40oozcitak/url@1.0.4",
       "externalReferences": [
         {
@@ -6123,7 +6123,7 @@
       "name": "util",
       "group": "@oozcitak",
       "version": "8.3.8",
-      "bom-ref": "nachet-frontend@0.10.3|@oozcitak/util@8.3.8",
+      "bom-ref": "nachet-frontend@0.10.4|@oozcitak/util@8.3.8",
       "purl": "pkg:npm/%40oozcitak/util@8.3.8",
       "externalReferences": [
         {
@@ -6154,7 +6154,7 @@
       "name": "parseargs",
       "group": "@pkgjs",
       "version": "0.11.0",
-      "bom-ref": "nachet-frontend@0.10.3|@pkgjs/parseargs@0.11.0",
+      "bom-ref": "nachet-frontend@0.10.4|@pkgjs/parseargs@0.11.0",
       "scope": "optional",
       "purl": "pkg:npm/%40pkgjs/parseargs@0.11.0",
       "externalReferences": [
@@ -6186,7 +6186,7 @@
       "name": "core",
       "group": "@pkgr",
       "version": "0.2.9",
-      "bom-ref": "nachet-frontend@0.10.3|@pkgr/core@0.2.9",
+      "bom-ref": "nachet-frontend@0.10.4|@pkgr/core@0.2.9",
       "purl": "pkg:npm/%40pkgr/core@0.2.9",
       "externalReferences": [
         {
@@ -6217,7 +6217,7 @@
       "name": "core",
       "group": "@popperjs",
       "version": "2.11.8",
-      "bom-ref": "nachet-frontend@0.10.3|@popperjs/core@2.11.8",
+      "bom-ref": "nachet-frontend@0.10.4|@popperjs/core@2.11.8",
       "purl": "pkg:npm/%40popperjs/core@2.11.8",
       "externalReferences": [
         {
@@ -6244,7 +6244,7 @@
       "name": "pluginutils",
       "group": "@rolldown",
       "version": "1.0.0-beta.32",
-      "bom-ref": "nachet-frontend@0.10.3|@rolldown/pluginutils@1.0.0-beta.32",
+      "bom-ref": "nachet-frontend@0.10.4|@rolldown/pluginutils@1.0.0-beta.32",
       "purl": "pkg:npm/%40rolldown/pluginutils@1.0.0-beta.32",
       "externalReferences": [
         {
@@ -6275,7 +6275,7 @@
       "name": "rollup-android-arm-eabi",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-android-arm-eabi@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-android-arm-eabi@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-android-arm-eabi@4.50.2",
       "externalReferences": [
@@ -6307,7 +6307,7 @@
       "name": "rollup-android-arm64",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-android-arm64@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-android-arm64@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-android-arm64@4.50.2",
       "externalReferences": [
@@ -6339,7 +6339,7 @@
       "name": "rollup-darwin-arm64",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-darwin-arm64@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-darwin-arm64@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-darwin-arm64@4.50.2",
       "externalReferences": [
@@ -6371,7 +6371,7 @@
       "name": "rollup-darwin-x64",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-darwin-x64@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-darwin-x64@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-darwin-x64@4.50.2",
       "externalReferences": [
@@ -6403,7 +6403,7 @@
       "name": "rollup-freebsd-arm64",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-freebsd-arm64@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-freebsd-arm64@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-freebsd-arm64@4.50.2",
       "externalReferences": [
@@ -6435,7 +6435,7 @@
       "name": "rollup-freebsd-x64",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-freebsd-x64@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-freebsd-x64@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-freebsd-x64@4.50.2",
       "externalReferences": [
@@ -6467,7 +6467,7 @@
       "name": "rollup-linux-arm-gnueabihf",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm-gnueabihf@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm-gnueabihf@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-arm-gnueabihf@4.50.2",
       "externalReferences": [
@@ -6499,7 +6499,7 @@
       "name": "rollup-linux-arm-musleabihf",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm-musleabihf@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm-musleabihf@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-arm-musleabihf@4.50.2",
       "externalReferences": [
@@ -6531,7 +6531,7 @@
       "name": "rollup-linux-arm64-gnu",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm64-gnu@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm64-gnu@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-arm64-gnu@4.50.2",
       "externalReferences": [
@@ -6563,7 +6563,7 @@
       "name": "rollup-linux-arm64-musl",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm64-musl@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm64-musl@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-arm64-musl@4.50.2",
       "externalReferences": [
@@ -6595,7 +6595,7 @@
       "name": "rollup-linux-loong64-gnu",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-loong64-gnu@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-loong64-gnu@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-loong64-gnu@4.50.2",
       "externalReferences": [
@@ -6627,7 +6627,7 @@
       "name": "rollup-linux-ppc64-gnu",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-ppc64-gnu@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-ppc64-gnu@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-ppc64-gnu@4.50.2",
       "externalReferences": [
@@ -6659,7 +6659,7 @@
       "name": "rollup-linux-riscv64-gnu",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-riscv64-gnu@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-riscv64-gnu@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-riscv64-gnu@4.50.2",
       "externalReferences": [
@@ -6691,7 +6691,7 @@
       "name": "rollup-linux-riscv64-musl",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-riscv64-musl@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-riscv64-musl@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-riscv64-musl@4.50.2",
       "externalReferences": [
@@ -6723,7 +6723,7 @@
       "name": "rollup-linux-s390x-gnu",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-s390x-gnu@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-s390x-gnu@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-s390x-gnu@4.50.2",
       "externalReferences": [
@@ -6755,7 +6755,7 @@
       "name": "rollup-linux-x64-gnu",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-x64-gnu@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-x64-gnu@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-x64-gnu@4.50.2",
       "externalReferences": [
@@ -6787,7 +6787,7 @@
       "name": "rollup-linux-x64-musl",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-x64-musl@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-x64-musl@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-linux-x64-musl@4.50.2",
       "externalReferences": [
@@ -6819,7 +6819,7 @@
       "name": "rollup-openharmony-arm64",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-openharmony-arm64@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-openharmony-arm64@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-openharmony-arm64@4.50.2",
       "externalReferences": [
@@ -6851,7 +6851,7 @@
       "name": "rollup-win32-arm64-msvc",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-win32-arm64-msvc@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-win32-arm64-msvc@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-win32-arm64-msvc@4.50.2",
       "externalReferences": [
@@ -6883,7 +6883,7 @@
       "name": "rollup-win32-ia32-msvc",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-win32-ia32-msvc@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-win32-ia32-msvc@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-win32-ia32-msvc@4.50.2",
       "externalReferences": [
@@ -6915,7 +6915,7 @@
       "name": "rollup-win32-x64-msvc",
       "group": "@rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|@rollup/rollup-win32-x64-msvc@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|@rollup/rollup-win32-x64-msvc@4.50.2",
       "scope": "optional",
       "purl": "pkg:npm/%40rollup/rollup-win32-x64-msvc@4.50.2",
       "externalReferences": [
@@ -6947,7 +6947,7 @@
       "name": "scc",
       "group": "@rtsao",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|@rtsao/scc@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|@rtsao/scc@1.1.0",
       "purl": "pkg:npm/%40rtsao/scc@1.1.0",
       "externalReferences": [
         {
@@ -6978,7 +6978,7 @@
       "name": "ts-appversion",
       "group": "@saithodev",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|@saithodev/ts-appversion@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|@saithodev/ts-appversion@2.2.0",
       "purl": "pkg:npm/%40saithodev/ts-appversion@2.2.0",
       "externalReferences": [
         {
@@ -7005,7 +7005,7 @@
       "name": "typebox",
       "group": "@sinclair",
       "version": "0.34.41",
-      "bom-ref": "nachet-frontend@0.10.3|@sinclair/typebox@0.34.41",
+      "bom-ref": "nachet-frontend@0.10.4|@sinclair/typebox@0.34.41",
       "purl": "pkg:npm/%40sinclair/typebox@0.34.41",
       "externalReferences": [
         {
@@ -7036,7 +7036,7 @@
       "name": "commons",
       "group": "@sinonjs",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|@sinonjs/commons@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|@sinonjs/commons@3.0.1",
       "purl": "pkg:npm/%40sinonjs/commons@3.0.1",
       "externalReferences": [
         {
@@ -7067,7 +7067,7 @@
       "name": "fake-timers",
       "group": "@sinonjs",
       "version": "13.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|@sinonjs/fake-timers@13.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|@sinonjs/fake-timers@13.0.5",
       "purl": "pkg:npm/%40sinonjs/fake-timers@13.0.5",
       "externalReferences": [
         {
@@ -7098,7 +7098,7 @@
       "name": "core-darwin-arm64",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-darwin-arm64@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-darwin-arm64@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-darwin-arm64@1.13.5",
       "externalReferences": [
@@ -7130,7 +7130,7 @@
       "name": "core-darwin-x64",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-darwin-x64@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-darwin-x64@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-darwin-x64@1.13.5",
       "externalReferences": [
@@ -7162,7 +7162,7 @@
       "name": "core-linux-arm-gnueabihf",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-linux-arm-gnueabihf@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-linux-arm-gnueabihf@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-linux-arm-gnueabihf@1.13.5",
       "externalReferences": [
@@ -7194,7 +7194,7 @@
       "name": "core-linux-arm64-gnu",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-linux-arm64-gnu@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-linux-arm64-gnu@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-linux-arm64-gnu@1.13.5",
       "externalReferences": [
@@ -7226,7 +7226,7 @@
       "name": "core-linux-arm64-musl",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-linux-arm64-musl@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-linux-arm64-musl@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-linux-arm64-musl@1.13.5",
       "externalReferences": [
@@ -7258,7 +7258,7 @@
       "name": "core-linux-x64-gnu",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-linux-x64-gnu@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-linux-x64-gnu@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-linux-x64-gnu@1.13.5",
       "externalReferences": [
@@ -7290,7 +7290,7 @@
       "name": "core-linux-x64-musl",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-linux-x64-musl@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-linux-x64-musl@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-linux-x64-musl@1.13.5",
       "externalReferences": [
@@ -7322,7 +7322,7 @@
       "name": "core-win32-arm64-msvc",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-win32-arm64-msvc@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-win32-arm64-msvc@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-win32-arm64-msvc@1.13.5",
       "externalReferences": [
@@ -7354,7 +7354,7 @@
       "name": "core-win32-ia32-msvc",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-win32-ia32-msvc@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-win32-ia32-msvc@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-win32-ia32-msvc@1.13.5",
       "externalReferences": [
@@ -7386,7 +7386,7 @@
       "name": "core-win32-x64-msvc",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core-win32-x64-msvc@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core-win32-x64-msvc@1.13.5",
       "scope": "optional",
       "purl": "pkg:npm/%40swc/core-win32-x64-msvc@1.13.5",
       "externalReferences": [
@@ -7418,7 +7418,7 @@
       "name": "core",
       "group": "@swc",
       "version": "1.13.5",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/core@1.13.5",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/core@1.13.5",
       "purl": "pkg:npm/%40swc/core@1.13.5",
       "externalReferences": [
         {
@@ -7449,7 +7449,7 @@
       "name": "counter",
       "group": "@swc",
       "version": "0.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/counter@0.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/counter@0.1.3",
       "purl": "pkg:npm/%40swc/counter@0.1.3",
       "externalReferences": [
         {
@@ -7480,7 +7480,7 @@
       "name": "types",
       "group": "@swc",
       "version": "0.1.25",
-      "bom-ref": "nachet-frontend@0.10.3|@swc/types@0.1.25",
+      "bom-ref": "nachet-frontend@0.10.4|@swc/types@0.1.25",
       "purl": "pkg:npm/%40swc/types@0.1.25",
       "externalReferences": [
         {
@@ -7511,7 +7511,7 @@
       "name": "dom",
       "group": "@testing-library",
       "version": "10.4.1",
-      "bom-ref": "nachet-frontend@0.10.3|@testing-library/dom@10.4.1",
+      "bom-ref": "nachet-frontend@0.10.4|@testing-library/dom@10.4.1",
       "purl": "pkg:npm/%40testing-library/dom@10.4.1",
       "externalReferences": [
         {
@@ -7542,7 +7542,7 @@
       "name": "jest-dom",
       "group": "@testing-library",
       "version": "6.8.0",
-      "bom-ref": "nachet-frontend@0.10.3|@testing-library/jest-dom@6.8.0",
+      "bom-ref": "nachet-frontend@0.10.4|@testing-library/jest-dom@6.8.0",
       "purl": "pkg:npm/%40testing-library/jest-dom@6.8.0",
       "externalReferences": [
         {
@@ -7568,7 +7568,7 @@
           "type": "library",
           "name": "dom-accessibility-api",
           "version": "0.6.3",
-          "bom-ref": "nachet-frontend@0.10.3|@testing-library/jest-dom@6.8.0|dom-accessibility-api@0.6.3",
+          "bom-ref": "nachet-frontend@0.10.4|@testing-library/jest-dom@6.8.0|dom-accessibility-api@0.6.3",
           "purl": "pkg:npm/dom-accessibility-api@0.6.3",
           "externalReferences": [
             {
@@ -7597,7 +7597,7 @@
       "name": "react",
       "group": "@testing-library",
       "version": "16.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|@testing-library/react@16.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|@testing-library/react@16.3.0",
       "purl": "pkg:npm/%40testing-library/react@16.3.0",
       "externalReferences": [
         {
@@ -7628,7 +7628,7 @@
       "name": "user-event",
       "group": "@testing-library",
       "version": "14.6.1",
-      "bom-ref": "nachet-frontend@0.10.3|@testing-library/user-event@14.6.1",
+      "bom-ref": "nachet-frontend@0.10.4|@testing-library/user-event@14.6.1",
       "purl": "pkg:npm/%40testing-library/user-event@14.6.1",
       "externalReferences": [
         {
@@ -7659,7 +7659,7 @@
       "name": "aria-query",
       "group": "@types",
       "version": "5.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|@types/aria-query@5.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|@types/aria-query@5.0.4",
       "purl": "pkg:npm/%40types/aria-query@5.0.4",
       "externalReferences": [
         {
@@ -7690,7 +7690,7 @@
       "name": "chai",
       "group": "@types",
       "version": "5.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|@types/chai@5.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|@types/chai@5.2.2",
       "purl": "pkg:npm/%40types/chai@5.2.2",
       "externalReferences": [
         {
@@ -7721,7 +7721,7 @@
       "name": "deep-eql",
       "group": "@types",
       "version": "4.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|@types/deep-eql@4.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|@types/deep-eql@4.0.2",
       "purl": "pkg:npm/%40types/deep-eql@4.0.2",
       "externalReferences": [
         {
@@ -7752,7 +7752,7 @@
       "name": "estree",
       "group": "@types",
       "version": "1.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|@types/estree@1.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|@types/estree@1.0.8",
       "purl": "pkg:npm/%40types/estree@1.0.8",
       "externalReferences": [
         {
@@ -7783,7 +7783,7 @@
       "name": "file-saver",
       "group": "@types",
       "version": "2.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|@types/file-saver@2.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|@types/file-saver@2.0.7",
       "purl": "pkg:npm/%40types/file-saver@2.0.7",
       "externalReferences": [
         {
@@ -7814,7 +7814,7 @@
       "name": "istanbul-lib-coverage",
       "group": "@types",
       "version": "2.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|@types/istanbul-lib-coverage@2.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|@types/istanbul-lib-coverage@2.0.6",
       "purl": "pkg:npm/%40types/istanbul-lib-coverage@2.0.6",
       "externalReferences": [
         {
@@ -7845,7 +7845,7 @@
       "name": "istanbul-lib-report",
       "group": "@types",
       "version": "3.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|@types/istanbul-lib-report@3.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|@types/istanbul-lib-report@3.0.3",
       "purl": "pkg:npm/%40types/istanbul-lib-report@3.0.3",
       "externalReferences": [
         {
@@ -7876,7 +7876,7 @@
       "name": "istanbul-reports",
       "group": "@types",
       "version": "3.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|@types/istanbul-reports@3.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|@types/istanbul-reports@3.0.4",
       "purl": "pkg:npm/%40types/istanbul-reports@3.0.4",
       "externalReferences": [
         {
@@ -7907,7 +7907,7 @@
       "name": "js-cookie",
       "group": "@types",
       "version": "3.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|@types/js-cookie@3.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|@types/js-cookie@3.0.6",
       "purl": "pkg:npm/%40types/js-cookie@3.0.6",
       "externalReferences": [
         {
@@ -7938,7 +7938,7 @@
       "name": "jsdom",
       "group": "@types",
       "version": "21.1.7",
-      "bom-ref": "nachet-frontend@0.10.3|@types/jsdom@21.1.7",
+      "bom-ref": "nachet-frontend@0.10.4|@types/jsdom@21.1.7",
       "purl": "pkg:npm/%40types/jsdom@21.1.7",
       "externalReferences": [
         {
@@ -7969,7 +7969,7 @@
       "name": "json-schema",
       "group": "@types",
       "version": "7.0.15",
-      "bom-ref": "nachet-frontend@0.10.3|@types/json-schema@7.0.15",
+      "bom-ref": "nachet-frontend@0.10.4|@types/json-schema@7.0.15",
       "purl": "pkg:npm/%40types/json-schema@7.0.15",
       "externalReferences": [
         {
@@ -8000,7 +8000,7 @@
       "name": "json5",
       "group": "@types",
       "version": "0.0.29",
-      "bom-ref": "nachet-frontend@0.10.3|@types/json5@0.0.29",
+      "bom-ref": "nachet-frontend@0.10.4|@types/json5@0.0.29",
       "purl": "pkg:npm/%40types/json5@0.0.29",
       "externalReferences": [
         {
@@ -8030,17 +8030,25 @@
       "type": "library",
       "name": "node",
       "group": "@types",
-      "version": "22.18.4",
-      "bom-ref": "nachet-frontend@0.10.3|@types/node@22.18.4",
-      "purl": "pkg:npm/%40types/node@22.18.4",
+      "version": "22.18.5",
+      "bom-ref": "nachet-frontend@0.10.4|@types/node@22.18.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40types/node@22.18.5",
       "externalReferences": [
         {
-          "url": "https://registry.npmjs.org/@types/node/-/node-22.18.4.tgz",
+          "url": "https://registry.npmjs.org/@types/node/-/node-22.18.5.tgz",
           "type": "distribution",
           "hashes": [
             {
               "alg": "SHA-512",
-              "content": "50975b945a97ca648186665ff7a0676e2b28148afca288a2051328950820efb11af95337ee35f0efa0b62d0afd9fcc26f7e8bf3af954956eb14afab0cf0ab39f"
+              "content": "83d0693df26fc5805751623d6d5dfb8fa77a2d330d43cf213f0756594798667321968eba14883d802735fc365bd7943294948ac0e663c2b724bce4d6a4e88286"
             }
           ],
           "comment": "as detected from npm-ls property \"resolved\" and property \"integrity\""
@@ -8062,7 +8070,7 @@
       "name": "pako",
       "group": "@types",
       "version": "2.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|@types/pako@2.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|@types/pako@2.0.4",
       "purl": "pkg:npm/%40types/pako@2.0.4",
       "externalReferences": [
         {
@@ -8093,7 +8101,7 @@
       "name": "parse-json",
       "group": "@types",
       "version": "4.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|@types/parse-json@4.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|@types/parse-json@4.0.2",
       "purl": "pkg:npm/%40types/parse-json@4.0.2",
       "externalReferences": [
         {
@@ -8120,7 +8128,7 @@
       "name": "prop-types",
       "group": "@types",
       "version": "15.7.15",
-      "bom-ref": "nachet-frontend@0.10.3|@types/prop-types@15.7.15",
+      "bom-ref": "nachet-frontend@0.10.4|@types/prop-types@15.7.15",
       "purl": "pkg:npm/%40types/prop-types@15.7.15",
       "externalReferences": [
         {
@@ -8147,7 +8155,7 @@
       "name": "react-dom",
       "group": "@types",
       "version": "19.1.9",
-      "bom-ref": "nachet-frontend@0.10.3|@types/react-dom@19.1.9",
+      "bom-ref": "nachet-frontend@0.10.4|@types/react-dom@19.1.9",
       "purl": "pkg:npm/%40types/react-dom@19.1.9",
       "externalReferences": [
         {
@@ -8178,7 +8186,7 @@
       "name": "react-transition-group",
       "group": "@types",
       "version": "4.4.12",
-      "bom-ref": "nachet-frontend@0.10.3|@types/react-transition-group@4.4.12",
+      "bom-ref": "nachet-frontend@0.10.4|@types/react-transition-group@4.4.12",
       "purl": "pkg:npm/%40types/react-transition-group@4.4.12",
       "externalReferences": [
         {
@@ -8205,7 +8213,7 @@
       "name": "react",
       "group": "@types",
       "version": "19.1.13",
-      "bom-ref": "nachet-frontend@0.10.3|@types/react@19.1.13",
+      "bom-ref": "nachet-frontend@0.10.4|@types/react@19.1.13",
       "purl": "pkg:npm/%40types/react@19.1.13",
       "externalReferences": [
         {
@@ -8232,7 +8240,7 @@
       "name": "sanitize-html",
       "group": "@types",
       "version": "2.16.0",
-      "bom-ref": "nachet-frontend@0.10.3|@types/sanitize-html@2.16.0",
+      "bom-ref": "nachet-frontend@0.10.4|@types/sanitize-html@2.16.0",
       "purl": "pkg:npm/%40types/sanitize-html@2.16.0",
       "externalReferences": [
         {
@@ -8263,7 +8271,7 @@
       "name": "semver",
       "group": "@types",
       "version": "7.7.1",
-      "bom-ref": "nachet-frontend@0.10.3|@types/semver@7.7.1",
+      "bom-ref": "nachet-frontend@0.10.4|@types/semver@7.7.1",
       "purl": "pkg:npm/%40types/semver@7.7.1",
       "externalReferences": [
         {
@@ -8290,7 +8298,7 @@
       "name": "stack-utils",
       "group": "@types",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|@types/stack-utils@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|@types/stack-utils@2.0.3",
       "purl": "pkg:npm/%40types/stack-utils@2.0.3",
       "externalReferences": [
         {
@@ -8321,7 +8329,7 @@
       "name": "stylis",
       "group": "@types",
       "version": "4.2.5",
-      "bom-ref": "nachet-frontend@0.10.3|@types/stylis@4.2.5",
+      "bom-ref": "nachet-frontend@0.10.4|@types/stylis@4.2.5",
       "purl": "pkg:npm/%40types/stylis@4.2.5",
       "externalReferences": [
         {
@@ -8348,7 +8356,7 @@
       "name": "tough-cookie",
       "group": "@types",
       "version": "4.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|@types/tough-cookie@4.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|@types/tough-cookie@4.0.5",
       "purl": "pkg:npm/%40types/tough-cookie@4.0.5",
       "externalReferences": [
         {
@@ -8379,7 +8387,7 @@
       "name": "trusted-types",
       "group": "@types",
       "version": "2.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|@types/trusted-types@2.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|@types/trusted-types@2.0.7",
       "scope": "optional",
       "purl": "pkg:npm/%40types/trusted-types@2.0.7",
       "externalReferences": [
@@ -8407,7 +8415,7 @@
       "name": "utif",
       "group": "@types",
       "version": "3.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|@types/utif@3.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|@types/utif@3.0.6",
       "purl": "pkg:npm/%40types/utif@3.0.6",
       "externalReferences": [
         {
@@ -8438,7 +8446,7 @@
       "name": "uuid",
       "group": "@types",
       "version": "10.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|@types/uuid@10.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|@types/uuid@10.0.0",
       "purl": "pkg:npm/%40types/uuid@10.0.0",
       "externalReferences": [
         {
@@ -8469,7 +8477,7 @@
       "name": "yargs-parser",
       "group": "@types",
       "version": "21.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|@types/yargs-parser@21.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|@types/yargs-parser@21.0.3",
       "purl": "pkg:npm/%40types/yargs-parser@21.0.3",
       "externalReferences": [
         {
@@ -8500,7 +8508,7 @@
       "name": "yargs",
       "group": "@types",
       "version": "17.0.33",
-      "bom-ref": "nachet-frontend@0.10.3|@types/yargs@17.0.33",
+      "bom-ref": "nachet-frontend@0.10.4|@types/yargs@17.0.33",
       "purl": "pkg:npm/%40types/yargs@17.0.33",
       "externalReferences": [
         {
@@ -8531,7 +8539,7 @@
       "name": "eslint-plugin",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/eslint-plugin@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/eslint-plugin@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/eslint-plugin@8.44.0",
       "externalReferences": [
         {
@@ -8561,7 +8569,7 @@
           "type": "library",
           "name": "ignore",
           "version": "7.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/eslint-plugin@8.44.0|ignore@7.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/eslint-plugin@8.44.0|ignore@7.0.5",
           "purl": "pkg:npm/ignore@7.0.5",
           "externalReferences": [
             {
@@ -8594,7 +8602,7 @@
       "name": "parser",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/parser@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/parser@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/parser@8.44.0",
       "externalReferences": [
         {
@@ -8625,7 +8633,7 @@
       "name": "project-service",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/project-service@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/project-service@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/project-service@8.44.0",
       "externalReferences": [
         {
@@ -8656,7 +8664,7 @@
       "name": "scope-manager",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/scope-manager@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/scope-manager@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/scope-manager@8.44.0",
       "externalReferences": [
         {
@@ -8687,7 +8695,7 @@
       "name": "tsconfig-utils",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/tsconfig-utils@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/tsconfig-utils@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/tsconfig-utils@8.44.0",
       "externalReferences": [
         {
@@ -8718,7 +8726,7 @@
       "name": "type-utils",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/type-utils@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/type-utils@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/type-utils@8.44.0",
       "externalReferences": [
         {
@@ -8749,7 +8757,7 @@
       "name": "types",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/types@8.44.0",
       "externalReferences": [
         {
@@ -8780,7 +8788,7 @@
       "name": "typescript-estree",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/typescript-estree@8.44.0",
       "externalReferences": [
         {
@@ -8810,7 +8818,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "2.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|brace-expansion@2.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|brace-expansion@2.0.2",
           "purl": "pkg:npm/brace-expansion@2.0.2",
           "externalReferences": [
             {
@@ -8840,7 +8848,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "9.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|minimatch@9.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|minimatch@9.0.5",
           "purl": "pkg:npm/minimatch@9.0.5",
           "externalReferences": [
             {
@@ -8870,7 +8878,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|semver@7.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|semver@7.7.2",
           "purl": "pkg:npm/semver@7.7.2",
           "externalReferences": [
             {
@@ -8903,7 +8911,7 @@
       "name": "utils",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/utils@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/utils@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/utils@8.44.0",
       "externalReferences": [
         {
@@ -8934,7 +8942,7 @@
       "name": "visitor-keys",
       "group": "@typescript-eslint",
       "version": "8.44.0",
-      "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0",
+      "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0",
       "purl": "pkg:npm/%40typescript-eslint/visitor-keys@8.44.0",
       "externalReferences": [
         {
@@ -8964,7 +8972,7 @@
           "type": "library",
           "name": "eslint-visitor-keys",
           "version": "4.2.1",
-          "bom-ref": "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0|eslint-visitor-keys@4.2.1",
+          "bom-ref": "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0|eslint-visitor-keys@4.2.1",
           "purl": "pkg:npm/eslint-visitor-keys@4.2.1",
           "externalReferences": [
             {
@@ -8997,7 +9005,7 @@
       "name": "plugin-react-swc",
       "group": "@vitejs",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|@vitejs/plugin-react-swc@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|@vitejs/plugin-react-swc@4.0.1",
       "purl": "pkg:npm/%40vitejs/plugin-react-swc@4.0.1",
       "externalReferences": [
         {
@@ -9028,7 +9036,7 @@
       "name": "coverage-v8",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/coverage-v8@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/coverage-v8@3.2.4",
       "purl": "pkg:npm/%40vitest/coverage-v8@3.2.4",
       "externalReferences": [
         {
@@ -9059,7 +9067,7 @@
       "name": "expect",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/expect@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/expect@3.2.4",
       "purl": "pkg:npm/%40vitest/expect@3.2.4",
       "externalReferences": [
         {
@@ -9090,7 +9098,7 @@
       "name": "mocker",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/mocker@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/mocker@3.2.4",
       "purl": "pkg:npm/%40vitest/mocker@3.2.4",
       "externalReferences": [
         {
@@ -9121,7 +9129,7 @@
       "name": "pretty-format",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/pretty-format@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/pretty-format@3.2.4",
       "purl": "pkg:npm/%40vitest/pretty-format@3.2.4",
       "externalReferences": [
         {
@@ -9152,7 +9160,7 @@
       "name": "runner",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/runner@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/runner@3.2.4",
       "purl": "pkg:npm/%40vitest/runner@3.2.4",
       "externalReferences": [
         {
@@ -9183,7 +9191,7 @@
       "name": "snapshot",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/snapshot@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/snapshot@3.2.4",
       "purl": "pkg:npm/%40vitest/snapshot@3.2.4",
       "externalReferences": [
         {
@@ -9214,7 +9222,7 @@
       "name": "spy",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/spy@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/spy@3.2.4",
       "purl": "pkg:npm/%40vitest/spy@3.2.4",
       "externalReferences": [
         {
@@ -9245,7 +9253,7 @@
       "name": "utils",
       "group": "@vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|@vitest/utils@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|@vitest/utils@3.2.4",
       "purl": "pkg:npm/%40vitest/utils@3.2.4",
       "externalReferences": [
         {
@@ -9276,7 +9284,7 @@
       "name": "schemas",
       "group": "@zeit",
       "version": "2.36.0",
-      "bom-ref": "nachet-frontend@0.10.3|@zeit/schemas@2.36.0",
+      "bom-ref": "nachet-frontend@0.10.4|@zeit/schemas@2.36.0",
       "purl": "pkg:npm/%40zeit/schemas@2.36.0",
       "externalReferences": [
         {
@@ -9302,7 +9310,7 @@
       "type": "library",
       "name": "abbrev",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|abbrev@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|abbrev@3.0.1",
       "scope": "optional",
       "purl": "pkg:npm/abbrev@3.0.1",
       "externalReferences": [
@@ -9333,7 +9341,7 @@
       "type": "library",
       "name": "accepts",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|accepts@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|accepts@2.0.0",
       "purl": "pkg:npm/accepts@2.0.0",
       "externalReferences": [
         {
@@ -9359,7 +9367,7 @@
       "type": "library",
       "name": "acorn-jsx",
       "version": "5.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|acorn-jsx@5.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|acorn-jsx@5.3.2",
       "purl": "pkg:npm/acorn-jsx@5.3.2",
       "externalReferences": [
         {
@@ -9389,7 +9397,7 @@
       "type": "library",
       "name": "acorn",
       "version": "8.15.0",
-      "bom-ref": "nachet-frontend@0.10.3|acorn@8.15.0",
+      "bom-ref": "nachet-frontend@0.10.4|acorn@8.15.0",
       "purl": "pkg:npm/acorn@8.15.0",
       "externalReferences": [
         {
@@ -9419,7 +9427,7 @@
       "type": "library",
       "name": "agent-base",
       "version": "7.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|agent-base@7.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|agent-base@7.1.4",
       "purl": "pkg:npm/agent-base@7.1.4",
       "externalReferences": [
         {
@@ -9449,7 +9457,7 @@
       "type": "library",
       "name": "ajv-formats-draft2019",
       "version": "1.6.1",
-      "bom-ref": "nachet-frontend@0.10.3|ajv-formats-draft2019@1.6.1",
+      "bom-ref": "nachet-frontend@0.10.4|ajv-formats-draft2019@1.6.1",
       "scope": "optional",
       "purl": "pkg:npm/ajv-formats-draft2019@1.6.1",
       "externalReferences": [
@@ -9480,7 +9488,7 @@
       "type": "library",
       "name": "ajv-formats",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|ajv-formats@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|ajv-formats@3.0.1",
       "scope": "optional",
       "purl": "pkg:npm/ajv-formats@3.0.1",
       "externalReferences": [
@@ -9511,7 +9519,7 @@
       "type": "library",
       "name": "ajv",
       "version": "8.17.1",
-      "bom-ref": "nachet-frontend@0.10.3|ajv@8.17.1",
+      "bom-ref": "nachet-frontend@0.10.4|ajv@8.17.1",
       "scope": "optional",
       "purl": "pkg:npm/ajv@8.17.1",
       "externalReferences": [
@@ -9542,7 +9550,7 @@
       "type": "library",
       "name": "ansi-align",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|ansi-align@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|ansi-align@3.0.1",
       "purl": "pkg:npm/ansi-align@3.0.1",
       "externalReferences": [
         {
@@ -9568,7 +9576,7 @@
           "type": "library",
           "name": "emoji-regex",
           "version": "8.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|ansi-align@3.0.1|emoji-regex@8.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|ansi-align@3.0.1|emoji-regex@8.0.0",
           "purl": "pkg:npm/emoji-regex@8.0.0",
           "externalReferences": [
             {
@@ -9594,7 +9602,7 @@
           "type": "library",
           "name": "string-width",
           "version": "4.2.3",
-          "bom-ref": "nachet-frontend@0.10.3|ansi-align@3.0.1|string-width@4.2.3",
+          "bom-ref": "nachet-frontend@0.10.4|ansi-align@3.0.1|string-width@4.2.3",
           "purl": "pkg:npm/string-width@4.2.3",
           "externalReferences": [
             {
@@ -9620,7 +9628,7 @@
           "type": "library",
           "name": "strip-ansi",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|ansi-align@3.0.1|strip-ansi@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|ansi-align@3.0.1|strip-ansi@6.0.1",
           "purl": "pkg:npm/strip-ansi@6.0.1",
           "externalReferences": [
             {
@@ -9648,7 +9656,7 @@
       "type": "library",
       "name": "ansi-regex",
       "version": "5.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|ansi-regex@5.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|ansi-regex@5.0.1",
       "purl": "pkg:npm/ansi-regex@5.0.1",
       "externalReferences": [
         {
@@ -9674,7 +9682,7 @@
       "type": "library",
       "name": "ansi-styles",
       "version": "4.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|ansi-styles@4.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|ansi-styles@4.3.0",
       "purl": "pkg:npm/ansi-styles@4.3.0",
       "externalReferences": [
         {
@@ -9700,7 +9708,7 @@
       "type": "library",
       "name": "arch",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|arch@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|arch@2.2.0",
       "purl": "pkg:npm/arch@2.2.0",
       "externalReferences": [
         {
@@ -9726,7 +9734,7 @@
       "type": "library",
       "name": "arg",
       "version": "5.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|arg@5.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|arg@5.0.2",
       "purl": "pkg:npm/arg@5.0.2",
       "externalReferences": [
         {
@@ -9752,7 +9760,7 @@
       "type": "library",
       "name": "argparse",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|argparse@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|argparse@2.0.1",
       "purl": "pkg:npm/argparse@2.0.1",
       "externalReferences": [
         {
@@ -9782,7 +9790,7 @@
       "type": "library",
       "name": "aria-query",
       "version": "5.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|aria-query@5.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|aria-query@5.3.0",
       "purl": "pkg:npm/aria-query@5.3.0",
       "externalReferences": [
         {
@@ -9808,7 +9816,7 @@
       "type": "library",
       "name": "array-buffer-byte-length",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|array-buffer-byte-length@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|array-buffer-byte-length@1.0.2",
       "purl": "pkg:npm/array-buffer-byte-length@1.0.2",
       "externalReferences": [
         {
@@ -9838,7 +9846,7 @@
       "type": "library",
       "name": "array-includes",
       "version": "3.1.9",
-      "bom-ref": "nachet-frontend@0.10.3|array-includes@3.1.9",
+      "bom-ref": "nachet-frontend@0.10.4|array-includes@3.1.9",
       "purl": "pkg:npm/array-includes@3.1.9",
       "externalReferences": [
         {
@@ -9868,7 +9876,7 @@
       "type": "library",
       "name": "array.prototype.findlast",
       "version": "1.2.5",
-      "bom-ref": "nachet-frontend@0.10.3|array.prototype.findlast@1.2.5",
+      "bom-ref": "nachet-frontend@0.10.4|array.prototype.findlast@1.2.5",
       "purl": "pkg:npm/array.prototype.findlast@1.2.5",
       "externalReferences": [
         {
@@ -9898,7 +9906,7 @@
       "type": "library",
       "name": "array.prototype.findlastindex",
       "version": "1.2.6",
-      "bom-ref": "nachet-frontend@0.10.3|array.prototype.findlastindex@1.2.6",
+      "bom-ref": "nachet-frontend@0.10.4|array.prototype.findlastindex@1.2.6",
       "purl": "pkg:npm/array.prototype.findlastindex@1.2.6",
       "externalReferences": [
         {
@@ -9928,7 +9936,7 @@
       "type": "library",
       "name": "array.prototype.flat",
       "version": "1.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|array.prototype.flat@1.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|array.prototype.flat@1.3.3",
       "purl": "pkg:npm/array.prototype.flat@1.3.3",
       "externalReferences": [
         {
@@ -9958,7 +9966,7 @@
       "type": "library",
       "name": "array.prototype.flatmap",
       "version": "1.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|array.prototype.flatmap@1.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|array.prototype.flatmap@1.3.3",
       "purl": "pkg:npm/array.prototype.flatmap@1.3.3",
       "externalReferences": [
         {
@@ -9988,7 +9996,7 @@
       "type": "library",
       "name": "array.prototype.tosorted",
       "version": "1.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|array.prototype.tosorted@1.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|array.prototype.tosorted@1.1.4",
       "purl": "pkg:npm/array.prototype.tosorted@1.1.4",
       "externalReferences": [
         {
@@ -10018,7 +10026,7 @@
       "type": "library",
       "name": "arraybuffer.prototype.slice",
       "version": "1.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|arraybuffer.prototype.slice@1.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|arraybuffer.prototype.slice@1.0.4",
       "purl": "pkg:npm/arraybuffer.prototype.slice@1.0.4",
       "externalReferences": [
         {
@@ -10048,7 +10056,7 @@
       "type": "library",
       "name": "assertion-error",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|assertion-error@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|assertion-error@2.0.1",
       "purl": "pkg:npm/assertion-error@2.0.1",
       "externalReferences": [
         {
@@ -10078,7 +10086,7 @@
       "type": "library",
       "name": "ast-v8-to-istanbul",
       "version": "0.3.5",
-      "bom-ref": "nachet-frontend@0.10.3|ast-v8-to-istanbul@0.3.5",
+      "bom-ref": "nachet-frontend@0.10.4|ast-v8-to-istanbul@0.3.5",
       "purl": "pkg:npm/ast-v8-to-istanbul@0.3.5",
       "externalReferences": [
         {
@@ -10108,7 +10116,7 @@
           "type": "library",
           "name": "js-tokens",
           "version": "9.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|ast-v8-to-istanbul@0.3.5|js-tokens@9.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|ast-v8-to-istanbul@0.3.5|js-tokens@9.0.1",
           "purl": "pkg:npm/js-tokens@9.0.1",
           "externalReferences": [
             {
@@ -10140,7 +10148,7 @@
       "type": "library",
       "name": "async-function",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|async-function@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|async-function@1.0.0",
       "purl": "pkg:npm/async-function@1.0.0",
       "externalReferences": [
         {
@@ -10170,7 +10178,7 @@
       "type": "library",
       "name": "asynckit",
       "version": "0.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|asynckit@0.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|asynckit@0.4.0",
       "purl": "pkg:npm/asynckit@0.4.0",
       "externalReferences": [
         {
@@ -10196,7 +10204,7 @@
       "type": "library",
       "name": "available-typed-arrays",
       "version": "1.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|available-typed-arrays@1.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|available-typed-arrays@1.0.7",
       "purl": "pkg:npm/available-typed-arrays@1.0.7",
       "externalReferences": [
         {
@@ -10226,7 +10234,7 @@
       "type": "library",
       "name": "axios",
       "version": "1.12.2",
-      "bom-ref": "nachet-frontend@0.10.3|axios@1.12.2",
+      "bom-ref": "nachet-frontend@0.10.4|axios@1.12.2",
       "purl": "pkg:npm/axios@1.12.2",
       "externalReferences": [
         {
@@ -10252,7 +10260,7 @@
       "type": "library",
       "name": "babel-plugin-macros",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|babel-plugin-macros@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|babel-plugin-macros@3.1.0",
       "purl": "pkg:npm/babel-plugin-macros@3.1.0",
       "externalReferences": [
         {
@@ -10278,7 +10286,7 @@
       "type": "library",
       "name": "babel-plugin-polyfill-corejs2",
       "version": "0.4.14",
-      "bom-ref": "nachet-frontend@0.10.3|babel-plugin-polyfill-corejs2@0.4.14",
+      "bom-ref": "nachet-frontend@0.10.4|babel-plugin-polyfill-corejs2@0.4.14",
       "purl": "pkg:npm/babel-plugin-polyfill-corejs2@0.4.14",
       "externalReferences": [
         {
@@ -10308,7 +10316,7 @@
       "type": "library",
       "name": "babel-plugin-polyfill-corejs3",
       "version": "0.13.0",
-      "bom-ref": "nachet-frontend@0.10.3|babel-plugin-polyfill-corejs3@0.13.0",
+      "bom-ref": "nachet-frontend@0.10.4|babel-plugin-polyfill-corejs3@0.13.0",
       "purl": "pkg:npm/babel-plugin-polyfill-corejs3@0.13.0",
       "externalReferences": [
         {
@@ -10338,7 +10346,7 @@
       "type": "library",
       "name": "babel-plugin-polyfill-regenerator",
       "version": "0.6.5",
-      "bom-ref": "nachet-frontend@0.10.3|babel-plugin-polyfill-regenerator@0.6.5",
+      "bom-ref": "nachet-frontend@0.10.4|babel-plugin-polyfill-regenerator@0.6.5",
       "purl": "pkg:npm/babel-plugin-polyfill-regenerator@0.6.5",
       "externalReferences": [
         {
@@ -10368,7 +10376,7 @@
       "type": "library",
       "name": "balanced-match",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|balanced-match@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|balanced-match@1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "externalReferences": [
         {
@@ -10394,7 +10402,7 @@
       "type": "library",
       "name": "base64-js",
       "version": "1.5.1",
-      "bom-ref": "nachet-frontend@0.10.3|base64-js@1.5.1",
+      "bom-ref": "nachet-frontend@0.10.4|base64-js@1.5.1",
       "scope": "optional",
       "purl": "pkg:npm/base64-js@1.5.1",
       "externalReferences": [
@@ -10425,7 +10433,7 @@
       "type": "library",
       "name": "baseline-browser-mapping",
       "version": "2.8.4",
-      "bom-ref": "nachet-frontend@0.10.3|baseline-browser-mapping@2.8.4",
+      "bom-ref": "nachet-frontend@0.10.4|baseline-browser-mapping@2.8.4",
       "purl": "pkg:npm/baseline-browser-mapping@2.8.4",
       "externalReferences": [
         {
@@ -10451,7 +10459,7 @@
       "type": "library",
       "name": "bindings",
       "version": "1.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|bindings@1.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|bindings@1.5.0",
       "scope": "optional",
       "purl": "pkg:npm/bindings@1.5.0",
       "externalReferences": [
@@ -10482,7 +10490,7 @@
       "type": "library",
       "name": "bl",
       "version": "4.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|bl@4.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|bl@4.1.0",
       "scope": "optional",
       "purl": "pkg:npm/bl@4.1.0",
       "externalReferences": [
@@ -10513,7 +10521,7 @@
           "type": "library",
           "name": "readable-stream",
           "version": "3.6.2",
-          "bom-ref": "nachet-frontend@0.10.3|bl@4.1.0|readable-stream@3.6.2",
+          "bom-ref": "nachet-frontend@0.10.4|bl@4.1.0|readable-stream@3.6.2",
           "scope": "optional",
           "purl": "pkg:npm/readable-stream@3.6.2",
           "externalReferences": [
@@ -10546,7 +10554,7 @@
       "type": "library",
       "name": "body-parser",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|body-parser@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|body-parser@2.2.0",
       "purl": "pkg:npm/body-parser@2.2.0",
       "externalReferences": [
         {
@@ -10572,7 +10580,7 @@
       "type": "library",
       "name": "boxen",
       "version": "7.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|boxen@7.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|boxen@7.0.0",
       "purl": "pkg:npm/boxen@7.0.0",
       "externalReferences": [
         {
@@ -10598,7 +10606,7 @@
           "type": "library",
           "name": "chalk",
           "version": "5.6.2",
-          "bom-ref": "nachet-frontend@0.10.3|boxen@7.0.0|chalk@5.6.2",
+          "bom-ref": "nachet-frontend@0.10.4|boxen@7.0.0|chalk@5.6.2",
           "purl": "pkg:npm/chalk@5.6.2",
           "externalReferences": [
             {
@@ -10626,7 +10634,7 @@
       "type": "library",
       "name": "brace-expansion",
       "version": "1.1.12",
-      "bom-ref": "nachet-frontend@0.10.3|brace-expansion@1.1.12",
+      "bom-ref": "nachet-frontend@0.10.4|brace-expansion@1.1.12",
       "purl": "pkg:npm/brace-expansion@1.1.12",
       "externalReferences": [
         {
@@ -10652,7 +10660,7 @@
       "type": "library",
       "name": "braces",
       "version": "3.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|braces@3.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|braces@3.0.3",
       "purl": "pkg:npm/braces@3.0.3",
       "externalReferences": [
         {
@@ -10682,7 +10690,7 @@
       "type": "library",
       "name": "browser-image-compression",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|browser-image-compression@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|browser-image-compression@2.0.2",
       "purl": "pkg:npm/browser-image-compression@2.0.2",
       "externalReferences": [
         {
@@ -10708,7 +10716,7 @@
       "type": "library",
       "name": "browserslist",
       "version": "4.26.2",
-      "bom-ref": "nachet-frontend@0.10.3|browserslist@4.26.2",
+      "bom-ref": "nachet-frontend@0.10.4|browserslist@4.26.2",
       "purl": "pkg:npm/browserslist@4.26.2",
       "externalReferences": [
         {
@@ -10734,7 +10742,7 @@
       "type": "library",
       "name": "buffer",
       "version": "5.7.1",
-      "bom-ref": "nachet-frontend@0.10.3|buffer@5.7.1",
+      "bom-ref": "nachet-frontend@0.10.4|buffer@5.7.1",
       "scope": "optional",
       "purl": "pkg:npm/buffer@5.7.1",
       "externalReferences": [
@@ -10765,7 +10773,7 @@
       "type": "library",
       "name": "bytes",
       "version": "3.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|bytes@3.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|bytes@3.1.2",
       "purl": "pkg:npm/bytes@3.1.2",
       "externalReferences": [
         {
@@ -10791,7 +10799,7 @@
       "type": "library",
       "name": "cac",
       "version": "6.7.14",
-      "bom-ref": "nachet-frontend@0.10.3|cac@6.7.14",
+      "bom-ref": "nachet-frontend@0.10.4|cac@6.7.14",
       "purl": "pkg:npm/cac@6.7.14",
       "externalReferences": [
         {
@@ -10821,7 +10829,7 @@
       "type": "library",
       "name": "cacache",
       "version": "19.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|cacache@19.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|cacache@19.0.1",
       "scope": "optional",
       "purl": "pkg:npm/cacache@19.0.1",
       "externalReferences": [
@@ -10852,7 +10860,7 @@
           "type": "library",
           "name": "lru-cache",
           "version": "10.4.3",
-          "bom-ref": "nachet-frontend@0.10.3|cacache@19.0.1|lru-cache@10.4.3",
+          "bom-ref": "nachet-frontend@0.10.4|cacache@19.0.1|lru-cache@10.4.3",
           "scope": "optional",
           "purl": "pkg:npm/lru-cache@10.4.3",
           "externalReferences": [
@@ -10885,7 +10893,7 @@
       "type": "library",
       "name": "call-bind-apply-helpers",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|call-bind-apply-helpers@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|call-bind-apply-helpers@1.0.2",
       "purl": "pkg:npm/call-bind-apply-helpers@1.0.2",
       "externalReferences": [
         {
@@ -10911,7 +10919,7 @@
       "type": "library",
       "name": "call-bind",
       "version": "1.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|call-bind@1.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|call-bind@1.0.8",
       "purl": "pkg:npm/call-bind@1.0.8",
       "externalReferences": [
         {
@@ -10941,7 +10949,7 @@
       "type": "library",
       "name": "call-bound",
       "version": "1.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|call-bound@1.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|call-bound@1.0.4",
       "purl": "pkg:npm/call-bound@1.0.4",
       "externalReferences": [
         {
@@ -10967,7 +10975,7 @@
       "type": "library",
       "name": "callsites",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|callsites@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|callsites@3.1.0",
       "purl": "pkg:npm/callsites@3.1.0",
       "externalReferences": [
         {
@@ -10993,7 +11001,7 @@
       "type": "library",
       "name": "camelcase",
       "version": "7.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|camelcase@7.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|camelcase@7.0.1",
       "purl": "pkg:npm/camelcase@7.0.1",
       "externalReferences": [
         {
@@ -11019,7 +11027,7 @@
       "type": "library",
       "name": "camelize",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|camelize@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|camelize@1.0.1",
       "purl": "pkg:npm/camelize@1.0.1",
       "externalReferences": [
         {
@@ -11045,7 +11053,7 @@
       "type": "library",
       "name": "caniuse-lite",
       "version": "1.0.30001743",
-      "bom-ref": "nachet-frontend@0.10.3|caniuse-lite@1.0.30001743",
+      "bom-ref": "nachet-frontend@0.10.4|caniuse-lite@1.0.30001743",
       "purl": "pkg:npm/caniuse-lite@1.0.30001743",
       "externalReferences": [
         {
@@ -11071,7 +11079,7 @@
       "type": "library",
       "name": "chai",
       "version": "5.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|chai@5.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|chai@5.3.3",
       "purl": "pkg:npm/chai@5.3.3",
       "externalReferences": [
         {
@@ -11101,7 +11109,7 @@
       "type": "library",
       "name": "chalk-template",
       "version": "0.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|chalk-template@0.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|chalk-template@0.4.0",
       "purl": "pkg:npm/chalk-template@0.4.0",
       "externalReferences": [
         {
@@ -11127,7 +11135,7 @@
       "type": "library",
       "name": "chalk",
       "version": "4.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|chalk@4.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|chalk@4.1.2",
       "purl": "pkg:npm/chalk@4.1.2",
       "externalReferences": [
         {
@@ -11153,7 +11161,7 @@
       "type": "library",
       "name": "check-error",
       "version": "2.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|check-error@2.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|check-error@2.1.1",
       "purl": "pkg:npm/check-error@2.1.1",
       "externalReferences": [
         {
@@ -11183,7 +11191,7 @@
       "type": "library",
       "name": "chownr",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|chownr@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|chownr@3.0.0",
       "scope": "optional",
       "purl": "pkg:npm/chownr@3.0.0",
       "externalReferences": [
@@ -11214,7 +11222,7 @@
       "type": "library",
       "name": "ci-info",
       "version": "4.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|ci-info@4.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|ci-info@4.3.0",
       "purl": "pkg:npm/ci-info@4.3.0",
       "externalReferences": [
         {
@@ -11244,7 +11252,7 @@
       "type": "library",
       "name": "cli-boxes",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|cli-boxes@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|cli-boxes@3.0.0",
       "purl": "pkg:npm/cli-boxes@3.0.0",
       "externalReferences": [
         {
@@ -11270,7 +11278,7 @@
       "type": "library",
       "name": "clipboardy",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|clipboardy@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|clipboardy@3.0.0",
       "purl": "pkg:npm/clipboardy@3.0.0",
       "externalReferences": [
         {
@@ -11296,7 +11304,7 @@
           "type": "library",
           "name": "execa",
           "version": "5.1.1",
-          "bom-ref": "nachet-frontend@0.10.3|clipboardy@3.0.0|execa@5.1.1",
+          "bom-ref": "nachet-frontend@0.10.4|clipboardy@3.0.0|execa@5.1.1",
           "purl": "pkg:npm/execa@5.1.1",
           "externalReferences": [
             {
@@ -11322,7 +11330,7 @@
           "type": "library",
           "name": "get-stream",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|clipboardy@3.0.0|get-stream@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|clipboardy@3.0.0|get-stream@6.0.1",
           "purl": "pkg:npm/get-stream@6.0.1",
           "externalReferences": [
             {
@@ -11348,7 +11356,7 @@
           "type": "library",
           "name": "human-signals",
           "version": "2.1.0",
-          "bom-ref": "nachet-frontend@0.10.3|clipboardy@3.0.0|human-signals@2.1.0",
+          "bom-ref": "nachet-frontend@0.10.4|clipboardy@3.0.0|human-signals@2.1.0",
           "purl": "pkg:npm/human-signals@2.1.0",
           "externalReferences": [
             {
@@ -11376,7 +11384,7 @@
       "type": "library",
       "name": "cliui",
       "version": "7.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|cliui@7.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|cliui@7.0.4",
       "purl": "pkg:npm/cliui@7.0.4",
       "externalReferences": [
         {
@@ -11402,7 +11410,7 @@
           "type": "library",
           "name": "emoji-regex",
           "version": "8.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|cliui@7.0.4|emoji-regex@8.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|cliui@7.0.4|emoji-regex@8.0.0",
           "purl": "pkg:npm/emoji-regex@8.0.0",
           "externalReferences": [
             {
@@ -11428,7 +11436,7 @@
           "type": "library",
           "name": "string-width",
           "version": "4.2.3",
-          "bom-ref": "nachet-frontend@0.10.3|cliui@7.0.4|string-width@4.2.3",
+          "bom-ref": "nachet-frontend@0.10.4|cliui@7.0.4|string-width@4.2.3",
           "purl": "pkg:npm/string-width@4.2.3",
           "externalReferences": [
             {
@@ -11454,7 +11462,7 @@
           "type": "library",
           "name": "strip-ansi",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|cliui@7.0.4|strip-ansi@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|cliui@7.0.4|strip-ansi@6.0.1",
           "purl": "pkg:npm/strip-ansi@6.0.1",
           "externalReferences": [
             {
@@ -11480,7 +11488,7 @@
           "type": "library",
           "name": "wrap-ansi",
           "version": "7.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|cliui@7.0.4|wrap-ansi@7.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|cliui@7.0.4|wrap-ansi@7.0.0",
           "purl": "pkg:npm/wrap-ansi@7.0.0",
           "externalReferences": [
             {
@@ -11508,7 +11516,7 @@
       "type": "library",
       "name": "clsx",
       "version": "2.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|clsx@2.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|clsx@2.1.1",
       "purl": "pkg:npm/clsx@2.1.1",
       "externalReferences": [
         {
@@ -11534,7 +11542,7 @@
       "type": "library",
       "name": "color-convert",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|color-convert@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|color-convert@2.0.1",
       "purl": "pkg:npm/color-convert@2.0.1",
       "externalReferences": [
         {
@@ -11560,7 +11568,7 @@
       "type": "library",
       "name": "color-name",
       "version": "1.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|color-name@1.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|color-name@1.1.4",
       "purl": "pkg:npm/color-name@1.1.4",
       "externalReferences": [
         {
@@ -11586,7 +11594,7 @@
       "type": "library",
       "name": "colors",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|colors@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|colors@1.4.0",
       "purl": "pkg:npm/colors@1.4.0",
       "externalReferences": [
         {
@@ -11612,7 +11620,7 @@
       "type": "library",
       "name": "combined-stream",
       "version": "1.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|combined-stream@1.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|combined-stream@1.0.8",
       "purl": "pkg:npm/combined-stream@1.0.8",
       "externalReferences": [
         {
@@ -11638,7 +11646,7 @@
       "type": "library",
       "name": "commander",
       "version": "14.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|commander@14.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|commander@14.0.1",
       "purl": "pkg:npm/commander@14.0.1",
       "externalReferences": [
         {
@@ -11668,7 +11676,7 @@
       "type": "library",
       "name": "compressible",
       "version": "2.0.18",
-      "bom-ref": "nachet-frontend@0.10.3|compressible@2.0.18",
+      "bom-ref": "nachet-frontend@0.10.4|compressible@2.0.18",
       "purl": "pkg:npm/compressible@2.0.18",
       "externalReferences": [
         {
@@ -11694,7 +11702,7 @@
       "type": "library",
       "name": "compression",
       "version": "1.8.1",
-      "bom-ref": "nachet-frontend@0.10.3|compression@1.8.1",
+      "bom-ref": "nachet-frontend@0.10.4|compression@1.8.1",
       "purl": "pkg:npm/compression@1.8.1",
       "externalReferences": [
         {
@@ -11720,7 +11728,7 @@
           "type": "library",
           "name": "debug",
           "version": "2.6.9",
-          "bom-ref": "nachet-frontend@0.10.3|compression@1.8.1|debug@2.6.9",
+          "bom-ref": "nachet-frontend@0.10.4|compression@1.8.1|debug@2.6.9",
           "purl": "pkg:npm/debug@2.6.9",
           "externalReferences": [
             {
@@ -11746,7 +11754,7 @@
           "type": "library",
           "name": "ms",
           "version": "2.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|compression@1.8.1|ms@2.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|compression@1.8.1|ms@2.0.0",
           "purl": "pkg:npm/ms@2.0.0",
           "externalReferences": [
             {
@@ -11772,7 +11780,7 @@
           "type": "library",
           "name": "negotiator",
           "version": "0.6.4",
-          "bom-ref": "nachet-frontend@0.10.3|compression@1.8.1|negotiator@0.6.4",
+          "bom-ref": "nachet-frontend@0.10.4|compression@1.8.1|negotiator@0.6.4",
           "purl": "pkg:npm/negotiator@0.6.4",
           "externalReferences": [
             {
@@ -11800,7 +11808,7 @@
       "type": "library",
       "name": "concat-map",
       "version": "0.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|concat-map@0.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|concat-map@0.0.1",
       "purl": "pkg:npm/concat-map@0.0.1",
       "externalReferences": [
         {
@@ -11826,7 +11834,7 @@
       "type": "library",
       "name": "content-disposition",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|content-disposition@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|content-disposition@1.0.0",
       "purl": "pkg:npm/content-disposition@1.0.0",
       "externalReferences": [
         {
@@ -11852,7 +11860,7 @@
       "type": "library",
       "name": "content-type",
       "version": "1.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|content-type@1.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|content-type@1.0.5",
       "purl": "pkg:npm/content-type@1.0.5",
       "externalReferences": [
         {
@@ -11878,7 +11886,7 @@
       "type": "library",
       "name": "convert-source-map",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|convert-source-map@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|convert-source-map@2.0.0",
       "purl": "pkg:npm/convert-source-map@2.0.0",
       "externalReferences": [
         {
@@ -11904,7 +11912,7 @@
       "type": "library",
       "name": "cookie-signature",
       "version": "1.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|cookie-signature@1.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|cookie-signature@1.2.2",
       "purl": "pkg:npm/cookie-signature@1.2.2",
       "externalReferences": [
         {
@@ -11930,7 +11938,7 @@
       "type": "library",
       "name": "cookie",
       "version": "0.7.2",
-      "bom-ref": "nachet-frontend@0.10.3|cookie@0.7.2",
+      "bom-ref": "nachet-frontend@0.10.4|cookie@0.7.2",
       "purl": "pkg:npm/cookie@0.7.2",
       "externalReferences": [
         {
@@ -11956,7 +11964,7 @@
       "type": "library",
       "name": "core-js-compat",
       "version": "3.45.1",
-      "bom-ref": "nachet-frontend@0.10.3|core-js-compat@3.45.1",
+      "bom-ref": "nachet-frontend@0.10.4|core-js-compat@3.45.1",
       "purl": "pkg:npm/core-js-compat@3.45.1",
       "externalReferences": [
         {
@@ -11986,7 +11994,7 @@
       "type": "library",
       "name": "core-util-is",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|core-util-is@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|core-util-is@1.0.3",
       "purl": "pkg:npm/core-util-is@1.0.3",
       "externalReferences": [
         {
@@ -12012,7 +12020,7 @@
       "type": "library",
       "name": "cosmiconfig",
       "version": "7.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|cosmiconfig@7.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|cosmiconfig@7.1.0",
       "purl": "pkg:npm/cosmiconfig@7.1.0",
       "externalReferences": [
         {
@@ -12038,7 +12046,7 @@
           "type": "library",
           "name": "yaml",
           "version": "1.10.2",
-          "bom-ref": "nachet-frontend@0.10.3|cosmiconfig@7.1.0|yaml@1.10.2",
+          "bom-ref": "nachet-frontend@0.10.4|cosmiconfig@7.1.0|yaml@1.10.2",
           "purl": "pkg:npm/yaml@1.10.2",
           "externalReferences": [
             {
@@ -12066,7 +12074,7 @@
       "type": "library",
       "name": "cross-spawn",
       "version": "7.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|cross-spawn@7.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|cross-spawn@7.0.6",
       "purl": "pkg:npm/cross-spawn@7.0.6",
       "externalReferences": [
         {
@@ -12092,7 +12100,7 @@
       "type": "library",
       "name": "css-color-keywords",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|css-color-keywords@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|css-color-keywords@1.0.0",
       "purl": "pkg:npm/css-color-keywords@1.0.0",
       "externalReferences": [
         {
@@ -12118,7 +12126,7 @@
       "type": "library",
       "name": "css-to-react-native",
       "version": "3.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|css-to-react-native@3.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|css-to-react-native@3.2.0",
       "purl": "pkg:npm/css-to-react-native@3.2.0",
       "externalReferences": [
         {
@@ -12144,7 +12152,7 @@
       "type": "library",
       "name": "css.escape",
       "version": "1.5.1",
-      "bom-ref": "nachet-frontend@0.10.3|css.escape@1.5.1",
+      "bom-ref": "nachet-frontend@0.10.4|css.escape@1.5.1",
       "purl": "pkg:npm/css.escape@1.5.1",
       "externalReferences": [
         {
@@ -12170,7 +12178,7 @@
       "type": "library",
       "name": "cssstyle",
       "version": "4.6.0",
-      "bom-ref": "nachet-frontend@0.10.3|cssstyle@4.6.0",
+      "bom-ref": "nachet-frontend@0.10.4|cssstyle@4.6.0",
       "purl": "pkg:npm/cssstyle@4.6.0",
       "externalReferences": [
         {
@@ -12200,7 +12208,7 @@
       "type": "library",
       "name": "csstype",
       "version": "3.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|csstype@3.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|csstype@3.1.3",
       "purl": "pkg:npm/csstype@3.1.3",
       "externalReferences": [
         {
@@ -12226,7 +12234,7 @@
       "type": "library",
       "name": "data-uri-to-buffer",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|data-uri-to-buffer@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|data-uri-to-buffer@4.0.1",
       "purl": "pkg:npm/data-uri-to-buffer@4.0.1",
       "externalReferences": [
         {
@@ -12256,7 +12264,7 @@
       "type": "library",
       "name": "data-urls",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|data-urls@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|data-urls@5.0.0",
       "purl": "pkg:npm/data-urls@5.0.0",
       "externalReferences": [
         {
@@ -12286,7 +12294,7 @@
       "type": "library",
       "name": "data-view-buffer",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|data-view-buffer@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|data-view-buffer@1.0.2",
       "purl": "pkg:npm/data-view-buffer@1.0.2",
       "externalReferences": [
         {
@@ -12316,7 +12324,7 @@
       "type": "library",
       "name": "data-view-byte-length",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|data-view-byte-length@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|data-view-byte-length@1.0.2",
       "purl": "pkg:npm/data-view-byte-length@1.0.2",
       "externalReferences": [
         {
@@ -12346,7 +12354,7 @@
       "type": "library",
       "name": "data-view-byte-offset",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|data-view-byte-offset@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|data-view-byte-offset@1.0.1",
       "purl": "pkg:npm/data-view-byte-offset@1.0.1",
       "externalReferences": [
         {
@@ -12376,7 +12384,7 @@
       "type": "library",
       "name": "debug",
       "version": "4.4.3",
-      "bom-ref": "nachet-frontend@0.10.3|debug@4.4.3",
+      "bom-ref": "nachet-frontend@0.10.4|debug@4.4.3",
       "purl": "pkg:npm/debug@4.4.3",
       "externalReferences": [
         {
@@ -12402,7 +12410,7 @@
       "type": "library",
       "name": "decimal.js",
       "version": "10.6.0",
-      "bom-ref": "nachet-frontend@0.10.3|decimal.js@10.6.0",
+      "bom-ref": "nachet-frontend@0.10.4|decimal.js@10.6.0",
       "purl": "pkg:npm/decimal.js@10.6.0",
       "externalReferences": [
         {
@@ -12432,7 +12440,7 @@
       "type": "library",
       "name": "decompress-response",
       "version": "6.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|decompress-response@6.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|decompress-response@6.0.0",
       "scope": "optional",
       "purl": "pkg:npm/decompress-response@6.0.0",
       "externalReferences": [
@@ -12463,7 +12471,7 @@
       "type": "library",
       "name": "deep-eql",
       "version": "5.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|deep-eql@5.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|deep-eql@5.0.2",
       "purl": "pkg:npm/deep-eql@5.0.2",
       "externalReferences": [
         {
@@ -12493,7 +12501,7 @@
       "type": "library",
       "name": "deep-extend",
       "version": "0.6.0",
-      "bom-ref": "nachet-frontend@0.10.3|deep-extend@0.6.0",
+      "bom-ref": "nachet-frontend@0.10.4|deep-extend@0.6.0",
       "purl": "pkg:npm/deep-extend@0.6.0",
       "externalReferences": [
         {
@@ -12519,7 +12527,7 @@
       "type": "library",
       "name": "deep-is",
       "version": "0.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|deep-is@0.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|deep-is@0.1.4",
       "purl": "pkg:npm/deep-is@0.1.4",
       "externalReferences": [
         {
@@ -12549,7 +12557,7 @@
       "type": "library",
       "name": "deepmerge",
       "version": "4.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|deepmerge@4.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|deepmerge@4.3.1",
       "purl": "pkg:npm/deepmerge@4.3.1",
       "externalReferences": [
         {
@@ -12575,7 +12583,7 @@
       "type": "library",
       "name": "define-data-property",
       "version": "1.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|define-data-property@1.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|define-data-property@1.1.4",
       "purl": "pkg:npm/define-data-property@1.1.4",
       "externalReferences": [
         {
@@ -12605,7 +12613,7 @@
       "type": "library",
       "name": "define-properties",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|define-properties@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|define-properties@1.2.1",
       "purl": "pkg:npm/define-properties@1.2.1",
       "externalReferences": [
         {
@@ -12635,7 +12643,7 @@
       "type": "library",
       "name": "delayed-stream",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|delayed-stream@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|delayed-stream@1.0.0",
       "purl": "pkg:npm/delayed-stream@1.0.0",
       "externalReferences": [
         {
@@ -12661,7 +12669,7 @@
       "type": "library",
       "name": "depd",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|depd@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|depd@2.0.0",
       "purl": "pkg:npm/depd@2.0.0",
       "externalReferences": [
         {
@@ -12687,7 +12695,7 @@
       "type": "library",
       "name": "dequal",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|dequal@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|dequal@2.0.3",
       "purl": "pkg:npm/dequal@2.0.3",
       "externalReferences": [
         {
@@ -12713,7 +12721,7 @@
       "type": "library",
       "name": "detect-libc",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|detect-libc@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|detect-libc@2.1.0",
       "scope": "optional",
       "purl": "pkg:npm/detect-libc@2.1.0",
       "externalReferences": [
@@ -12744,7 +12752,7 @@
       "type": "library",
       "name": "discontinuous-range",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|discontinuous-range@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|discontinuous-range@1.0.0",
       "scope": "optional",
       "purl": "pkg:npm/discontinuous-range@1.0.0",
       "externalReferences": [
@@ -12775,7 +12783,7 @@
       "type": "library",
       "name": "doctrine",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|doctrine@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|doctrine@2.1.0",
       "purl": "pkg:npm/doctrine@2.1.0",
       "externalReferences": [
         {
@@ -12805,7 +12813,7 @@
       "type": "library",
       "name": "dom-accessibility-api",
       "version": "0.5.16",
-      "bom-ref": "nachet-frontend@0.10.3|dom-accessibility-api@0.5.16",
+      "bom-ref": "nachet-frontend@0.10.4|dom-accessibility-api@0.5.16",
       "purl": "pkg:npm/dom-accessibility-api@0.5.16",
       "externalReferences": [
         {
@@ -12835,7 +12843,7 @@
       "type": "library",
       "name": "dom-helpers",
       "version": "5.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|dom-helpers@5.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|dom-helpers@5.2.1",
       "purl": "pkg:npm/dom-helpers@5.2.1",
       "externalReferences": [
         {
@@ -12861,7 +12869,7 @@
       "type": "library",
       "name": "dom-serializer",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|dom-serializer@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|dom-serializer@2.0.0",
       "purl": "pkg:npm/dom-serializer@2.0.0",
       "externalReferences": [
         {
@@ -12887,7 +12895,7 @@
       "type": "library",
       "name": "domelementtype",
       "version": "2.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|domelementtype@2.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|domelementtype@2.3.0",
       "purl": "pkg:npm/domelementtype@2.3.0",
       "externalReferences": [
         {
@@ -12913,7 +12921,7 @@
       "type": "library",
       "name": "domhandler",
       "version": "5.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|domhandler@5.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|domhandler@5.0.3",
       "purl": "pkg:npm/domhandler@5.0.3",
       "externalReferences": [
         {
@@ -12939,7 +12947,7 @@
       "type": "library",
       "name": "dompurify",
       "version": "3.2.6",
-      "bom-ref": "nachet-frontend@0.10.3|dompurify@3.2.6",
+      "bom-ref": "nachet-frontend@0.10.4|dompurify@3.2.6",
       "purl": "pkg:npm/dompurify@3.2.6",
       "externalReferences": [
         {
@@ -12965,7 +12973,7 @@
       "type": "library",
       "name": "domutils",
       "version": "3.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|domutils@3.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|domutils@3.2.2",
       "purl": "pkg:npm/domutils@3.2.2",
       "externalReferences": [
         {
@@ -12991,7 +12999,7 @@
       "type": "library",
       "name": "dunder-proto",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|dunder-proto@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|dunder-proto@1.0.1",
       "purl": "pkg:npm/dunder-proto@1.0.1",
       "externalReferences": [
         {
@@ -13017,7 +13025,7 @@
       "type": "library",
       "name": "eastasianwidth",
       "version": "0.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|eastasianwidth@0.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|eastasianwidth@0.2.0",
       "purl": "pkg:npm/eastasianwidth@0.2.0",
       "externalReferences": [
         {
@@ -13043,7 +13051,7 @@
       "type": "library",
       "name": "ee-first",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|ee-first@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|ee-first@1.1.1",
       "purl": "pkg:npm/ee-first@1.1.1",
       "externalReferences": [
         {
@@ -13069,7 +13077,7 @@
       "type": "library",
       "name": "electron-to-chromium",
       "version": "1.5.218",
-      "bom-ref": "nachet-frontend@0.10.3|electron-to-chromium@1.5.218",
+      "bom-ref": "nachet-frontend@0.10.4|electron-to-chromium@1.5.218",
       "purl": "pkg:npm/electron-to-chromium@1.5.218",
       "externalReferences": [
         {
@@ -13095,7 +13103,7 @@
       "type": "library",
       "name": "emoji-regex",
       "version": "9.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|emoji-regex@9.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|emoji-regex@9.2.2",
       "purl": "pkg:npm/emoji-regex@9.2.2",
       "externalReferences": [
         {
@@ -13121,7 +13129,7 @@
       "type": "library",
       "name": "encodeurl",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|encodeurl@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|encodeurl@2.0.0",
       "purl": "pkg:npm/encodeurl@2.0.0",
       "externalReferences": [
         {
@@ -13147,7 +13155,7 @@
       "type": "library",
       "name": "encoding",
       "version": "0.1.13",
-      "bom-ref": "nachet-frontend@0.10.3|encoding@0.1.13",
+      "bom-ref": "nachet-frontend@0.10.4|encoding@0.1.13",
       "scope": "optional",
       "purl": "pkg:npm/encoding@0.1.13",
       "externalReferences": [
@@ -13178,7 +13186,7 @@
       "type": "library",
       "name": "end-of-stream",
       "version": "1.4.5",
-      "bom-ref": "nachet-frontend@0.10.3|end-of-stream@1.4.5",
+      "bom-ref": "nachet-frontend@0.10.4|end-of-stream@1.4.5",
       "purl": "pkg:npm/end-of-stream@1.4.5",
       "externalReferences": [
         {
@@ -13204,7 +13212,7 @@
       "type": "library",
       "name": "entities",
       "version": "4.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|entities@4.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|entities@4.5.0",
       "purl": "pkg:npm/entities@4.5.0",
       "externalReferences": [
         {
@@ -13230,7 +13238,7 @@
       "type": "library",
       "name": "env-paths",
       "version": "2.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|env-paths@2.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|env-paths@2.2.1",
       "scope": "optional",
       "purl": "pkg:npm/env-paths@2.2.1",
       "externalReferences": [
@@ -13261,7 +13269,7 @@
       "type": "library",
       "name": "err-code",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|err-code@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|err-code@2.0.3",
       "scope": "optional",
       "purl": "pkg:npm/err-code@2.0.3",
       "externalReferences": [
@@ -13292,7 +13300,7 @@
       "type": "library",
       "name": "error-ex",
       "version": "1.3.4",
-      "bom-ref": "nachet-frontend@0.10.3|error-ex@1.3.4",
+      "bom-ref": "nachet-frontend@0.10.4|error-ex@1.3.4",
       "purl": "pkg:npm/error-ex@1.3.4",
       "externalReferences": [
         {
@@ -13318,7 +13326,7 @@
       "type": "library",
       "name": "es-abstract",
       "version": "1.24.0",
-      "bom-ref": "nachet-frontend@0.10.3|es-abstract@1.24.0",
+      "bom-ref": "nachet-frontend@0.10.4|es-abstract@1.24.0",
       "purl": "pkg:npm/es-abstract@1.24.0",
       "externalReferences": [
         {
@@ -13348,7 +13356,7 @@
       "type": "library",
       "name": "es-define-property",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|es-define-property@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|es-define-property@1.0.1",
       "purl": "pkg:npm/es-define-property@1.0.1",
       "externalReferences": [
         {
@@ -13374,7 +13382,7 @@
       "type": "library",
       "name": "es-errors",
       "version": "1.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|es-errors@1.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|es-errors@1.3.0",
       "purl": "pkg:npm/es-errors@1.3.0",
       "externalReferences": [
         {
@@ -13400,7 +13408,7 @@
       "type": "library",
       "name": "es-iterator-helpers",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|es-iterator-helpers@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|es-iterator-helpers@1.2.1",
       "purl": "pkg:npm/es-iterator-helpers@1.2.1",
       "externalReferences": [
         {
@@ -13430,7 +13438,7 @@
       "type": "library",
       "name": "es-module-lexer",
       "version": "1.7.0",
-      "bom-ref": "nachet-frontend@0.10.3|es-module-lexer@1.7.0",
+      "bom-ref": "nachet-frontend@0.10.4|es-module-lexer@1.7.0",
       "purl": "pkg:npm/es-module-lexer@1.7.0",
       "externalReferences": [
         {
@@ -13460,7 +13468,7 @@
       "type": "library",
       "name": "es-object-atoms",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
       "purl": "pkg:npm/es-object-atoms@1.1.1",
       "externalReferences": [
         {
@@ -13486,7 +13494,7 @@
       "type": "library",
       "name": "es-set-tostringtag",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|es-set-tostringtag@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|es-set-tostringtag@2.1.0",
       "purl": "pkg:npm/es-set-tostringtag@2.1.0",
       "externalReferences": [
         {
@@ -13512,7 +13520,7 @@
       "type": "library",
       "name": "es-shim-unscopables",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0",
       "purl": "pkg:npm/es-shim-unscopables@1.1.0",
       "externalReferences": [
         {
@@ -13542,7 +13550,7 @@
       "type": "library",
       "name": "es-to-primitive",
       "version": "1.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|es-to-primitive@1.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|es-to-primitive@1.3.0",
       "purl": "pkg:npm/es-to-primitive@1.3.0",
       "externalReferences": [
         {
@@ -13572,7 +13580,7 @@
       "type": "library",
       "name": "esbuild",
       "version": "0.25.9",
-      "bom-ref": "nachet-frontend@0.10.3|esbuild@0.25.9",
+      "bom-ref": "nachet-frontend@0.10.4|esbuild@0.25.9",
       "purl": "pkg:npm/esbuild@0.25.9",
       "externalReferences": [
         {
@@ -13602,7 +13610,7 @@
       "type": "library",
       "name": "escalade",
       "version": "3.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|escalade@3.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|escalade@3.2.0",
       "purl": "pkg:npm/escalade@3.2.0",
       "externalReferences": [
         {
@@ -13628,7 +13636,7 @@
       "type": "library",
       "name": "escape-html",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|escape-html@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|escape-html@1.0.3",
       "purl": "pkg:npm/escape-html@1.0.3",
       "externalReferences": [
         {
@@ -13654,7 +13662,7 @@
       "type": "library",
       "name": "escape-string-regexp",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|escape-string-regexp@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|escape-string-regexp@4.0.0",
       "purl": "pkg:npm/escape-string-regexp@4.0.0",
       "externalReferences": [
         {
@@ -13680,7 +13688,7 @@
       "type": "library",
       "name": "eslint-config-prettier",
       "version": "10.1.8",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-config-prettier@10.1.8",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-config-prettier@10.1.8",
       "purl": "pkg:npm/eslint-config-prettier@10.1.8",
       "externalReferences": [
         {
@@ -13710,7 +13718,7 @@
       "type": "library",
       "name": "eslint-import-resolver-node",
       "version": "0.3.9",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-import-resolver-node@0.3.9",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-import-resolver-node@0.3.9",
       "purl": "pkg:npm/eslint-import-resolver-node@0.3.9",
       "externalReferences": [
         {
@@ -13740,7 +13748,7 @@
           "type": "library",
           "name": "debug",
           "version": "3.2.7",
-          "bom-ref": "nachet-frontend@0.10.3|eslint-import-resolver-node@0.3.9|debug@3.2.7",
+          "bom-ref": "nachet-frontend@0.10.4|eslint-import-resolver-node@0.3.9|debug@3.2.7",
           "purl": "pkg:npm/debug@3.2.7",
           "externalReferences": [
             {
@@ -13772,7 +13780,7 @@
       "type": "library",
       "name": "eslint-module-utils",
       "version": "2.12.1",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-module-utils@2.12.1",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-module-utils@2.12.1",
       "purl": "pkg:npm/eslint-module-utils@2.12.1",
       "externalReferences": [
         {
@@ -13802,7 +13810,7 @@
           "type": "library",
           "name": "debug",
           "version": "3.2.7",
-          "bom-ref": "nachet-frontend@0.10.3|eslint-module-utils@2.12.1|debug@3.2.7",
+          "bom-ref": "nachet-frontend@0.10.4|eslint-module-utils@2.12.1|debug@3.2.7",
           "purl": "pkg:npm/debug@3.2.7",
           "externalReferences": [
             {
@@ -13834,7 +13842,7 @@
       "type": "library",
       "name": "eslint-plugin-import",
       "version": "2.32.0",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-import@2.32.0",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-import@2.32.0",
       "purl": "pkg:npm/eslint-plugin-import@2.32.0",
       "externalReferences": [
         {
@@ -13864,7 +13872,7 @@
           "type": "library",
           "name": "debug",
           "version": "3.2.7",
-          "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-import@2.32.0|debug@3.2.7",
+          "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-import@2.32.0|debug@3.2.7",
           "purl": "pkg:npm/debug@3.2.7",
           "externalReferences": [
             {
@@ -13896,7 +13904,7 @@
       "type": "library",
       "name": "eslint-plugin-prettier",
       "version": "5.5.4",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-prettier@5.5.4",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-prettier@5.5.4",
       "purl": "pkg:npm/eslint-plugin-prettier@5.5.4",
       "externalReferences": [
         {
@@ -13926,7 +13934,7 @@
       "type": "library",
       "name": "eslint-plugin-react-hooks",
       "version": "5.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-react-hooks@5.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-react-hooks@5.2.0",
       "purl": "pkg:npm/eslint-plugin-react-hooks@5.2.0",
       "externalReferences": [
         {
@@ -13956,7 +13964,7 @@
       "type": "library",
       "name": "eslint-plugin-react-refresh",
       "version": "0.4.20",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-react-refresh@0.4.20",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-react-refresh@0.4.20",
       "purl": "pkg:npm/eslint-plugin-react-refresh@0.4.20",
       "externalReferences": [
         {
@@ -13986,7 +13994,7 @@
       "type": "library",
       "name": "eslint-plugin-react",
       "version": "7.37.5",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-react@7.37.5",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-react@7.37.5",
       "purl": "pkg:npm/eslint-plugin-react@7.37.5",
       "externalReferences": [
         {
@@ -14016,7 +14024,7 @@
           "type": "library",
           "name": "resolve",
           "version": "2.0.0-next.5",
-          "bom-ref": "nachet-frontend@0.10.3|eslint-plugin-react@7.37.5|resolve@2.0.0-next.5",
+          "bom-ref": "nachet-frontend@0.10.4|eslint-plugin-react@7.37.5|resolve@2.0.0-next.5",
           "purl": "pkg:npm/resolve@2.0.0-next.5",
           "externalReferences": [
             {
@@ -14048,7 +14056,7 @@
       "type": "library",
       "name": "eslint-scope",
       "version": "8.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-scope@8.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-scope@8.4.0",
       "purl": "pkg:npm/eslint-scope@8.4.0",
       "externalReferences": [
         {
@@ -14078,7 +14086,7 @@
       "type": "library",
       "name": "eslint-visitor-keys",
       "version": "3.4.3",
-      "bom-ref": "nachet-frontend@0.10.3|eslint-visitor-keys@3.4.3",
+      "bom-ref": "nachet-frontend@0.10.4|eslint-visitor-keys@3.4.3",
       "purl": "pkg:npm/eslint-visitor-keys@3.4.3",
       "externalReferences": [
         {
@@ -14108,7 +14116,7 @@
       "type": "library",
       "name": "eslint",
       "version": "9.35.0",
-      "bom-ref": "nachet-frontend@0.10.3|eslint@9.35.0",
+      "bom-ref": "nachet-frontend@0.10.4|eslint@9.35.0",
       "purl": "pkg:npm/eslint@9.35.0",
       "externalReferences": [
         {
@@ -14138,7 +14146,7 @@
           "type": "library",
           "name": "ajv",
           "version": "6.12.6",
-          "bom-ref": "nachet-frontend@0.10.3|eslint@9.35.0|ajv@6.12.6",
+          "bom-ref": "nachet-frontend@0.10.4|eslint@9.35.0|ajv@6.12.6",
           "purl": "pkg:npm/ajv@6.12.6",
           "externalReferences": [
             {
@@ -14168,7 +14176,7 @@
           "type": "library",
           "name": "eslint-visitor-keys",
           "version": "4.2.1",
-          "bom-ref": "nachet-frontend@0.10.3|eslint@9.35.0|eslint-visitor-keys@4.2.1",
+          "bom-ref": "nachet-frontend@0.10.4|eslint@9.35.0|eslint-visitor-keys@4.2.1",
           "purl": "pkg:npm/eslint-visitor-keys@4.2.1",
           "externalReferences": [
             {
@@ -14198,7 +14206,7 @@
           "type": "library",
           "name": "json-schema-traverse",
           "version": "0.4.1",
-          "bom-ref": "nachet-frontend@0.10.3|eslint@9.35.0|json-schema-traverse@0.4.1",
+          "bom-ref": "nachet-frontend@0.10.4|eslint@9.35.0|json-schema-traverse@0.4.1",
           "purl": "pkg:npm/json-schema-traverse@0.4.1",
           "externalReferences": [
             {
@@ -14230,7 +14238,7 @@
       "type": "library",
       "name": "espree",
       "version": "10.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|espree@10.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|espree@10.4.0",
       "purl": "pkg:npm/espree@10.4.0",
       "externalReferences": [
         {
@@ -14260,7 +14268,7 @@
           "type": "library",
           "name": "eslint-visitor-keys",
           "version": "4.2.1",
-          "bom-ref": "nachet-frontend@0.10.3|espree@10.4.0|eslint-visitor-keys@4.2.1",
+          "bom-ref": "nachet-frontend@0.10.4|espree@10.4.0|eslint-visitor-keys@4.2.1",
           "purl": "pkg:npm/eslint-visitor-keys@4.2.1",
           "externalReferences": [
             {
@@ -14292,7 +14300,7 @@
       "type": "library",
       "name": "esprima",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|esprima@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|esprima@4.0.1",
       "purl": "pkg:npm/esprima@4.0.1",
       "externalReferences": [
         {
@@ -14322,7 +14330,7 @@
       "type": "library",
       "name": "esquery",
       "version": "1.6.0",
-      "bom-ref": "nachet-frontend@0.10.3|esquery@1.6.0",
+      "bom-ref": "nachet-frontend@0.10.4|esquery@1.6.0",
       "purl": "pkg:npm/esquery@1.6.0",
       "externalReferences": [
         {
@@ -14352,7 +14360,7 @@
       "type": "library",
       "name": "esrecurse",
       "version": "4.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|esrecurse@4.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|esrecurse@4.3.0",
       "purl": "pkg:npm/esrecurse@4.3.0",
       "externalReferences": [
         {
@@ -14382,7 +14390,7 @@
       "type": "library",
       "name": "estraverse",
       "version": "5.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|estraverse@5.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|estraverse@5.3.0",
       "purl": "pkg:npm/estraverse@5.3.0",
       "externalReferences": [
         {
@@ -14412,7 +14420,7 @@
       "type": "library",
       "name": "estree-walker",
       "version": "3.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|estree-walker@3.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|estree-walker@3.0.3",
       "purl": "pkg:npm/estree-walker@3.0.3",
       "externalReferences": [
         {
@@ -14442,7 +14450,7 @@
       "type": "library",
       "name": "esutils",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|esutils@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|esutils@2.0.3",
       "purl": "pkg:npm/esutils@2.0.3",
       "externalReferences": [
         {
@@ -14472,7 +14480,7 @@
       "type": "library",
       "name": "etag",
       "version": "1.8.1",
-      "bom-ref": "nachet-frontend@0.10.3|etag@1.8.1",
+      "bom-ref": "nachet-frontend@0.10.4|etag@1.8.1",
       "purl": "pkg:npm/etag@1.8.1",
       "externalReferences": [
         {
@@ -14498,7 +14506,7 @@
       "type": "library",
       "name": "execa",
       "version": "4.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|execa@4.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|execa@4.1.0",
       "purl": "pkg:npm/execa@4.1.0",
       "externalReferences": [
         {
@@ -14524,7 +14532,7 @@
       "type": "library",
       "name": "expand-template",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|expand-template@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|expand-template@2.0.3",
       "scope": "optional",
       "purl": "pkg:npm/expand-template@2.0.3",
       "externalReferences": [
@@ -14555,7 +14563,7 @@
       "type": "library",
       "name": "expect-type",
       "version": "1.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|expect-type@1.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|expect-type@1.2.2",
       "purl": "pkg:npm/expect-type@1.2.2",
       "externalReferences": [
         {
@@ -14585,7 +14593,7 @@
       "type": "library",
       "name": "exponential-backoff",
       "version": "3.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|exponential-backoff@3.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|exponential-backoff@3.1.2",
       "scope": "optional",
       "purl": "pkg:npm/exponential-backoff@3.1.2",
       "externalReferences": [
@@ -14616,7 +14624,7 @@
       "type": "library",
       "name": "express",
       "version": "5.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|express@5.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|express@5.1.0",
       "purl": "pkg:npm/express@5.1.0",
       "externalReferences": [
         {
@@ -14642,7 +14650,7 @@
       "type": "library",
       "name": "extend",
       "version": "3.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|extend@3.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|extend@3.0.2",
       "scope": "optional",
       "purl": "pkg:npm/extend@3.0.2",
       "externalReferences": [
@@ -14673,7 +14681,7 @@
       "type": "library",
       "name": "fast-deep-equal",
       "version": "3.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|fast-deep-equal@3.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|fast-deep-equal@3.1.3",
       "purl": "pkg:npm/fast-deep-equal@3.1.3",
       "externalReferences": [
         {
@@ -14699,7 +14707,7 @@
       "type": "library",
       "name": "fast-diff",
       "version": "1.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|fast-diff@1.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|fast-diff@1.3.0",
       "purl": "pkg:npm/fast-diff@1.3.0",
       "externalReferences": [
         {
@@ -14729,7 +14737,7 @@
       "type": "library",
       "name": "fast-glob",
       "version": "3.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|fast-glob@3.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|fast-glob@3.3.3",
       "purl": "pkg:npm/fast-glob@3.3.3",
       "externalReferences": [
         {
@@ -14759,7 +14767,7 @@
           "type": "library",
           "name": "glob-parent",
           "version": "5.1.2",
-          "bom-ref": "nachet-frontend@0.10.3|fast-glob@3.3.3|glob-parent@5.1.2",
+          "bom-ref": "nachet-frontend@0.10.4|fast-glob@3.3.3|glob-parent@5.1.2",
           "purl": "pkg:npm/glob-parent@5.1.2",
           "externalReferences": [
             {
@@ -14791,7 +14799,7 @@
       "type": "library",
       "name": "fast-json-stable-stringify",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|fast-json-stable-stringify@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|fast-json-stable-stringify@2.1.0",
       "purl": "pkg:npm/fast-json-stable-stringify@2.1.0",
       "externalReferences": [
         {
@@ -14821,7 +14829,7 @@
       "type": "library",
       "name": "fast-levenshtein",
       "version": "2.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|fast-levenshtein@2.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|fast-levenshtein@2.0.6",
       "purl": "pkg:npm/fast-levenshtein@2.0.6",
       "externalReferences": [
         {
@@ -14851,7 +14859,7 @@
       "type": "library",
       "name": "fast-uri",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|fast-uri@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|fast-uri@3.1.0",
       "scope": "optional",
       "purl": "pkg:npm/fast-uri@3.1.0",
       "externalReferences": [
@@ -14882,7 +14890,7 @@
       "type": "library",
       "name": "fastq",
       "version": "1.19.1",
-      "bom-ref": "nachet-frontend@0.10.3|fastq@1.19.1",
+      "bom-ref": "nachet-frontend@0.10.4|fastq@1.19.1",
       "purl": "pkg:npm/fastq@1.19.1",
       "externalReferences": [
         {
@@ -14912,7 +14920,7 @@
       "type": "library",
       "name": "fdir",
       "version": "6.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|fdir@6.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|fdir@6.5.0",
       "purl": "pkg:npm/fdir@6.5.0",
       "externalReferences": [
         {
@@ -14942,7 +14950,7 @@
       "type": "library",
       "name": "fetch-blob",
       "version": "3.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|fetch-blob@3.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|fetch-blob@3.2.0",
       "purl": "pkg:npm/fetch-blob@3.2.0",
       "externalReferences": [
         {
@@ -14972,7 +14980,7 @@
       "type": "library",
       "name": "file-entry-cache",
       "version": "8.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|file-entry-cache@8.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|file-entry-cache@8.0.0",
       "purl": "pkg:npm/file-entry-cache@8.0.0",
       "externalReferences": [
         {
@@ -15002,7 +15010,7 @@
       "type": "library",
       "name": "file-saver",
       "version": "2.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|file-saver@2.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|file-saver@2.0.5",
       "purl": "pkg:npm/file-saver@2.0.5",
       "externalReferences": [
         {
@@ -15028,7 +15036,7 @@
       "type": "library",
       "name": "file-uri-to-path",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|file-uri-to-path@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|file-uri-to-path@1.0.0",
       "scope": "optional",
       "purl": "pkg:npm/file-uri-to-path@1.0.0",
       "externalReferences": [
@@ -15059,7 +15067,7 @@
       "type": "library",
       "name": "fill-range",
       "version": "7.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|fill-range@7.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|fill-range@7.1.1",
       "purl": "pkg:npm/fill-range@7.1.1",
       "externalReferences": [
         {
@@ -15089,7 +15097,7 @@
       "type": "library",
       "name": "finalhandler",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|finalhandler@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|finalhandler@2.1.0",
       "purl": "pkg:npm/finalhandler@2.1.0",
       "externalReferences": [
         {
@@ -15115,7 +15123,7 @@
       "type": "library",
       "name": "find-root",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|find-root@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|find-root@1.1.0",
       "purl": "pkg:npm/find-root@1.1.0",
       "externalReferences": [
         {
@@ -15141,7 +15149,7 @@
       "type": "library",
       "name": "find-up",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|find-up@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|find-up@5.0.0",
       "purl": "pkg:npm/find-up@5.0.0",
       "externalReferences": [
         {
@@ -15171,7 +15179,7 @@
       "type": "library",
       "name": "flat-cache",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|flat-cache@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|flat-cache@4.0.1",
       "purl": "pkg:npm/flat-cache@4.0.1",
       "externalReferences": [
         {
@@ -15201,7 +15209,7 @@
       "type": "library",
       "name": "flatted",
       "version": "3.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|flatted@3.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|flatted@3.3.3",
       "purl": "pkg:npm/flatted@3.3.3",
       "externalReferences": [
         {
@@ -15231,7 +15239,7 @@
       "type": "library",
       "name": "follow-redirects",
       "version": "1.15.11",
-      "bom-ref": "nachet-frontend@0.10.3|follow-redirects@1.15.11",
+      "bom-ref": "nachet-frontend@0.10.4|follow-redirects@1.15.11",
       "purl": "pkg:npm/follow-redirects@1.15.11",
       "externalReferences": [
         {
@@ -15257,7 +15265,7 @@
       "type": "library",
       "name": "for-each",
       "version": "0.3.5",
-      "bom-ref": "nachet-frontend@0.10.3|for-each@0.3.5",
+      "bom-ref": "nachet-frontend@0.10.4|for-each@0.3.5",
       "purl": "pkg:npm/for-each@0.3.5",
       "externalReferences": [
         {
@@ -15287,7 +15295,7 @@
       "type": "library",
       "name": "foreground-child",
       "version": "3.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|foreground-child@3.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|foreground-child@3.3.1",
       "purl": "pkg:npm/foreground-child@3.3.1",
       "externalReferences": [
         {
@@ -15317,7 +15325,7 @@
           "type": "library",
           "name": "signal-exit",
           "version": "4.1.0",
-          "bom-ref": "nachet-frontend@0.10.3|foreground-child@3.3.1|signal-exit@4.1.0",
+          "bom-ref": "nachet-frontend@0.10.4|foreground-child@3.3.1|signal-exit@4.1.0",
           "purl": "pkg:npm/signal-exit@4.1.0",
           "externalReferences": [
             {
@@ -15349,7 +15357,7 @@
       "type": "library",
       "name": "form-data",
       "version": "4.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|form-data@4.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|form-data@4.0.4",
       "purl": "pkg:npm/form-data@4.0.4",
       "externalReferences": [
         {
@@ -15375,7 +15383,7 @@
           "type": "library",
           "name": "mime-db",
           "version": "1.52.0",
-          "bom-ref": "nachet-frontend@0.10.3|form-data@4.0.4|mime-db@1.52.0",
+          "bom-ref": "nachet-frontend@0.10.4|form-data@4.0.4|mime-db@1.52.0",
           "purl": "pkg:npm/mime-db@1.52.0",
           "externalReferences": [
             {
@@ -15401,7 +15409,7 @@
           "type": "library",
           "name": "mime-types",
           "version": "2.1.35",
-          "bom-ref": "nachet-frontend@0.10.3|form-data@4.0.4|mime-types@2.1.35",
+          "bom-ref": "nachet-frontend@0.10.4|form-data@4.0.4|mime-types@2.1.35",
           "purl": "pkg:npm/mime-types@2.1.35",
           "externalReferences": [
             {
@@ -15429,7 +15437,7 @@
       "type": "library",
       "name": "formdata-polyfill",
       "version": "4.0.10",
-      "bom-ref": "nachet-frontend@0.10.3|formdata-polyfill@4.0.10",
+      "bom-ref": "nachet-frontend@0.10.4|formdata-polyfill@4.0.10",
       "purl": "pkg:npm/formdata-polyfill@4.0.10",
       "externalReferences": [
         {
@@ -15459,7 +15467,7 @@
       "type": "library",
       "name": "forwarded",
       "version": "0.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|forwarded@0.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|forwarded@0.2.0",
       "purl": "pkg:npm/forwarded@0.2.0",
       "externalReferences": [
         {
@@ -15485,7 +15493,7 @@
       "type": "library",
       "name": "fresh",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|fresh@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|fresh@2.0.0",
       "purl": "pkg:npm/fresh@2.0.0",
       "externalReferences": [
         {
@@ -15511,7 +15519,7 @@
       "type": "library",
       "name": "fs-constants",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|fs-constants@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|fs-constants@1.0.0",
       "scope": "optional",
       "purl": "pkg:npm/fs-constants@1.0.0",
       "externalReferences": [
@@ -15542,7 +15550,7 @@
       "type": "library",
       "name": "fs-minipass",
       "version": "3.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|fs-minipass@3.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|fs-minipass@3.0.3",
       "scope": "optional",
       "purl": "pkg:npm/fs-minipass@3.0.3",
       "externalReferences": [
@@ -15573,7 +15581,7 @@
       "type": "library",
       "name": "fsevents",
       "version": "2.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|fsevents@2.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|fsevents@2.3.2",
       "scope": "optional",
       "purl": "pkg:npm/fsevents@2.3.2",
       "externalReferences": [
@@ -15604,7 +15612,7 @@
       "type": "library",
       "name": "function-bind",
       "version": "1.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|function-bind@1.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|function-bind@1.1.2",
       "purl": "pkg:npm/function-bind@1.1.2",
       "externalReferences": [
         {
@@ -15630,7 +15638,7 @@
       "type": "library",
       "name": "function.prototype.name",
       "version": "1.1.8",
-      "bom-ref": "nachet-frontend@0.10.3|function.prototype.name@1.1.8",
+      "bom-ref": "nachet-frontend@0.10.4|function.prototype.name@1.1.8",
       "purl": "pkg:npm/function.prototype.name@1.1.8",
       "externalReferences": [
         {
@@ -15660,7 +15668,7 @@
       "type": "library",
       "name": "functions-have-names",
       "version": "1.2.3",
-      "bom-ref": "nachet-frontend@0.10.3|functions-have-names@1.2.3",
+      "bom-ref": "nachet-frontend@0.10.4|functions-have-names@1.2.3",
       "purl": "pkg:npm/functions-have-names@1.2.3",
       "externalReferences": [
         {
@@ -15690,7 +15698,7 @@
       "type": "library",
       "name": "gensync",
       "version": "1.0.0-beta.2",
-      "bom-ref": "nachet-frontend@0.10.3|gensync@1.0.0-beta.2",
+      "bom-ref": "nachet-frontend@0.10.4|gensync@1.0.0-beta.2",
       "purl": "pkg:npm/gensync@1.0.0-beta.2",
       "externalReferences": [
         {
@@ -15716,7 +15724,7 @@
       "type": "library",
       "name": "get-caller-file",
       "version": "2.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|get-caller-file@2.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|get-caller-file@2.0.5",
       "purl": "pkg:npm/get-caller-file@2.0.5",
       "externalReferences": [
         {
@@ -15742,7 +15750,7 @@
       "type": "library",
       "name": "get-intrinsic",
       "version": "1.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
       "purl": "pkg:npm/get-intrinsic@1.3.0",
       "externalReferences": [
         {
@@ -15768,7 +15776,7 @@
       "type": "library",
       "name": "get-proto",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|get-proto@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|get-proto@1.0.1",
       "purl": "pkg:npm/get-proto@1.0.1",
       "externalReferences": [
         {
@@ -15794,7 +15802,7 @@
       "type": "library",
       "name": "get-stream",
       "version": "5.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|get-stream@5.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|get-stream@5.2.0",
       "purl": "pkg:npm/get-stream@5.2.0",
       "externalReferences": [
         {
@@ -15820,7 +15828,7 @@
       "type": "library",
       "name": "get-symbol-description",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|get-symbol-description@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|get-symbol-description@1.1.0",
       "purl": "pkg:npm/get-symbol-description@1.1.0",
       "externalReferences": [
         {
@@ -15850,7 +15858,7 @@
       "type": "library",
       "name": "git-commit-info",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|git-commit-info@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|git-commit-info@2.0.2",
       "purl": "pkg:npm/git-commit-info@2.0.2",
       "externalReferences": [
         {
@@ -15876,7 +15884,7 @@
       "type": "library",
       "name": "git-describe",
       "version": "4.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|git-describe@4.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|git-describe@4.1.1",
       "purl": "pkg:npm/git-describe@4.1.1",
       "externalReferences": [
         {
@@ -15902,7 +15910,7 @@
           "type": "library",
           "name": "semver",
           "version": "5.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|git-describe@4.1.1|semver@5.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|git-describe@4.1.1|semver@5.7.2",
           "scope": "optional",
           "purl": "pkg:npm/semver@5.7.2",
           "externalReferences": [
@@ -15931,7 +15939,7 @@
       "type": "library",
       "name": "github-from-package",
       "version": "0.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|github-from-package@0.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|github-from-package@0.0.0",
       "scope": "optional",
       "purl": "pkg:npm/github-from-package@0.0.0",
       "externalReferences": [
@@ -15962,7 +15970,7 @@
       "type": "library",
       "name": "glob-parent",
       "version": "6.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|glob-parent@6.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|glob-parent@6.0.2",
       "purl": "pkg:npm/glob-parent@6.0.2",
       "externalReferences": [
         {
@@ -15992,7 +16000,7 @@
       "type": "library",
       "name": "glob",
       "version": "10.4.5",
-      "bom-ref": "nachet-frontend@0.10.3|glob@10.4.5",
+      "bom-ref": "nachet-frontend@0.10.4|glob@10.4.5",
       "purl": "pkg:npm/glob@10.4.5",
       "externalReferences": [
         {
@@ -16022,7 +16030,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "2.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|glob@10.4.5|brace-expansion@2.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|glob@10.4.5|brace-expansion@2.0.2",
           "purl": "pkg:npm/brace-expansion@2.0.2",
           "externalReferences": [
             {
@@ -16052,7 +16060,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "9.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|glob@10.4.5|minimatch@9.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|glob@10.4.5|minimatch@9.0.5",
           "purl": "pkg:npm/minimatch@9.0.5",
           "externalReferences": [
             {
@@ -16084,7 +16092,7 @@
       "type": "library",
       "name": "globals",
       "version": "16.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|globals@16.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|globals@16.4.0",
       "purl": "pkg:npm/globals@16.4.0",
       "externalReferences": [
         {
@@ -16114,7 +16122,7 @@
       "type": "library",
       "name": "globalthis",
       "version": "1.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|globalthis@1.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|globalthis@1.0.4",
       "purl": "pkg:npm/globalthis@1.0.4",
       "externalReferences": [
         {
@@ -16144,7 +16152,7 @@
       "type": "library",
       "name": "gopd",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|gopd@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|gopd@1.2.0",
       "purl": "pkg:npm/gopd@1.2.0",
       "externalReferences": [
         {
@@ -16170,7 +16178,7 @@
       "type": "library",
       "name": "graceful-fs",
       "version": "4.2.11",
-      "bom-ref": "nachet-frontend@0.10.3|graceful-fs@4.2.11",
+      "bom-ref": "nachet-frontend@0.10.4|graceful-fs@4.2.11",
       "purl": "pkg:npm/graceful-fs@4.2.11",
       "externalReferences": [
         {
@@ -16200,7 +16208,7 @@
       "type": "library",
       "name": "graphemer",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|graphemer@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|graphemer@1.4.0",
       "purl": "pkg:npm/graphemer@1.4.0",
       "externalReferences": [
         {
@@ -16230,7 +16238,7 @@
       "type": "library",
       "name": "harmony-reflect",
       "version": "1.6.2",
-      "bom-ref": "nachet-frontend@0.10.3|harmony-reflect@1.6.2",
+      "bom-ref": "nachet-frontend@0.10.4|harmony-reflect@1.6.2",
       "purl": "pkg:npm/harmony-reflect@1.6.2",
       "externalReferences": [
         {
@@ -16260,7 +16268,7 @@
       "type": "library",
       "name": "has-bigints",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|has-bigints@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|has-bigints@1.1.0",
       "purl": "pkg:npm/has-bigints@1.1.0",
       "externalReferences": [
         {
@@ -16290,7 +16298,7 @@
       "type": "library",
       "name": "has-flag",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|has-flag@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|has-flag@4.0.0",
       "purl": "pkg:npm/has-flag@4.0.0",
       "externalReferences": [
         {
@@ -16316,7 +16324,7 @@
       "type": "library",
       "name": "has-property-descriptors",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|has-property-descriptors@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|has-property-descriptors@1.0.2",
       "purl": "pkg:npm/has-property-descriptors@1.0.2",
       "externalReferences": [
         {
@@ -16346,7 +16354,7 @@
       "type": "library",
       "name": "has-proto",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|has-proto@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|has-proto@1.2.0",
       "purl": "pkg:npm/has-proto@1.2.0",
       "externalReferences": [
         {
@@ -16376,7 +16384,7 @@
       "type": "library",
       "name": "has-symbols",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|has-symbols@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|has-symbols@1.1.0",
       "purl": "pkg:npm/has-symbols@1.1.0",
       "externalReferences": [
         {
@@ -16402,7 +16410,7 @@
       "type": "library",
       "name": "has-tostringtag",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
       "purl": "pkg:npm/has-tostringtag@1.0.2",
       "externalReferences": [
         {
@@ -16428,7 +16436,7 @@
       "type": "library",
       "name": "hasown",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|hasown@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|hasown@2.0.2",
       "purl": "pkg:npm/hasown@2.0.2",
       "externalReferences": [
         {
@@ -16454,7 +16462,7 @@
       "type": "library",
       "name": "hoist-non-react-statics",
       "version": "3.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|hoist-non-react-statics@3.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|hoist-non-react-statics@3.3.2",
       "purl": "pkg:npm/hoist-non-react-statics@3.3.2",
       "externalReferences": [
         {
@@ -16480,7 +16488,7 @@
           "type": "library",
           "name": "react-is",
           "version": "16.13.1",
-          "bom-ref": "nachet-frontend@0.10.3|hoist-non-react-statics@3.3.2|react-is@16.13.1",
+          "bom-ref": "nachet-frontend@0.10.4|hoist-non-react-statics@3.3.2|react-is@16.13.1",
           "purl": "pkg:npm/react-is@16.13.1",
           "externalReferences": [
             {
@@ -16508,7 +16516,7 @@
       "type": "library",
       "name": "hosted-git-info",
       "version": "9.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|hosted-git-info@9.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|hosted-git-info@9.0.0",
       "purl": "pkg:npm/hosted-git-info@9.0.0",
       "externalReferences": [
         {
@@ -16538,7 +16546,7 @@
           "type": "library",
           "name": "lru-cache",
           "version": "11.2.1",
-          "bom-ref": "nachet-frontend@0.10.3|hosted-git-info@9.0.0|lru-cache@11.2.1",
+          "bom-ref": "nachet-frontend@0.10.4|hosted-git-info@9.0.0|lru-cache@11.2.1",
           "purl": "pkg:npm/lru-cache@11.2.1",
           "externalReferences": [
             {
@@ -16570,7 +16578,7 @@
       "type": "library",
       "name": "html-encoding-sniffer",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|html-encoding-sniffer@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|html-encoding-sniffer@4.0.0",
       "purl": "pkg:npm/html-encoding-sniffer@4.0.0",
       "externalReferences": [
         {
@@ -16600,7 +16608,7 @@
       "type": "library",
       "name": "html-escaper",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|html-escaper@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|html-escaper@2.0.2",
       "purl": "pkg:npm/html-escaper@2.0.2",
       "externalReferences": [
         {
@@ -16630,7 +16638,7 @@
       "type": "library",
       "name": "htmlparser2",
       "version": "8.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|htmlparser2@8.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|htmlparser2@8.0.2",
       "purl": "pkg:npm/htmlparser2@8.0.2",
       "externalReferences": [
         {
@@ -16656,7 +16664,7 @@
       "type": "library",
       "name": "http-cache-semantics",
       "version": "4.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|http-cache-semantics@4.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|http-cache-semantics@4.2.0",
       "scope": "optional",
       "purl": "pkg:npm/http-cache-semantics@4.2.0",
       "externalReferences": [
@@ -16687,7 +16695,7 @@
       "type": "library",
       "name": "http-errors",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|http-errors@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|http-errors@2.0.0",
       "purl": "pkg:npm/http-errors@2.0.0",
       "externalReferences": [
         {
@@ -16713,7 +16721,7 @@
           "type": "library",
           "name": "statuses",
           "version": "2.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|http-errors@2.0.0|statuses@2.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|http-errors@2.0.0|statuses@2.0.1",
           "purl": "pkg:npm/statuses@2.0.1",
           "externalReferences": [
             {
@@ -16741,7 +16749,7 @@
       "type": "library",
       "name": "http-proxy-agent",
       "version": "7.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|http-proxy-agent@7.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|http-proxy-agent@7.0.2",
       "purl": "pkg:npm/http-proxy-agent@7.0.2",
       "externalReferences": [
         {
@@ -16771,7 +16779,7 @@
       "type": "library",
       "name": "https-proxy-agent",
       "version": "7.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|https-proxy-agent@7.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|https-proxy-agent@7.0.6",
       "purl": "pkg:npm/https-proxy-agent@7.0.6",
       "externalReferences": [
         {
@@ -16801,7 +16809,7 @@
       "type": "library",
       "name": "human-signals",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|human-signals@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|human-signals@1.1.1",
       "purl": "pkg:npm/human-signals@1.1.1",
       "externalReferences": [
         {
@@ -16827,7 +16835,7 @@
       "type": "library",
       "name": "iconv-lite",
       "version": "0.6.3",
-      "bom-ref": "nachet-frontend@0.10.3|iconv-lite@0.6.3",
+      "bom-ref": "nachet-frontend@0.10.4|iconv-lite@0.6.3",
       "purl": "pkg:npm/iconv-lite@0.6.3",
       "externalReferences": [
         {
@@ -16853,7 +16861,7 @@
       "type": "library",
       "name": "identity-obj-proxy",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|identity-obj-proxy@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|identity-obj-proxy@3.0.0",
       "purl": "pkg:npm/identity-obj-proxy@3.0.0",
       "externalReferences": [
         {
@@ -16883,7 +16891,7 @@
       "type": "library",
       "name": "ieee754",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|ieee754@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|ieee754@1.2.1",
       "scope": "optional",
       "purl": "pkg:npm/ieee754@1.2.1",
       "externalReferences": [
@@ -16914,7 +16922,7 @@
       "type": "library",
       "name": "ignore",
       "version": "5.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|ignore@5.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|ignore@5.3.2",
       "purl": "pkg:npm/ignore@5.3.2",
       "externalReferences": [
         {
@@ -16944,7 +16952,7 @@
       "type": "library",
       "name": "immediate",
       "version": "3.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|immediate@3.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|immediate@3.0.6",
       "purl": "pkg:npm/immediate@3.0.6",
       "externalReferences": [
         {
@@ -16970,7 +16978,7 @@
       "type": "library",
       "name": "import-fresh",
       "version": "3.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|import-fresh@3.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|import-fresh@3.3.1",
       "purl": "pkg:npm/import-fresh@3.3.1",
       "externalReferences": [
         {
@@ -16996,7 +17004,7 @@
       "type": "library",
       "name": "imurmurhash",
       "version": "0.1.4",
-      "bom-ref": "nachet-frontend@0.10.3|imurmurhash@0.1.4",
+      "bom-ref": "nachet-frontend@0.10.4|imurmurhash@0.1.4",
       "purl": "pkg:npm/imurmurhash@0.1.4",
       "externalReferences": [
         {
@@ -17026,7 +17034,7 @@
       "type": "library",
       "name": "indent-string",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|indent-string@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|indent-string@4.0.0",
       "purl": "pkg:npm/indent-string@4.0.0",
       "externalReferences": [
         {
@@ -17052,7 +17060,7 @@
       "type": "library",
       "name": "inherits",
       "version": "2.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|inherits@2.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|inherits@2.0.4",
       "purl": "pkg:npm/inherits@2.0.4",
       "externalReferences": [
         {
@@ -17078,7 +17086,7 @@
       "type": "library",
       "name": "ini",
       "version": "1.3.8",
-      "bom-ref": "nachet-frontend@0.10.3|ini@1.3.8",
+      "bom-ref": "nachet-frontend@0.10.4|ini@1.3.8",
       "purl": "pkg:npm/ini@1.3.8",
       "externalReferences": [
         {
@@ -17104,7 +17112,7 @@
       "type": "library",
       "name": "internal-slot",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|internal-slot@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|internal-slot@1.1.0",
       "purl": "pkg:npm/internal-slot@1.1.0",
       "externalReferences": [
         {
@@ -17134,7 +17142,7 @@
       "type": "library",
       "name": "ip-address",
       "version": "10.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|ip-address@10.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|ip-address@10.0.1",
       "scope": "optional",
       "purl": "pkg:npm/ip-address@10.0.1",
       "externalReferences": [
@@ -17165,7 +17173,7 @@
       "type": "library",
       "name": "ipaddr.js",
       "version": "1.9.1",
-      "bom-ref": "nachet-frontend@0.10.3|ipaddr.js@1.9.1",
+      "bom-ref": "nachet-frontend@0.10.4|ipaddr.js@1.9.1",
       "purl": "pkg:npm/ipaddr.js@1.9.1",
       "externalReferences": [
         {
@@ -17191,7 +17199,7 @@
       "type": "library",
       "name": "is-array-buffer",
       "version": "3.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|is-array-buffer@3.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|is-array-buffer@3.0.5",
       "purl": "pkg:npm/is-array-buffer@3.0.5",
       "externalReferences": [
         {
@@ -17221,7 +17229,7 @@
       "type": "library",
       "name": "is-arrayish",
       "version": "0.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-arrayish@0.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-arrayish@0.2.1",
       "purl": "pkg:npm/is-arrayish@0.2.1",
       "externalReferences": [
         {
@@ -17247,7 +17255,7 @@
       "type": "library",
       "name": "is-async-function",
       "version": "2.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-async-function@2.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-async-function@2.1.1",
       "purl": "pkg:npm/is-async-function@2.1.1",
       "externalReferences": [
         {
@@ -17277,7 +17285,7 @@
       "type": "library",
       "name": "is-bigint",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-bigint@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-bigint@1.1.0",
       "purl": "pkg:npm/is-bigint@1.1.0",
       "externalReferences": [
         {
@@ -17307,7 +17315,7 @@
       "type": "library",
       "name": "is-boolean-object",
       "version": "1.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|is-boolean-object@1.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|is-boolean-object@1.2.2",
       "purl": "pkg:npm/is-boolean-object@1.2.2",
       "externalReferences": [
         {
@@ -17337,7 +17345,7 @@
       "type": "library",
       "name": "is-callable",
       "version": "1.2.7",
-      "bom-ref": "nachet-frontend@0.10.3|is-callable@1.2.7",
+      "bom-ref": "nachet-frontend@0.10.4|is-callable@1.2.7",
       "purl": "pkg:npm/is-callable@1.2.7",
       "externalReferences": [
         {
@@ -17367,7 +17375,7 @@
       "type": "library",
       "name": "is-core-module",
       "version": "2.16.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-core-module@2.16.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-core-module@2.16.1",
       "purl": "pkg:npm/is-core-module@2.16.1",
       "externalReferences": [
         {
@@ -17393,7 +17401,7 @@
       "type": "library",
       "name": "is-data-view",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|is-data-view@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|is-data-view@1.0.2",
       "purl": "pkg:npm/is-data-view@1.0.2",
       "externalReferences": [
         {
@@ -17423,7 +17431,7 @@
       "type": "library",
       "name": "is-date-object",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-date-object@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-date-object@1.1.0",
       "purl": "pkg:npm/is-date-object@1.1.0",
       "externalReferences": [
         {
@@ -17453,7 +17461,7 @@
       "type": "library",
       "name": "is-docker",
       "version": "2.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-docker@2.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-docker@2.2.1",
       "purl": "pkg:npm/is-docker@2.2.1",
       "externalReferences": [
         {
@@ -17479,7 +17487,7 @@
       "type": "library",
       "name": "is-extglob",
       "version": "2.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-extglob@2.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-extglob@2.1.1",
       "purl": "pkg:npm/is-extglob@2.1.1",
       "externalReferences": [
         {
@@ -17509,7 +17517,7 @@
       "type": "library",
       "name": "is-finalizationregistry",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-finalizationregistry@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-finalizationregistry@1.1.1",
       "purl": "pkg:npm/is-finalizationregistry@1.1.1",
       "externalReferences": [
         {
@@ -17539,7 +17547,7 @@
       "type": "library",
       "name": "is-fullwidth-code-point",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0",
       "purl": "pkg:npm/is-fullwidth-code-point@3.0.0",
       "externalReferences": [
         {
@@ -17565,7 +17573,7 @@
       "type": "library",
       "name": "is-generator-function",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-generator-function@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-generator-function@1.1.0",
       "purl": "pkg:npm/is-generator-function@1.1.0",
       "externalReferences": [
         {
@@ -17595,7 +17603,7 @@
       "type": "library",
       "name": "is-git-repository",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1",
       "purl": "pkg:npm/is-git-repository@1.1.1",
       "externalReferences": [
         {
@@ -17621,7 +17629,7 @@
           "type": "library",
           "name": "execa",
           "version": "0.6.3",
-          "bom-ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|execa@0.6.3",
+          "bom-ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|execa@0.6.3",
           "purl": "pkg:npm/execa@0.6.3",
           "externalReferences": [
             {
@@ -17647,7 +17655,7 @@
           "type": "library",
           "name": "get-stream",
           "version": "3.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|get-stream@3.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|get-stream@3.0.0",
           "purl": "pkg:npm/get-stream@3.0.0",
           "externalReferences": [
             {
@@ -17673,7 +17681,7 @@
           "type": "library",
           "name": "is-stream",
           "version": "1.1.0",
-          "bom-ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|is-stream@1.1.0",
+          "bom-ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|is-stream@1.1.0",
           "purl": "pkg:npm/is-stream@1.1.0",
           "externalReferences": [
             {
@@ -17699,7 +17707,7 @@
           "type": "library",
           "name": "npm-run-path",
           "version": "2.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|npm-run-path@2.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|npm-run-path@2.0.2",
           "purl": "pkg:npm/npm-run-path@2.0.2",
           "externalReferences": [
             {
@@ -17725,7 +17733,7 @@
           "type": "library",
           "name": "path-key",
           "version": "2.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|path-key@2.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|path-key@2.0.1",
           "purl": "pkg:npm/path-key@2.0.1",
           "externalReferences": [
             {
@@ -17753,7 +17761,7 @@
       "type": "library",
       "name": "is-glob",
       "version": "4.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|is-glob@4.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|is-glob@4.0.3",
       "purl": "pkg:npm/is-glob@4.0.3",
       "externalReferences": [
         {
@@ -17783,7 +17791,7 @@
       "type": "library",
       "name": "is-map",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|is-map@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|is-map@2.0.3",
       "purl": "pkg:npm/is-map@2.0.3",
       "externalReferences": [
         {
@@ -17813,7 +17821,7 @@
       "type": "library",
       "name": "is-negative-zero",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|is-negative-zero@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|is-negative-zero@2.0.3",
       "purl": "pkg:npm/is-negative-zero@2.0.3",
       "externalReferences": [
         {
@@ -17843,7 +17851,7 @@
       "type": "library",
       "name": "is-number-object",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-number-object@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-number-object@1.1.1",
       "purl": "pkg:npm/is-number-object@1.1.1",
       "externalReferences": [
         {
@@ -17873,7 +17881,7 @@
       "type": "library",
       "name": "is-number",
       "version": "7.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-number@7.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-number@7.0.0",
       "purl": "pkg:npm/is-number@7.0.0",
       "externalReferences": [
         {
@@ -17903,7 +17911,7 @@
       "type": "library",
       "name": "is-plain-object",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-plain-object@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-plain-object@5.0.0",
       "purl": "pkg:npm/is-plain-object@5.0.0",
       "externalReferences": [
         {
@@ -17929,7 +17937,7 @@
       "type": "library",
       "name": "is-port-reachable",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-port-reachable@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-port-reachable@4.0.0",
       "purl": "pkg:npm/is-port-reachable@4.0.0",
       "externalReferences": [
         {
@@ -17955,7 +17963,7 @@
       "type": "library",
       "name": "is-potential-custom-element-name",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-potential-custom-element-name@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-potential-custom-element-name@1.0.1",
       "purl": "pkg:npm/is-potential-custom-element-name@1.0.1",
       "externalReferences": [
         {
@@ -17985,7 +17993,7 @@
       "type": "library",
       "name": "is-promise",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-promise@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-promise@4.0.0",
       "purl": "pkg:npm/is-promise@4.0.0",
       "externalReferences": [
         {
@@ -18011,7 +18019,7 @@
       "type": "library",
       "name": "is-regex",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-regex@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-regex@1.2.1",
       "purl": "pkg:npm/is-regex@1.2.1",
       "externalReferences": [
         {
@@ -18041,7 +18049,7 @@
       "type": "library",
       "name": "is-set",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|is-set@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|is-set@2.0.3",
       "purl": "pkg:npm/is-set@2.0.3",
       "externalReferences": [
         {
@@ -18071,7 +18079,7 @@
       "type": "library",
       "name": "is-shared-array-buffer",
       "version": "1.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|is-shared-array-buffer@1.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|is-shared-array-buffer@1.0.4",
       "purl": "pkg:npm/is-shared-array-buffer@1.0.4",
       "externalReferences": [
         {
@@ -18101,7 +18109,7 @@
       "type": "library",
       "name": "is-stream",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-stream@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-stream@2.0.1",
       "purl": "pkg:npm/is-stream@2.0.1",
       "externalReferences": [
         {
@@ -18127,7 +18135,7 @@
       "type": "library",
       "name": "is-string",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-string@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-string@1.1.1",
       "purl": "pkg:npm/is-string@1.1.1",
       "externalReferences": [
         {
@@ -18157,7 +18165,7 @@
       "type": "library",
       "name": "is-symbol",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-symbol@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-symbol@1.1.1",
       "purl": "pkg:npm/is-symbol@1.1.1",
       "externalReferences": [
         {
@@ -18187,7 +18195,7 @@
       "type": "library",
       "name": "is-typed-array",
       "version": "1.1.15",
-      "bom-ref": "nachet-frontend@0.10.3|is-typed-array@1.1.15",
+      "bom-ref": "nachet-frontend@0.10.4|is-typed-array@1.1.15",
       "purl": "pkg:npm/is-typed-array@1.1.15",
       "externalReferences": [
         {
@@ -18217,7 +18225,7 @@
       "type": "library",
       "name": "is-weakmap",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|is-weakmap@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|is-weakmap@2.0.2",
       "purl": "pkg:npm/is-weakmap@2.0.2",
       "externalReferences": [
         {
@@ -18247,7 +18255,7 @@
       "type": "library",
       "name": "is-weakref",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|is-weakref@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|is-weakref@1.1.1",
       "purl": "pkg:npm/is-weakref@1.1.1",
       "externalReferences": [
         {
@@ -18277,7 +18285,7 @@
       "type": "library",
       "name": "is-weakset",
       "version": "2.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|is-weakset@2.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|is-weakset@2.0.4",
       "purl": "pkg:npm/is-weakset@2.0.4",
       "externalReferences": [
         {
@@ -18307,7 +18315,7 @@
       "type": "library",
       "name": "is-wsl",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|is-wsl@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|is-wsl@2.2.0",
       "purl": "pkg:npm/is-wsl@2.2.0",
       "externalReferences": [
         {
@@ -18333,7 +18341,7 @@
       "type": "library",
       "name": "isarray",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|isarray@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|isarray@1.0.0",
       "purl": "pkg:npm/isarray@1.0.0",
       "externalReferences": [
         {
@@ -18359,7 +18367,7 @@
       "type": "library",
       "name": "isexe",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|isexe@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|isexe@2.0.0",
       "purl": "pkg:npm/isexe@2.0.0",
       "externalReferences": [
         {
@@ -18385,7 +18393,7 @@
       "type": "library",
       "name": "istanbul-lib-coverage",
       "version": "3.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|istanbul-lib-coverage@3.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|istanbul-lib-coverage@3.2.2",
       "purl": "pkg:npm/istanbul-lib-coverage@3.2.2",
       "externalReferences": [
         {
@@ -18415,7 +18423,7 @@
       "type": "library",
       "name": "istanbul-lib-report",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|istanbul-lib-report@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|istanbul-lib-report@3.0.1",
       "purl": "pkg:npm/istanbul-lib-report@3.0.1",
       "externalReferences": [
         {
@@ -18445,7 +18453,7 @@
       "type": "library",
       "name": "istanbul-lib-source-maps",
       "version": "5.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|istanbul-lib-source-maps@5.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|istanbul-lib-source-maps@5.0.6",
       "purl": "pkg:npm/istanbul-lib-source-maps@5.0.6",
       "externalReferences": [
         {
@@ -18475,7 +18483,7 @@
       "type": "library",
       "name": "istanbul-reports",
       "version": "3.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|istanbul-reports@3.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|istanbul-reports@3.2.0",
       "purl": "pkg:npm/istanbul-reports@3.2.0",
       "externalReferences": [
         {
@@ -18505,7 +18513,7 @@
       "type": "library",
       "name": "iterator.prototype",
       "version": "1.1.5",
-      "bom-ref": "nachet-frontend@0.10.3|iterator.prototype@1.1.5",
+      "bom-ref": "nachet-frontend@0.10.4|iterator.prototype@1.1.5",
       "purl": "pkg:npm/iterator.prototype@1.1.5",
       "externalReferences": [
         {
@@ -18535,7 +18543,7 @@
       "type": "library",
       "name": "jackspeak",
       "version": "3.4.3",
-      "bom-ref": "nachet-frontend@0.10.3|jackspeak@3.4.3",
+      "bom-ref": "nachet-frontend@0.10.4|jackspeak@3.4.3",
       "purl": "pkg:npm/jackspeak@3.4.3",
       "externalReferences": [
         {
@@ -18565,7 +18573,7 @@
       "type": "library",
       "name": "jest-environment-jsdom",
       "version": "30.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|jest-environment-jsdom@30.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|jest-environment-jsdom@30.1.2",
       "purl": "pkg:npm/jest-environment-jsdom@30.1.2",
       "externalReferences": [
         {
@@ -18595,7 +18603,7 @@
       "type": "library",
       "name": "jest-message-util",
       "version": "30.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0",
       "purl": "pkg:npm/jest-message-util@30.1.0",
       "externalReferences": [
         {
@@ -18625,7 +18633,7 @@
           "type": "library",
           "name": "ansi-styles",
           "version": "5.2.0",
-          "bom-ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0|ansi-styles@5.2.0",
+          "bom-ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0|ansi-styles@5.2.0",
           "purl": "pkg:npm/ansi-styles@5.2.0",
           "externalReferences": [
             {
@@ -18655,7 +18663,7 @@
           "type": "library",
           "name": "pretty-format",
           "version": "30.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0|pretty-format@30.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0|pretty-format@30.0.5",
           "purl": "pkg:npm/pretty-format@30.0.5",
           "externalReferences": [
             {
@@ -18685,7 +18693,7 @@
           "type": "library",
           "name": "react-is",
           "version": "18.3.1",
-          "bom-ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0|react-is@18.3.1",
+          "bom-ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0|react-is@18.3.1",
           "purl": "pkg:npm/react-is@18.3.1",
           "externalReferences": [
             {
@@ -18717,7 +18725,7 @@
       "type": "library",
       "name": "jest-mock",
       "version": "30.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|jest-mock@30.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|jest-mock@30.0.5",
       "purl": "pkg:npm/jest-mock@30.0.5",
       "externalReferences": [
         {
@@ -18747,7 +18755,7 @@
       "type": "library",
       "name": "jest-regex-util",
       "version": "30.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|jest-regex-util@30.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|jest-regex-util@30.0.1",
       "purl": "pkg:npm/jest-regex-util@30.0.1",
       "externalReferences": [
         {
@@ -18777,7 +18785,7 @@
       "type": "library",
       "name": "jest-util",
       "version": "30.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|jest-util@30.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|jest-util@30.0.5",
       "purl": "pkg:npm/jest-util@30.0.5",
       "externalReferences": [
         {
@@ -18807,7 +18815,7 @@
       "type": "library",
       "name": "js-base64",
       "version": "3.7.8",
-      "bom-ref": "nachet-frontend@0.10.3|js-base64@3.7.8",
+      "bom-ref": "nachet-frontend@0.10.4|js-base64@3.7.8",
       "purl": "pkg:npm/js-base64@3.7.8",
       "externalReferences": [
         {
@@ -18833,7 +18841,7 @@
       "type": "library",
       "name": "js-cookie",
       "version": "3.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|js-cookie@3.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|js-cookie@3.0.5",
       "purl": "pkg:npm/js-cookie@3.0.5",
       "externalReferences": [
         {
@@ -18859,7 +18867,7 @@
       "type": "library",
       "name": "js-tokens",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|js-tokens@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|js-tokens@4.0.0",
       "purl": "pkg:npm/js-tokens@4.0.0",
       "externalReferences": [
         {
@@ -18885,7 +18893,7 @@
       "type": "library",
       "name": "js-yaml",
       "version": "4.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|js-yaml@4.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|js-yaml@4.1.0",
       "purl": "pkg:npm/js-yaml@4.1.0",
       "externalReferences": [
         {
@@ -18915,7 +18923,7 @@
       "type": "library",
       "name": "jsdom",
       "version": "26.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|jsdom@26.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|jsdom@26.1.0",
       "purl": "pkg:npm/jsdom@26.1.0",
       "externalReferences": [
         {
@@ -18945,7 +18953,7 @@
       "type": "library",
       "name": "jsesc",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|jsesc@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|jsesc@3.1.0",
       "purl": "pkg:npm/jsesc@3.1.0",
       "externalReferences": [
         {
@@ -18971,7 +18979,7 @@
       "type": "library",
       "name": "json-buffer",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|json-buffer@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|json-buffer@3.0.1",
       "purl": "pkg:npm/json-buffer@3.0.1",
       "externalReferences": [
         {
@@ -19001,7 +19009,7 @@
       "type": "library",
       "name": "json-parse-even-better-errors",
       "version": "2.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|json-parse-even-better-errors@2.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|json-parse-even-better-errors@2.3.1",
       "purl": "pkg:npm/json-parse-even-better-errors@2.3.1",
       "externalReferences": [
         {
@@ -19027,7 +19035,7 @@
       "type": "library",
       "name": "json-schema-traverse",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|json-schema-traverse@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|json-schema-traverse@1.0.0",
       "purl": "pkg:npm/json-schema-traverse@1.0.0",
       "externalReferences": [
         {
@@ -19053,7 +19061,7 @@
       "type": "library",
       "name": "json-stable-stringify-without-jsonify",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|json-stable-stringify-without-jsonify@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|json-stable-stringify-without-jsonify@1.0.1",
       "purl": "pkg:npm/json-stable-stringify-without-jsonify@1.0.1",
       "externalReferences": [
         {
@@ -19083,7 +19091,7 @@
       "type": "library",
       "name": "json5",
       "version": "2.2.3",
-      "bom-ref": "nachet-frontend@0.10.3|json5@2.2.3",
+      "bom-ref": "nachet-frontend@0.10.4|json5@2.2.3",
       "purl": "pkg:npm/json5@2.2.3",
       "externalReferences": [
         {
@@ -19109,7 +19117,7 @@
       "type": "library",
       "name": "jsx-ast-utils",
       "version": "3.3.5",
-      "bom-ref": "nachet-frontend@0.10.3|jsx-ast-utils@3.3.5",
+      "bom-ref": "nachet-frontend@0.10.4|jsx-ast-utils@3.3.5",
       "purl": "pkg:npm/jsx-ast-utils@3.3.5",
       "externalReferences": [
         {
@@ -19139,7 +19147,7 @@
       "type": "library",
       "name": "jszip",
       "version": "3.10.1",
-      "bom-ref": "nachet-frontend@0.10.3|jszip@3.10.1",
+      "bom-ref": "nachet-frontend@0.10.4|jszip@3.10.1",
       "purl": "pkg:npm/jszip@3.10.1",
       "externalReferences": [
         {
@@ -19165,7 +19173,7 @@
           "type": "library",
           "name": "pako",
           "version": "1.0.11",
-          "bom-ref": "nachet-frontend@0.10.3|jszip@3.10.1|pako@1.0.11",
+          "bom-ref": "nachet-frontend@0.10.4|jszip@3.10.1|pako@1.0.11",
           "purl": "pkg:npm/pako@1.0.11",
           "externalReferences": [
             {
@@ -19193,7 +19201,7 @@
       "type": "library",
       "name": "jwt-decode",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|jwt-decode@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|jwt-decode@4.0.0",
       "purl": "pkg:npm/jwt-decode@4.0.0",
       "externalReferences": [
         {
@@ -19219,7 +19227,7 @@
       "type": "library",
       "name": "keyv",
       "version": "4.5.4",
-      "bom-ref": "nachet-frontend@0.10.3|keyv@4.5.4",
+      "bom-ref": "nachet-frontend@0.10.4|keyv@4.5.4",
       "purl": "pkg:npm/keyv@4.5.4",
       "externalReferences": [
         {
@@ -19249,7 +19257,7 @@
       "type": "library",
       "name": "levn",
       "version": "0.4.1",
-      "bom-ref": "nachet-frontend@0.10.3|levn@0.4.1",
+      "bom-ref": "nachet-frontend@0.10.4|levn@0.4.1",
       "purl": "pkg:npm/levn@0.4.1",
       "externalReferences": [
         {
@@ -19279,7 +19287,7 @@
       "type": "library",
       "name": "libxmljs2",
       "version": "0.37.0",
-      "bom-ref": "nachet-frontend@0.10.3|libxmljs2@0.37.0",
+      "bom-ref": "nachet-frontend@0.10.4|libxmljs2@0.37.0",
       "scope": "optional",
       "purl": "pkg:npm/libxmljs2@0.37.0",
       "externalReferences": [
@@ -19310,7 +19318,7 @@
       "type": "library",
       "name": "lie",
       "version": "3.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|lie@3.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|lie@3.3.0",
       "purl": "pkg:npm/lie@3.3.0",
       "externalReferences": [
         {
@@ -19336,7 +19344,7 @@
       "type": "library",
       "name": "lines-and-columns",
       "version": "1.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|lines-and-columns@1.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|lines-and-columns@1.2.4",
       "purl": "pkg:npm/lines-and-columns@1.2.4",
       "externalReferences": [
         {
@@ -19362,7 +19370,7 @@
       "type": "library",
       "name": "locate-path",
       "version": "6.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|locate-path@6.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|locate-path@6.0.0",
       "purl": "pkg:npm/locate-path@6.0.0",
       "externalReferences": [
         {
@@ -19392,7 +19400,7 @@
       "type": "library",
       "name": "lodash.debounce",
       "version": "4.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|lodash.debounce@4.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|lodash.debounce@4.0.8",
       "purl": "pkg:npm/lodash.debounce@4.0.8",
       "externalReferences": [
         {
@@ -19422,7 +19430,7 @@
       "type": "library",
       "name": "lodash.merge",
       "version": "4.6.2",
-      "bom-ref": "nachet-frontend@0.10.3|lodash.merge@4.6.2",
+      "bom-ref": "nachet-frontend@0.10.4|lodash.merge@4.6.2",
       "purl": "pkg:npm/lodash.merge@4.6.2",
       "externalReferences": [
         {
@@ -19452,7 +19460,7 @@
       "type": "library",
       "name": "lodash",
       "version": "4.17.21",
-      "bom-ref": "nachet-frontend@0.10.3|lodash@4.17.21",
+      "bom-ref": "nachet-frontend@0.10.4|lodash@4.17.21",
       "purl": "pkg:npm/lodash@4.17.21",
       "externalReferences": [
         {
@@ -19478,7 +19486,7 @@
       "type": "library",
       "name": "loose-envify",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|loose-envify@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|loose-envify@1.4.0",
       "purl": "pkg:npm/loose-envify@1.4.0",
       "externalReferences": [
         {
@@ -19504,7 +19512,7 @@
       "type": "library",
       "name": "loupe",
       "version": "3.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|loupe@3.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|loupe@3.2.1",
       "purl": "pkg:npm/loupe@3.2.1",
       "externalReferences": [
         {
@@ -19534,7 +19542,7 @@
       "type": "library",
       "name": "lru-cache",
       "version": "5.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|lru-cache@5.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|lru-cache@5.1.1",
       "purl": "pkg:npm/lru-cache@5.1.1",
       "externalReferences": [
         {
@@ -19560,7 +19568,7 @@
       "type": "library",
       "name": "lz-string",
       "version": "1.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|lz-string@1.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|lz-string@1.5.0",
       "purl": "pkg:npm/lz-string@1.5.0",
       "externalReferences": [
         {
@@ -19590,7 +19598,7 @@
       "type": "library",
       "name": "magic-string",
       "version": "0.30.19",
-      "bom-ref": "nachet-frontend@0.10.3|magic-string@0.30.19",
+      "bom-ref": "nachet-frontend@0.10.4|magic-string@0.30.19",
       "purl": "pkg:npm/magic-string@0.30.19",
       "externalReferences": [
         {
@@ -19620,7 +19628,7 @@
       "type": "library",
       "name": "magicast",
       "version": "0.3.5",
-      "bom-ref": "nachet-frontend@0.10.3|magicast@0.3.5",
+      "bom-ref": "nachet-frontend@0.10.4|magicast@0.3.5",
       "purl": "pkg:npm/magicast@0.3.5",
       "externalReferences": [
         {
@@ -19650,7 +19658,7 @@
       "type": "library",
       "name": "make-dir",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|make-dir@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|make-dir@4.0.0",
       "purl": "pkg:npm/make-dir@4.0.0",
       "externalReferences": [
         {
@@ -19680,7 +19688,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|make-dir@4.0.0|semver@7.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|make-dir@4.0.0|semver@7.7.2",
           "purl": "pkg:npm/semver@7.7.2",
           "externalReferences": [
             {
@@ -19712,7 +19720,7 @@
       "type": "library",
       "name": "make-fetch-happen",
       "version": "14.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|make-fetch-happen@14.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|make-fetch-happen@14.0.3",
       "scope": "optional",
       "purl": "pkg:npm/make-fetch-happen@14.0.3",
       "externalReferences": [
@@ -19743,7 +19751,7 @@
       "type": "library",
       "name": "math-intrinsics",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|math-intrinsics@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|math-intrinsics@1.1.0",
       "purl": "pkg:npm/math-intrinsics@1.1.0",
       "externalReferences": [
         {
@@ -19769,7 +19777,7 @@
       "type": "library",
       "name": "media-typer",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|media-typer@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|media-typer@1.1.0",
       "purl": "pkg:npm/media-typer@1.1.0",
       "externalReferences": [
         {
@@ -19795,7 +19803,7 @@
       "type": "library",
       "name": "merge-descriptors",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|merge-descriptors@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|merge-descriptors@2.0.0",
       "purl": "pkg:npm/merge-descriptors@2.0.0",
       "externalReferences": [
         {
@@ -19821,7 +19829,7 @@
       "type": "library",
       "name": "merge-stream",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|merge-stream@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|merge-stream@2.0.0",
       "purl": "pkg:npm/merge-stream@2.0.0",
       "externalReferences": [
         {
@@ -19847,7 +19855,7 @@
       "type": "library",
       "name": "merge2",
       "version": "1.4.1",
-      "bom-ref": "nachet-frontend@0.10.3|merge2@1.4.1",
+      "bom-ref": "nachet-frontend@0.10.4|merge2@1.4.1",
       "purl": "pkg:npm/merge2@1.4.1",
       "externalReferences": [
         {
@@ -19877,7 +19885,7 @@
       "type": "library",
       "name": "micromatch",
       "version": "4.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|micromatch@4.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|micromatch@4.0.8",
       "purl": "pkg:npm/micromatch@4.0.8",
       "externalReferences": [
         {
@@ -19907,7 +19915,7 @@
           "type": "library",
           "name": "picomatch",
           "version": "2.3.1",
-          "bom-ref": "nachet-frontend@0.10.3|micromatch@4.0.8|picomatch@2.3.1",
+          "bom-ref": "nachet-frontend@0.10.4|micromatch@4.0.8|picomatch@2.3.1",
           "purl": "pkg:npm/picomatch@2.3.1",
           "externalReferences": [
             {
@@ -19939,7 +19947,7 @@
       "type": "library",
       "name": "mime-db",
       "version": "1.54.0",
-      "bom-ref": "nachet-frontend@0.10.3|mime-db@1.54.0",
+      "bom-ref": "nachet-frontend@0.10.4|mime-db@1.54.0",
       "purl": "pkg:npm/mime-db@1.54.0",
       "externalReferences": [
         {
@@ -19965,7 +19973,7 @@
       "type": "library",
       "name": "mime-types",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|mime-types@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|mime-types@3.0.1",
       "purl": "pkg:npm/mime-types@3.0.1",
       "externalReferences": [
         {
@@ -19991,7 +19999,7 @@
       "type": "library",
       "name": "mimic-fn",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|mimic-fn@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|mimic-fn@2.1.0",
       "purl": "pkg:npm/mimic-fn@2.1.0",
       "externalReferences": [
         {
@@ -20017,7 +20025,7 @@
       "type": "library",
       "name": "mimic-response",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|mimic-response@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|mimic-response@3.1.0",
       "scope": "optional",
       "purl": "pkg:npm/mimic-response@3.1.0",
       "externalReferences": [
@@ -20048,7 +20056,7 @@
       "type": "library",
       "name": "min-indent",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|min-indent@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|min-indent@1.0.1",
       "purl": "pkg:npm/min-indent@1.0.1",
       "externalReferences": [
         {
@@ -20074,7 +20082,7 @@
       "type": "library",
       "name": "minimatch",
       "version": "3.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|minimatch@3.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|minimatch@3.1.2",
       "purl": "pkg:npm/minimatch@3.1.2",
       "externalReferences": [
         {
@@ -20100,7 +20108,7 @@
       "type": "library",
       "name": "minimist",
       "version": "1.2.8",
-      "bom-ref": "nachet-frontend@0.10.3|minimist@1.2.8",
+      "bom-ref": "nachet-frontend@0.10.4|minimist@1.2.8",
       "purl": "pkg:npm/minimist@1.2.8",
       "externalReferences": [
         {
@@ -20126,7 +20134,7 @@
       "type": "library",
       "name": "minipass-collect",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|minipass-collect@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|minipass-collect@2.0.1",
       "scope": "optional",
       "purl": "pkg:npm/minipass-collect@2.0.1",
       "externalReferences": [
@@ -20157,7 +20165,7 @@
       "type": "library",
       "name": "minipass-fetch",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|minipass-fetch@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|minipass-fetch@4.0.1",
       "scope": "optional",
       "purl": "pkg:npm/minipass-fetch@4.0.1",
       "externalReferences": [
@@ -20188,7 +20196,7 @@
       "type": "library",
       "name": "minipass-flush",
       "version": "1.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|minipass-flush@1.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|minipass-flush@1.0.5",
       "scope": "optional",
       "purl": "pkg:npm/minipass-flush@1.0.5",
       "externalReferences": [
@@ -20219,7 +20227,7 @@
           "type": "library",
           "name": "minipass",
           "version": "3.3.6",
-          "bom-ref": "nachet-frontend@0.10.3|minipass-flush@1.0.5|minipass@3.3.6",
+          "bom-ref": "nachet-frontend@0.10.4|minipass-flush@1.0.5|minipass@3.3.6",
           "scope": "optional",
           "purl": "pkg:npm/minipass@3.3.6",
           "externalReferences": [
@@ -20250,7 +20258,7 @@
           "type": "library",
           "name": "yallist",
           "version": "4.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|minipass-flush@1.0.5|yallist@4.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|minipass-flush@1.0.5|yallist@4.0.0",
           "scope": "optional",
           "purl": "pkg:npm/yallist@4.0.0",
           "externalReferences": [
@@ -20283,7 +20291,7 @@
       "type": "library",
       "name": "minipass-pipeline",
       "version": "1.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|minipass-pipeline@1.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|minipass-pipeline@1.2.4",
       "scope": "optional",
       "purl": "pkg:npm/minipass-pipeline@1.2.4",
       "externalReferences": [
@@ -20314,7 +20322,7 @@
           "type": "library",
           "name": "minipass",
           "version": "3.3.6",
-          "bom-ref": "nachet-frontend@0.10.3|minipass-pipeline@1.2.4|minipass@3.3.6",
+          "bom-ref": "nachet-frontend@0.10.4|minipass-pipeline@1.2.4|minipass@3.3.6",
           "scope": "optional",
           "purl": "pkg:npm/minipass@3.3.6",
           "externalReferences": [
@@ -20345,7 +20353,7 @@
           "type": "library",
           "name": "yallist",
           "version": "4.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|minipass-pipeline@1.2.4|yallist@4.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|minipass-pipeline@1.2.4|yallist@4.0.0",
           "scope": "optional",
           "purl": "pkg:npm/yallist@4.0.0",
           "externalReferences": [
@@ -20378,7 +20386,7 @@
       "type": "library",
       "name": "minipass-sized",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|minipass-sized@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|minipass-sized@1.0.3",
       "scope": "optional",
       "purl": "pkg:npm/minipass-sized@1.0.3",
       "externalReferences": [
@@ -20409,7 +20417,7 @@
           "type": "library",
           "name": "minipass",
           "version": "3.3.6",
-          "bom-ref": "nachet-frontend@0.10.3|minipass-sized@1.0.3|minipass@3.3.6",
+          "bom-ref": "nachet-frontend@0.10.4|minipass-sized@1.0.3|minipass@3.3.6",
           "scope": "optional",
           "purl": "pkg:npm/minipass@3.3.6",
           "externalReferences": [
@@ -20440,7 +20448,7 @@
           "type": "library",
           "name": "yallist",
           "version": "4.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|minipass-sized@1.0.3|yallist@4.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|minipass-sized@1.0.3|yallist@4.0.0",
           "scope": "optional",
           "purl": "pkg:npm/yallist@4.0.0",
           "externalReferences": [
@@ -20473,7 +20481,7 @@
       "type": "library",
       "name": "minipass",
       "version": "7.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|minipass@7.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|minipass@7.1.2",
       "purl": "pkg:npm/minipass@7.1.2",
       "externalReferences": [
         {
@@ -20503,7 +20511,7 @@
       "type": "library",
       "name": "minizlib",
       "version": "3.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|minizlib@3.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|minizlib@3.0.2",
       "scope": "optional",
       "purl": "pkg:npm/minizlib@3.0.2",
       "externalReferences": [
@@ -20534,7 +20542,7 @@
       "type": "library",
       "name": "mkdirp-classic",
       "version": "0.5.3",
-      "bom-ref": "nachet-frontend@0.10.3|mkdirp-classic@0.5.3",
+      "bom-ref": "nachet-frontend@0.10.4|mkdirp-classic@0.5.3",
       "scope": "optional",
       "purl": "pkg:npm/mkdirp-classic@0.5.3",
       "externalReferences": [
@@ -20565,7 +20573,7 @@
       "type": "library",
       "name": "mkdirp",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|mkdirp@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|mkdirp@3.0.1",
       "scope": "optional",
       "purl": "pkg:npm/mkdirp@3.0.1",
       "externalReferences": [
@@ -20596,7 +20604,7 @@
       "type": "library",
       "name": "moo",
       "version": "0.5.2",
-      "bom-ref": "nachet-frontend@0.10.3|moo@0.5.2",
+      "bom-ref": "nachet-frontend@0.10.4|moo@0.5.2",
       "scope": "optional",
       "purl": "pkg:npm/moo@0.5.2",
       "externalReferences": [
@@ -20627,7 +20635,7 @@
       "type": "library",
       "name": "ms",
       "version": "2.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|ms@2.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|ms@2.1.3",
       "purl": "pkg:npm/ms@2.1.3",
       "externalReferences": [
         {
@@ -20653,7 +20661,7 @@
       "type": "library",
       "name": "nan",
       "version": "2.22.2",
-      "bom-ref": "nachet-frontend@0.10.3|nan@2.22.2",
+      "bom-ref": "nachet-frontend@0.10.4|nan@2.22.2",
       "scope": "optional",
       "purl": "pkg:npm/nan@2.22.2",
       "externalReferences": [
@@ -20684,7 +20692,7 @@
       "type": "library",
       "name": "nanoid",
       "version": "3.3.11",
-      "bom-ref": "nachet-frontend@0.10.3|nanoid@3.3.11",
+      "bom-ref": "nachet-frontend@0.10.4|nanoid@3.3.11",
       "purl": "pkg:npm/nanoid@3.3.11",
       "externalReferences": [
         {
@@ -20710,7 +20718,7 @@
       "type": "library",
       "name": "napi-build-utils",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|napi-build-utils@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|napi-build-utils@2.0.0",
       "scope": "optional",
       "purl": "pkg:npm/napi-build-utils@2.0.0",
       "externalReferences": [
@@ -20741,7 +20749,7 @@
       "type": "library",
       "name": "natural-compare",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|natural-compare@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|natural-compare@1.4.0",
       "purl": "pkg:npm/natural-compare@1.4.0",
       "externalReferences": [
         {
@@ -20771,7 +20779,7 @@
       "type": "library",
       "name": "nearley",
       "version": "2.20.1",
-      "bom-ref": "nachet-frontend@0.10.3|nearley@2.20.1",
+      "bom-ref": "nachet-frontend@0.10.4|nearley@2.20.1",
       "scope": "optional",
       "purl": "pkg:npm/nearley@2.20.1",
       "externalReferences": [
@@ -20802,7 +20810,7 @@
           "type": "library",
           "name": "commander",
           "version": "2.20.3",
-          "bom-ref": "nachet-frontend@0.10.3|nearley@2.20.1|commander@2.20.3",
+          "bom-ref": "nachet-frontend@0.10.4|nearley@2.20.1|commander@2.20.3",
           "scope": "optional",
           "purl": "pkg:npm/commander@2.20.3",
           "externalReferences": [
@@ -20835,7 +20843,7 @@
       "type": "library",
       "name": "negotiator",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|negotiator@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|negotiator@1.0.0",
       "purl": "pkg:npm/negotiator@1.0.0",
       "externalReferences": [
         {
@@ -20861,7 +20869,7 @@
       "type": "library",
       "name": "node-abi",
       "version": "3.77.0",
-      "bom-ref": "nachet-frontend@0.10.3|node-abi@3.77.0",
+      "bom-ref": "nachet-frontend@0.10.4|node-abi@3.77.0",
       "scope": "optional",
       "purl": "pkg:npm/node-abi@3.77.0",
       "externalReferences": [
@@ -20892,7 +20900,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|node-abi@3.77.0|semver@7.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|node-abi@3.77.0|semver@7.7.2",
           "scope": "optional",
           "purl": "pkg:npm/semver@7.7.2",
           "externalReferences": [
@@ -20925,7 +20933,7 @@
       "type": "library",
       "name": "node-domexception",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|node-domexception@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|node-domexception@1.0.0",
       "purl": "pkg:npm/node-domexception@1.0.0",
       "externalReferences": [
         {
@@ -20955,7 +20963,7 @@
       "type": "library",
       "name": "node-fetch",
       "version": "3.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|node-fetch@3.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|node-fetch@3.3.2",
       "purl": "pkg:npm/node-fetch@3.3.2",
       "externalReferences": [
         {
@@ -20985,7 +20993,7 @@
       "type": "library",
       "name": "node-gyp",
       "version": "11.4.2",
-      "bom-ref": "nachet-frontend@0.10.3|node-gyp@11.4.2",
+      "bom-ref": "nachet-frontend@0.10.4|node-gyp@11.4.2",
       "scope": "optional",
       "purl": "pkg:npm/node-gyp@11.4.2",
       "externalReferences": [
@@ -21016,7 +21024,7 @@
           "type": "library",
           "name": "isexe",
           "version": "3.1.1",
-          "bom-ref": "nachet-frontend@0.10.3|node-gyp@11.4.2|isexe@3.1.1",
+          "bom-ref": "nachet-frontend@0.10.4|node-gyp@11.4.2|isexe@3.1.1",
           "scope": "optional",
           "purl": "pkg:npm/isexe@3.1.1",
           "externalReferences": [
@@ -21047,7 +21055,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|node-gyp@11.4.2|semver@7.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|node-gyp@11.4.2|semver@7.7.2",
           "scope": "optional",
           "purl": "pkg:npm/semver@7.7.2",
           "externalReferences": [
@@ -21078,7 +21086,7 @@
           "type": "library",
           "name": "which",
           "version": "5.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|node-gyp@11.4.2|which@5.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|node-gyp@11.4.2|which@5.0.0",
           "scope": "optional",
           "purl": "pkg:npm/which@5.0.0",
           "externalReferences": [
@@ -21111,7 +21119,7 @@
       "type": "library",
       "name": "node-releases",
       "version": "2.0.21",
-      "bom-ref": "nachet-frontend@0.10.3|node-releases@2.0.21",
+      "bom-ref": "nachet-frontend@0.10.4|node-releases@2.0.21",
       "purl": "pkg:npm/node-releases@2.0.21",
       "externalReferences": [
         {
@@ -21137,7 +21145,7 @@
       "type": "library",
       "name": "nopt",
       "version": "8.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|nopt@8.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|nopt@8.1.0",
       "scope": "optional",
       "purl": "pkg:npm/nopt@8.1.0",
       "externalReferences": [
@@ -21168,7 +21176,7 @@
       "type": "library",
       "name": "normalize-package-data",
       "version": "8.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|normalize-package-data@8.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|normalize-package-data@8.0.0",
       "purl": "pkg:npm/normalize-package-data@8.0.0",
       "externalReferences": [
         {
@@ -21198,7 +21206,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.2",
-          "bom-ref": "nachet-frontend@0.10.3|normalize-package-data@8.0.0|semver@7.7.2",
+          "bom-ref": "nachet-frontend@0.10.4|normalize-package-data@8.0.0|semver@7.7.2",
           "purl": "pkg:npm/semver@7.7.2",
           "externalReferences": [
             {
@@ -21230,7 +21238,7 @@
       "type": "library",
       "name": "npm-run-path",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|npm-run-path@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|npm-run-path@4.0.1",
       "purl": "pkg:npm/npm-run-path@4.0.1",
       "externalReferences": [
         {
@@ -21256,7 +21264,7 @@
       "type": "library",
       "name": "nwsapi",
       "version": "2.2.22",
-      "bom-ref": "nachet-frontend@0.10.3|nwsapi@2.2.22",
+      "bom-ref": "nachet-frontend@0.10.4|nwsapi@2.2.22",
       "purl": "pkg:npm/nwsapi@2.2.22",
       "externalReferences": [
         {
@@ -21286,7 +21294,7 @@
       "type": "library",
       "name": "object-assign",
       "version": "4.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|object-assign@4.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|object-assign@4.1.1",
       "purl": "pkg:npm/object-assign@4.1.1",
       "externalReferences": [
         {
@@ -21312,7 +21320,7 @@
       "type": "library",
       "name": "object-inspect",
       "version": "1.13.4",
-      "bom-ref": "nachet-frontend@0.10.3|object-inspect@1.13.4",
+      "bom-ref": "nachet-frontend@0.10.4|object-inspect@1.13.4",
       "purl": "pkg:npm/object-inspect@1.13.4",
       "externalReferences": [
         {
@@ -21338,7 +21346,7 @@
       "type": "library",
       "name": "object-keys",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|object-keys@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|object-keys@1.1.1",
       "purl": "pkg:npm/object-keys@1.1.1",
       "externalReferences": [
         {
@@ -21368,7 +21376,7 @@
       "type": "library",
       "name": "object.assign",
       "version": "4.1.7",
-      "bom-ref": "nachet-frontend@0.10.3|object.assign@4.1.7",
+      "bom-ref": "nachet-frontend@0.10.4|object.assign@4.1.7",
       "purl": "pkg:npm/object.assign@4.1.7",
       "externalReferences": [
         {
@@ -21398,7 +21406,7 @@
       "type": "library",
       "name": "object.entries",
       "version": "1.1.9",
-      "bom-ref": "nachet-frontend@0.10.3|object.entries@1.1.9",
+      "bom-ref": "nachet-frontend@0.10.4|object.entries@1.1.9",
       "purl": "pkg:npm/object.entries@1.1.9",
       "externalReferences": [
         {
@@ -21428,7 +21436,7 @@
       "type": "library",
       "name": "object.fromentries",
       "version": "2.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|object.fromentries@2.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|object.fromentries@2.0.8",
       "purl": "pkg:npm/object.fromentries@2.0.8",
       "externalReferences": [
         {
@@ -21458,7 +21466,7 @@
       "type": "library",
       "name": "object.groupby",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|object.groupby@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|object.groupby@1.0.3",
       "purl": "pkg:npm/object.groupby@1.0.3",
       "externalReferences": [
         {
@@ -21488,7 +21496,7 @@
       "type": "library",
       "name": "object.values",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|object.values@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|object.values@1.2.1",
       "purl": "pkg:npm/object.values@1.2.1",
       "externalReferences": [
         {
@@ -21518,7 +21526,7 @@
       "type": "library",
       "name": "on-finished",
       "version": "2.4.1",
-      "bom-ref": "nachet-frontend@0.10.3|on-finished@2.4.1",
+      "bom-ref": "nachet-frontend@0.10.4|on-finished@2.4.1",
       "purl": "pkg:npm/on-finished@2.4.1",
       "externalReferences": [
         {
@@ -21544,7 +21552,7 @@
       "type": "library",
       "name": "on-headers",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|on-headers@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|on-headers@1.1.0",
       "purl": "pkg:npm/on-headers@1.1.0",
       "externalReferences": [
         {
@@ -21570,7 +21578,7 @@
       "type": "library",
       "name": "once",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|once@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|once@1.4.0",
       "purl": "pkg:npm/once@1.4.0",
       "externalReferences": [
         {
@@ -21596,7 +21604,7 @@
       "type": "library",
       "name": "onetime",
       "version": "5.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|onetime@5.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|onetime@5.1.2",
       "purl": "pkg:npm/onetime@5.1.2",
       "externalReferences": [
         {
@@ -21622,7 +21630,7 @@
       "type": "library",
       "name": "optionator",
       "version": "0.9.4",
-      "bom-ref": "nachet-frontend@0.10.3|optionator@0.9.4",
+      "bom-ref": "nachet-frontend@0.10.4|optionator@0.9.4",
       "purl": "pkg:npm/optionator@0.9.4",
       "externalReferences": [
         {
@@ -21652,7 +21660,7 @@
       "type": "library",
       "name": "own-keys",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|own-keys@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|own-keys@1.0.1",
       "purl": "pkg:npm/own-keys@1.0.1",
       "externalReferences": [
         {
@@ -21682,7 +21690,7 @@
       "type": "library",
       "name": "p-finally",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|p-finally@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|p-finally@1.0.0",
       "purl": "pkg:npm/p-finally@1.0.0",
       "externalReferences": [
         {
@@ -21708,7 +21716,7 @@
       "type": "library",
       "name": "p-limit",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|p-limit@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|p-limit@3.1.0",
       "purl": "pkg:npm/p-limit@3.1.0",
       "externalReferences": [
         {
@@ -21738,7 +21746,7 @@
       "type": "library",
       "name": "p-locate",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|p-locate@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|p-locate@5.0.0",
       "purl": "pkg:npm/p-locate@5.0.0",
       "externalReferences": [
         {
@@ -21768,7 +21776,7 @@
       "type": "library",
       "name": "p-map",
       "version": "7.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|p-map@7.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|p-map@7.0.3",
       "scope": "optional",
       "purl": "pkg:npm/p-map@7.0.3",
       "externalReferences": [
@@ -21799,7 +21807,7 @@
       "type": "library",
       "name": "package-json-from-dist",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|package-json-from-dist@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|package-json-from-dist@1.0.1",
       "purl": "pkg:npm/package-json-from-dist@1.0.1",
       "externalReferences": [
         {
@@ -21829,7 +21837,7 @@
       "type": "library",
       "name": "packageurl-js",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|packageurl-js@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|packageurl-js@2.0.1",
       "purl": "pkg:npm/packageurl-js@2.0.1",
       "externalReferences": [
         {
@@ -21859,7 +21867,7 @@
       "type": "library",
       "name": "pako",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|pako@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|pako@2.1.0",
       "purl": "pkg:npm/pako@2.1.0",
       "externalReferences": [
         {
@@ -21885,7 +21893,7 @@
       "type": "library",
       "name": "parent-module",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|parent-module@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|parent-module@1.0.1",
       "purl": "pkg:npm/parent-module@1.0.1",
       "externalReferences": [
         {
@@ -21911,7 +21919,7 @@
       "type": "library",
       "name": "parse-json",
       "version": "5.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|parse-json@5.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|parse-json@5.2.0",
       "purl": "pkg:npm/parse-json@5.2.0",
       "externalReferences": [
         {
@@ -21937,7 +21945,7 @@
       "type": "library",
       "name": "parse-srcset",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|parse-srcset@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|parse-srcset@1.0.2",
       "purl": "pkg:npm/parse-srcset@1.0.2",
       "externalReferences": [
         {
@@ -21963,7 +21971,7 @@
       "type": "library",
       "name": "parse5",
       "version": "7.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|parse5@7.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|parse5@7.3.0",
       "purl": "pkg:npm/parse5@7.3.0",
       "externalReferences": [
         {
@@ -21993,7 +22001,7 @@
           "type": "library",
           "name": "entities",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|parse5@7.3.0|entities@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|parse5@7.3.0|entities@6.0.1",
           "purl": "pkg:npm/entities@6.0.1",
           "externalReferences": [
             {
@@ -22025,7 +22033,7 @@
       "type": "library",
       "name": "parseurl",
       "version": "1.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|parseurl@1.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|parseurl@1.3.3",
       "purl": "pkg:npm/parseurl@1.3.3",
       "externalReferences": [
         {
@@ -22051,7 +22059,7 @@
       "type": "library",
       "name": "path-exists",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|path-exists@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|path-exists@4.0.0",
       "purl": "pkg:npm/path-exists@4.0.0",
       "externalReferences": [
         {
@@ -22081,7 +22089,7 @@
       "type": "library",
       "name": "path-is-absolute",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|path-is-absolute@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|path-is-absolute@1.0.1",
       "purl": "pkg:npm/path-is-absolute@1.0.1",
       "externalReferences": [
         {
@@ -22107,7 +22115,7 @@
       "type": "library",
       "name": "path-is-inside",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|path-is-inside@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|path-is-inside@1.0.2",
       "purl": "pkg:npm/path-is-inside@1.0.2",
       "externalReferences": [
         {
@@ -22133,7 +22141,7 @@
       "type": "library",
       "name": "path-key",
       "version": "3.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|path-key@3.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|path-key@3.1.1",
       "purl": "pkg:npm/path-key@3.1.1",
       "externalReferences": [
         {
@@ -22159,7 +22167,7 @@
       "type": "library",
       "name": "path-parse",
       "version": "1.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|path-parse@1.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|path-parse@1.0.7",
       "purl": "pkg:npm/path-parse@1.0.7",
       "externalReferences": [
         {
@@ -22185,7 +22193,7 @@
       "type": "library",
       "name": "path-scurry",
       "version": "1.11.1",
-      "bom-ref": "nachet-frontend@0.10.3|path-scurry@1.11.1",
+      "bom-ref": "nachet-frontend@0.10.4|path-scurry@1.11.1",
       "purl": "pkg:npm/path-scurry@1.11.1",
       "externalReferences": [
         {
@@ -22215,7 +22223,7 @@
           "type": "library",
           "name": "lru-cache",
           "version": "10.4.3",
-          "bom-ref": "nachet-frontend@0.10.3|path-scurry@1.11.1|lru-cache@10.4.3",
+          "bom-ref": "nachet-frontend@0.10.4|path-scurry@1.11.1|lru-cache@10.4.3",
           "purl": "pkg:npm/lru-cache@10.4.3",
           "externalReferences": [
             {
@@ -22247,7 +22255,7 @@
       "type": "library",
       "name": "path-to-regexp",
       "version": "8.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|path-to-regexp@8.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|path-to-regexp@8.3.0",
       "purl": "pkg:npm/path-to-regexp@8.3.0",
       "externalReferences": [
         {
@@ -22273,7 +22281,7 @@
       "type": "library",
       "name": "path-type",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|path-type@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|path-type@4.0.0",
       "purl": "pkg:npm/path-type@4.0.0",
       "externalReferences": [
         {
@@ -22299,7 +22307,7 @@
       "type": "library",
       "name": "pathe",
       "version": "2.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|pathe@2.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|pathe@2.0.3",
       "purl": "pkg:npm/pathe@2.0.3",
       "externalReferences": [
         {
@@ -22329,7 +22337,7 @@
       "type": "library",
       "name": "pathval",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|pathval@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|pathval@2.0.1",
       "purl": "pkg:npm/pathval@2.0.1",
       "externalReferences": [
         {
@@ -22359,7 +22367,7 @@
       "type": "library",
       "name": "picocolors",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|picocolors@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|picocolors@1.1.1",
       "purl": "pkg:npm/picocolors@1.1.1",
       "externalReferences": [
         {
@@ -22385,7 +22393,7 @@
       "type": "library",
       "name": "picomatch",
       "version": "4.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|picomatch@4.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|picomatch@4.0.3",
       "purl": "pkg:npm/picomatch@4.0.3",
       "externalReferences": [
         {
@@ -22415,7 +22423,7 @@
       "type": "library",
       "name": "playwright-core",
       "version": "1.55.0",
-      "bom-ref": "nachet-frontend@0.10.3|playwright-core@1.55.0",
+      "bom-ref": "nachet-frontend@0.10.4|playwright-core@1.55.0",
       "purl": "pkg:npm/playwright-core@1.55.0",
       "externalReferences": [
         {
@@ -22445,7 +22453,7 @@
       "type": "library",
       "name": "playwright",
       "version": "1.55.0",
-      "bom-ref": "nachet-frontend@0.10.3|playwright@1.55.0",
+      "bom-ref": "nachet-frontend@0.10.4|playwright@1.55.0",
       "purl": "pkg:npm/playwright@1.55.0",
       "externalReferences": [
         {
@@ -22475,7 +22483,7 @@
       "type": "library",
       "name": "possible-typed-array-names",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|possible-typed-array-names@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|possible-typed-array-names@1.1.0",
       "purl": "pkg:npm/possible-typed-array-names@1.1.0",
       "externalReferences": [
         {
@@ -22505,7 +22513,7 @@
       "type": "library",
       "name": "postcss-value-parser",
       "version": "4.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|postcss-value-parser@4.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|postcss-value-parser@4.2.0",
       "purl": "pkg:npm/postcss-value-parser@4.2.0",
       "externalReferences": [
         {
@@ -22531,7 +22539,7 @@
       "type": "library",
       "name": "postcss",
       "version": "8.5.6",
-      "bom-ref": "nachet-frontend@0.10.3|postcss@8.5.6",
+      "bom-ref": "nachet-frontend@0.10.4|postcss@8.5.6",
       "purl": "pkg:npm/postcss@8.5.6",
       "externalReferences": [
         {
@@ -22557,7 +22565,7 @@
       "type": "library",
       "name": "prebuild-install",
       "version": "7.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|prebuild-install@7.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|prebuild-install@7.1.3",
       "scope": "optional",
       "purl": "pkg:npm/prebuild-install@7.1.3",
       "externalReferences": [
@@ -22588,7 +22596,7 @@
       "type": "library",
       "name": "prelude-ls",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|prelude-ls@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|prelude-ls@1.2.1",
       "purl": "pkg:npm/prelude-ls@1.2.1",
       "externalReferences": [
         {
@@ -22618,7 +22626,7 @@
       "type": "library",
       "name": "prettier-linter-helpers",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|prettier-linter-helpers@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|prettier-linter-helpers@1.0.0",
       "purl": "pkg:npm/prettier-linter-helpers@1.0.0",
       "externalReferences": [
         {
@@ -22648,7 +22656,7 @@
       "type": "library",
       "name": "prettier",
       "version": "3.6.2",
-      "bom-ref": "nachet-frontend@0.10.3|prettier@3.6.2",
+      "bom-ref": "nachet-frontend@0.10.4|prettier@3.6.2",
       "purl": "pkg:npm/prettier@3.6.2",
       "externalReferences": [
         {
@@ -22678,7 +22686,7 @@
       "type": "library",
       "name": "pretty-format",
       "version": "27.5.1",
-      "bom-ref": "nachet-frontend@0.10.3|pretty-format@27.5.1",
+      "bom-ref": "nachet-frontend@0.10.4|pretty-format@27.5.1",
       "purl": "pkg:npm/pretty-format@27.5.1",
       "externalReferences": [
         {
@@ -22708,7 +22716,7 @@
           "type": "library",
           "name": "ansi-styles",
           "version": "5.2.0",
-          "bom-ref": "nachet-frontend@0.10.3|pretty-format@27.5.1|ansi-styles@5.2.0",
+          "bom-ref": "nachet-frontend@0.10.4|pretty-format@27.5.1|ansi-styles@5.2.0",
           "purl": "pkg:npm/ansi-styles@5.2.0",
           "externalReferences": [
             {
@@ -22738,7 +22746,7 @@
           "type": "library",
           "name": "react-is",
           "version": "17.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|pretty-format@27.5.1|react-is@17.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|pretty-format@27.5.1|react-is@17.0.2",
           "purl": "pkg:npm/react-is@17.0.2",
           "externalReferences": [
             {
@@ -22770,7 +22778,7 @@
       "type": "library",
       "name": "proc-log",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|proc-log@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|proc-log@5.0.0",
       "scope": "optional",
       "purl": "pkg:npm/proc-log@5.0.0",
       "externalReferences": [
@@ -22801,7 +22809,7 @@
       "type": "library",
       "name": "process-nextick-args",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|process-nextick-args@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|process-nextick-args@2.0.1",
       "purl": "pkg:npm/process-nextick-args@2.0.1",
       "externalReferences": [
         {
@@ -22827,7 +22835,7 @@
       "type": "library",
       "name": "promise-retry",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|promise-retry@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|promise-retry@2.0.1",
       "scope": "optional",
       "purl": "pkg:npm/promise-retry@2.0.1",
       "externalReferences": [
@@ -22858,7 +22866,7 @@
       "type": "library",
       "name": "prop-types",
       "version": "15.8.1",
-      "bom-ref": "nachet-frontend@0.10.3|prop-types@15.8.1",
+      "bom-ref": "nachet-frontend@0.10.4|prop-types@15.8.1",
       "purl": "pkg:npm/prop-types@15.8.1",
       "externalReferences": [
         {
@@ -22884,7 +22892,7 @@
           "type": "library",
           "name": "react-is",
           "version": "16.13.1",
-          "bom-ref": "nachet-frontend@0.10.3|prop-types@15.8.1|react-is@16.13.1",
+          "bom-ref": "nachet-frontend@0.10.4|prop-types@15.8.1|react-is@16.13.1",
           "purl": "pkg:npm/react-is@16.13.1",
           "externalReferences": [
             {
@@ -22912,7 +22920,7 @@
       "type": "library",
       "name": "proxy-addr",
       "version": "2.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|proxy-addr@2.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|proxy-addr@2.0.7",
       "purl": "pkg:npm/proxy-addr@2.0.7",
       "externalReferences": [
         {
@@ -22938,7 +22946,7 @@
       "type": "library",
       "name": "proxy-from-env",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|proxy-from-env@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|proxy-from-env@1.1.0",
       "purl": "pkg:npm/proxy-from-env@1.1.0",
       "externalReferences": [
         {
@@ -22964,7 +22972,7 @@
       "type": "library",
       "name": "pump",
       "version": "3.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|pump@3.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|pump@3.0.3",
       "purl": "pkg:npm/pump@3.0.3",
       "externalReferences": [
         {
@@ -22990,7 +22998,7 @@
       "type": "library",
       "name": "punycode",
       "version": "2.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|punycode@2.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|punycode@2.3.1",
       "purl": "pkg:npm/punycode@2.3.1",
       "externalReferences": [
         {
@@ -23016,7 +23024,7 @@
       "type": "library",
       "name": "qs",
       "version": "6.14.0",
-      "bom-ref": "nachet-frontend@0.10.3|qs@6.14.0",
+      "bom-ref": "nachet-frontend@0.10.4|qs@6.14.0",
       "purl": "pkg:npm/qs@6.14.0",
       "externalReferences": [
         {
@@ -23042,7 +23050,7 @@
       "type": "library",
       "name": "queue-microtask",
       "version": "1.2.3",
-      "bom-ref": "nachet-frontend@0.10.3|queue-microtask@1.2.3",
+      "bom-ref": "nachet-frontend@0.10.4|queue-microtask@1.2.3",
       "purl": "pkg:npm/queue-microtask@1.2.3",
       "externalReferences": [
         {
@@ -23072,7 +23080,7 @@
       "type": "library",
       "name": "railroad-diagrams",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|railroad-diagrams@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|railroad-diagrams@1.0.0",
       "scope": "optional",
       "purl": "pkg:npm/railroad-diagrams@1.0.0",
       "externalReferences": [
@@ -23103,7 +23111,7 @@
       "type": "library",
       "name": "randexp",
       "version": "0.4.6",
-      "bom-ref": "nachet-frontend@0.10.3|randexp@0.4.6",
+      "bom-ref": "nachet-frontend@0.10.4|randexp@0.4.6",
       "scope": "optional",
       "purl": "pkg:npm/randexp@0.4.6",
       "externalReferences": [
@@ -23134,7 +23142,7 @@
       "type": "library",
       "name": "range-parser",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|range-parser@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|range-parser@1.2.1",
       "purl": "pkg:npm/range-parser@1.2.1",
       "externalReferences": [
         {
@@ -23160,7 +23168,7 @@
       "type": "library",
       "name": "raw-body",
       "version": "3.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|raw-body@3.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|raw-body@3.0.1",
       "purl": "pkg:npm/raw-body@3.0.1",
       "externalReferences": [
         {
@@ -23186,7 +23194,7 @@
           "type": "library",
           "name": "iconv-lite",
           "version": "0.7.0",
-          "bom-ref": "nachet-frontend@0.10.3|raw-body@3.0.1|iconv-lite@0.7.0",
+          "bom-ref": "nachet-frontend@0.10.4|raw-body@3.0.1|iconv-lite@0.7.0",
           "purl": "pkg:npm/iconv-lite@0.7.0",
           "externalReferences": [
             {
@@ -23214,7 +23222,7 @@
       "type": "library",
       "name": "rc",
       "version": "1.2.8",
-      "bom-ref": "nachet-frontend@0.10.3|rc@1.2.8",
+      "bom-ref": "nachet-frontend@0.10.4|rc@1.2.8",
       "purl": "pkg:npm/rc@1.2.8",
       "externalReferences": [
         {
@@ -23240,7 +23248,7 @@
           "type": "library",
           "name": "strip-json-comments",
           "version": "2.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|rc@1.2.8|strip-json-comments@2.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|rc@1.2.8|strip-json-comments@2.0.1",
           "purl": "pkg:npm/strip-json-comments@2.0.1",
           "externalReferences": [
             {
@@ -23268,7 +23276,7 @@
       "type": "library",
       "name": "re-resizable",
       "version": "6.11.2",
-      "bom-ref": "nachet-frontend@0.10.3|re-resizable@6.11.2",
+      "bom-ref": "nachet-frontend@0.10.4|re-resizable@6.11.2",
       "purl": "pkg:npm/re-resizable@6.11.2",
       "externalReferences": [
         {
@@ -23294,7 +23302,7 @@
       "type": "library",
       "name": "react-dom",
       "version": "19.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|react-dom@19.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|react-dom@19.1.1",
       "purl": "pkg:npm/react-dom@19.1.1",
       "externalReferences": [
         {
@@ -23320,7 +23328,7 @@
       "type": "library",
       "name": "react-draggable",
       "version": "4.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|react-draggable@4.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|react-draggable@4.5.0",
       "purl": "pkg:npm/react-draggable@4.5.0",
       "externalReferences": [
         {
@@ -23346,7 +23354,7 @@
       "type": "library",
       "name": "react-icons",
       "version": "5.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|react-icons@5.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|react-icons@5.5.0",
       "purl": "pkg:npm/react-icons@5.5.0",
       "externalReferences": [
         {
@@ -23372,7 +23380,7 @@
       "type": "library",
       "name": "react-is",
       "version": "19.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|react-is@19.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|react-is@19.1.1",
       "purl": "pkg:npm/react-is@19.1.1",
       "externalReferences": [
         {
@@ -23398,7 +23406,7 @@
       "type": "library",
       "name": "react-picture-annotation",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|react-picture-annotation@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|react-picture-annotation@1.2.0",
       "purl": "pkg:npm/react-picture-annotation@1.2.0",
       "externalReferences": [
         {
@@ -23424,7 +23432,7 @@
       "type": "library",
       "name": "react-router-dom",
       "version": "7.9.1",
-      "bom-ref": "nachet-frontend@0.10.3|react-router-dom@7.9.1",
+      "bom-ref": "nachet-frontend@0.10.4|react-router-dom@7.9.1",
       "purl": "pkg:npm/react-router-dom@7.9.1",
       "externalReferences": [
         {
@@ -23450,7 +23458,7 @@
       "type": "library",
       "name": "react-router",
       "version": "7.9.1",
-      "bom-ref": "nachet-frontend@0.10.3|react-router@7.9.1",
+      "bom-ref": "nachet-frontend@0.10.4|react-router@7.9.1",
       "purl": "pkg:npm/react-router@7.9.1",
       "externalReferences": [
         {
@@ -23476,7 +23484,7 @@
           "type": "library",
           "name": "cookie",
           "version": "1.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|react-router@7.9.1|cookie@1.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|react-router@7.9.1|cookie@1.0.2",
           "purl": "pkg:npm/cookie@1.0.2",
           "externalReferences": [
             {
@@ -23504,7 +23512,7 @@
       "type": "library",
       "name": "react-transition-group",
       "version": "4.4.5",
-      "bom-ref": "nachet-frontend@0.10.3|react-transition-group@4.4.5",
+      "bom-ref": "nachet-frontend@0.10.4|react-transition-group@4.4.5",
       "purl": "pkg:npm/react-transition-group@4.4.5",
       "externalReferences": [
         {
@@ -23530,7 +23538,7 @@
       "type": "library",
       "name": "react-webcam",
       "version": "7.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|react-webcam@7.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|react-webcam@7.2.0",
       "purl": "pkg:npm/react-webcam@7.2.0",
       "externalReferences": [
         {
@@ -23556,7 +23564,7 @@
       "type": "library",
       "name": "react",
       "version": "19.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|react@19.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|react@19.1.1",
       "purl": "pkg:npm/react@19.1.1",
       "externalReferences": [
         {
@@ -23582,7 +23590,7 @@
       "type": "library",
       "name": "readable-stream",
       "version": "2.3.8",
-      "bom-ref": "nachet-frontend@0.10.3|readable-stream@2.3.8",
+      "bom-ref": "nachet-frontend@0.10.4|readable-stream@2.3.8",
       "purl": "pkg:npm/readable-stream@2.3.8",
       "externalReferences": [
         {
@@ -23608,7 +23616,7 @@
           "type": "library",
           "name": "safe-buffer",
           "version": "5.1.2",
-          "bom-ref": "nachet-frontend@0.10.3|readable-stream@2.3.8|safe-buffer@5.1.2",
+          "bom-ref": "nachet-frontend@0.10.4|readable-stream@2.3.8|safe-buffer@5.1.2",
           "purl": "pkg:npm/safe-buffer@5.1.2",
           "externalReferences": [
             {
@@ -23636,7 +23644,7 @@
       "type": "library",
       "name": "redent",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|redent@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|redent@3.0.0",
       "purl": "pkg:npm/redent@3.0.0",
       "externalReferences": [
         {
@@ -23662,7 +23670,7 @@
       "type": "library",
       "name": "reflect.getprototypeof",
       "version": "1.0.10",
-      "bom-ref": "nachet-frontend@0.10.3|reflect.getprototypeof@1.0.10",
+      "bom-ref": "nachet-frontend@0.10.4|reflect.getprototypeof@1.0.10",
       "purl": "pkg:npm/reflect.getprototypeof@1.0.10",
       "externalReferences": [
         {
@@ -23692,7 +23700,7 @@
       "type": "library",
       "name": "regenerate-unicode-properties",
       "version": "10.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|regenerate-unicode-properties@10.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|regenerate-unicode-properties@10.2.2",
       "purl": "pkg:npm/regenerate-unicode-properties@10.2.2",
       "externalReferences": [
         {
@@ -23722,7 +23730,7 @@
       "type": "library",
       "name": "regenerate",
       "version": "1.4.2",
-      "bom-ref": "nachet-frontend@0.10.3|regenerate@1.4.2",
+      "bom-ref": "nachet-frontend@0.10.4|regenerate@1.4.2",
       "purl": "pkg:npm/regenerate@1.4.2",
       "externalReferences": [
         {
@@ -23752,7 +23760,7 @@
       "type": "library",
       "name": "regexp.prototype.flags",
       "version": "1.5.4",
-      "bom-ref": "nachet-frontend@0.10.3|regexp.prototype.flags@1.5.4",
+      "bom-ref": "nachet-frontend@0.10.4|regexp.prototype.flags@1.5.4",
       "purl": "pkg:npm/regexp.prototype.flags@1.5.4",
       "externalReferences": [
         {
@@ -23782,7 +23790,7 @@
       "type": "library",
       "name": "regexpu-core",
       "version": "6.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|regexpu-core@6.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|regexpu-core@6.3.1",
       "purl": "pkg:npm/regexpu-core@6.3.1",
       "externalReferences": [
         {
@@ -23812,7 +23820,7 @@
       "type": "library",
       "name": "registry-auth-token",
       "version": "3.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|registry-auth-token@3.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|registry-auth-token@3.3.2",
       "purl": "pkg:npm/registry-auth-token@3.3.2",
       "externalReferences": [
         {
@@ -23838,7 +23846,7 @@
       "type": "library",
       "name": "registry-url",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|registry-url@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|registry-url@3.1.0",
       "purl": "pkg:npm/registry-url@3.1.0",
       "externalReferences": [
         {
@@ -23864,7 +23872,7 @@
       "type": "library",
       "name": "regjsgen",
       "version": "0.8.0",
-      "bom-ref": "nachet-frontend@0.10.3|regjsgen@0.8.0",
+      "bom-ref": "nachet-frontend@0.10.4|regjsgen@0.8.0",
       "purl": "pkg:npm/regjsgen@0.8.0",
       "externalReferences": [
         {
@@ -23894,7 +23902,7 @@
       "type": "library",
       "name": "regjsparser",
       "version": "0.12.0",
-      "bom-ref": "nachet-frontend@0.10.3|regjsparser@0.12.0",
+      "bom-ref": "nachet-frontend@0.10.4|regjsparser@0.12.0",
       "purl": "pkg:npm/regjsparser@0.12.0",
       "externalReferences": [
         {
@@ -23924,7 +23932,7 @@
           "type": "library",
           "name": "jsesc",
           "version": "3.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|regjsparser@0.12.0|jsesc@3.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|regjsparser@0.12.0|jsesc@3.0.2",
           "purl": "pkg:npm/jsesc@3.0.2",
           "externalReferences": [
             {
@@ -23956,7 +23964,7 @@
       "type": "library",
       "name": "require-directory",
       "version": "2.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|require-directory@2.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|require-directory@2.1.1",
       "purl": "pkg:npm/require-directory@2.1.1",
       "externalReferences": [
         {
@@ -23982,7 +23990,7 @@
       "type": "library",
       "name": "require-from-string",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|require-from-string@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|require-from-string@2.0.2",
       "purl": "pkg:npm/require-from-string@2.0.2",
       "externalReferences": [
         {
@@ -24008,7 +24016,7 @@
       "type": "library",
       "name": "resolve-from",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|resolve-from@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|resolve-from@4.0.0",
       "purl": "pkg:npm/resolve-from@4.0.0",
       "externalReferences": [
         {
@@ -24034,7 +24042,7 @@
       "type": "library",
       "name": "resolve",
       "version": "1.22.10",
-      "bom-ref": "nachet-frontend@0.10.3|resolve@1.22.10",
+      "bom-ref": "nachet-frontend@0.10.4|resolve@1.22.10",
       "purl": "pkg:npm/resolve@1.22.10",
       "externalReferences": [
         {
@@ -24060,7 +24068,7 @@
       "type": "library",
       "name": "ret",
       "version": "0.1.15",
-      "bom-ref": "nachet-frontend@0.10.3|ret@0.1.15",
+      "bom-ref": "nachet-frontend@0.10.4|ret@0.1.15",
       "scope": "optional",
       "purl": "pkg:npm/ret@0.1.15",
       "externalReferences": [
@@ -24091,7 +24099,7 @@
       "type": "library",
       "name": "retry",
       "version": "0.12.0",
-      "bom-ref": "nachet-frontend@0.10.3|retry@0.12.0",
+      "bom-ref": "nachet-frontend@0.10.4|retry@0.12.0",
       "scope": "optional",
       "purl": "pkg:npm/retry@0.12.0",
       "externalReferences": [
@@ -24122,7 +24130,7 @@
       "type": "library",
       "name": "reusify",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|reusify@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|reusify@1.1.0",
       "purl": "pkg:npm/reusify@1.1.0",
       "externalReferences": [
         {
@@ -24152,7 +24160,7 @@
       "type": "library",
       "name": "rollup",
       "version": "4.50.2",
-      "bom-ref": "nachet-frontend@0.10.3|rollup@4.50.2",
+      "bom-ref": "nachet-frontend@0.10.4|rollup@4.50.2",
       "purl": "pkg:npm/rollup@4.50.2",
       "externalReferences": [
         {
@@ -24182,7 +24190,7 @@
       "type": "library",
       "name": "router",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|router@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|router@2.2.0",
       "purl": "pkg:npm/router@2.2.0",
       "externalReferences": [
         {
@@ -24208,7 +24216,7 @@
       "type": "library",
       "name": "rrweb-cssom",
       "version": "0.8.0",
-      "bom-ref": "nachet-frontend@0.10.3|rrweb-cssom@0.8.0",
+      "bom-ref": "nachet-frontend@0.10.4|rrweb-cssom@0.8.0",
       "purl": "pkg:npm/rrweb-cssom@0.8.0",
       "externalReferences": [
         {
@@ -24238,7 +24246,7 @@
       "type": "library",
       "name": "run-parallel",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|run-parallel@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|run-parallel@1.2.0",
       "purl": "pkg:npm/run-parallel@1.2.0",
       "externalReferences": [
         {
@@ -24268,7 +24276,7 @@
       "type": "library",
       "name": "safe-array-concat",
       "version": "1.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|safe-array-concat@1.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|safe-array-concat@1.1.3",
       "purl": "pkg:npm/safe-array-concat@1.1.3",
       "externalReferences": [
         {
@@ -24298,7 +24306,7 @@
           "type": "library",
           "name": "isarray",
           "version": "2.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|safe-array-concat@1.1.3|isarray@2.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|safe-array-concat@1.1.3|isarray@2.0.5",
           "purl": "pkg:npm/isarray@2.0.5",
           "externalReferences": [
             {
@@ -24330,7 +24338,7 @@
       "type": "library",
       "name": "safe-buffer",
       "version": "5.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|safe-buffer@5.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|safe-buffer@5.2.1",
       "purl": "pkg:npm/safe-buffer@5.2.1",
       "externalReferences": [
         {
@@ -24356,7 +24364,7 @@
       "type": "library",
       "name": "safe-push-apply",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|safe-push-apply@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|safe-push-apply@1.0.0",
       "purl": "pkg:npm/safe-push-apply@1.0.0",
       "externalReferences": [
         {
@@ -24386,7 +24394,7 @@
           "type": "library",
           "name": "isarray",
           "version": "2.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|safe-push-apply@1.0.0|isarray@2.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|safe-push-apply@1.0.0|isarray@2.0.5",
           "purl": "pkg:npm/isarray@2.0.5",
           "externalReferences": [
             {
@@ -24418,7 +24426,7 @@
       "type": "library",
       "name": "safe-regex-test",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|safe-regex-test@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|safe-regex-test@1.1.0",
       "purl": "pkg:npm/safe-regex-test@1.1.0",
       "externalReferences": [
         {
@@ -24448,7 +24456,7 @@
       "type": "library",
       "name": "safer-buffer",
       "version": "2.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|safer-buffer@2.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|safer-buffer@2.1.2",
       "purl": "pkg:npm/safer-buffer@2.1.2",
       "externalReferences": [
         {
@@ -24474,7 +24482,7 @@
       "type": "library",
       "name": "sanitize-html",
       "version": "2.17.0",
-      "bom-ref": "nachet-frontend@0.10.3|sanitize-html@2.17.0",
+      "bom-ref": "nachet-frontend@0.10.4|sanitize-html@2.17.0",
       "purl": "pkg:npm/sanitize-html@2.17.0",
       "externalReferences": [
         {
@@ -24500,7 +24508,7 @@
       "type": "library",
       "name": "saxes",
       "version": "6.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|saxes@6.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|saxes@6.0.0",
       "purl": "pkg:npm/saxes@6.0.0",
       "externalReferences": [
         {
@@ -24530,7 +24538,7 @@
       "type": "library",
       "name": "scheduler",
       "version": "0.26.0",
-      "bom-ref": "nachet-frontend@0.10.3|scheduler@0.26.0",
+      "bom-ref": "nachet-frontend@0.10.4|scheduler@0.26.0",
       "purl": "pkg:npm/scheduler@0.26.0",
       "externalReferences": [
         {
@@ -24556,7 +24564,7 @@
       "type": "library",
       "name": "schemes",
       "version": "1.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|schemes@1.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|schemes@1.4.0",
       "scope": "optional",
       "purl": "pkg:npm/schemes@1.4.0",
       "externalReferences": [
@@ -24587,7 +24595,7 @@
       "type": "library",
       "name": "semver",
       "version": "6.3.1",
-      "bom-ref": "nachet-frontend@0.10.3|semver@6.3.1",
+      "bom-ref": "nachet-frontend@0.10.4|semver@6.3.1",
       "purl": "pkg:npm/semver@6.3.1",
       "externalReferences": [
         {
@@ -24613,7 +24621,7 @@
       "type": "library",
       "name": "send",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|send@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|send@1.2.0",
       "purl": "pkg:npm/send@1.2.0",
       "externalReferences": [
         {
@@ -24639,7 +24647,7 @@
       "type": "library",
       "name": "serve-handler",
       "version": "6.1.6",
-      "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6",
+      "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6",
       "purl": "pkg:npm/serve-handler@6.1.6",
       "externalReferences": [
         {
@@ -24665,7 +24673,7 @@
           "type": "library",
           "name": "bytes",
           "version": "3.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|bytes@3.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|bytes@3.0.0",
           "purl": "pkg:npm/bytes@3.0.0",
           "externalReferences": [
             {
@@ -24691,7 +24699,7 @@
           "type": "library",
           "name": "content-disposition",
           "version": "0.5.2",
-          "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|content-disposition@0.5.2",
+          "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|content-disposition@0.5.2",
           "purl": "pkg:npm/content-disposition@0.5.2",
           "externalReferences": [
             {
@@ -24717,7 +24725,7 @@
           "type": "library",
           "name": "mime-db",
           "version": "1.33.0",
-          "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|mime-db@1.33.0",
+          "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|mime-db@1.33.0",
           "purl": "pkg:npm/mime-db@1.33.0",
           "externalReferences": [
             {
@@ -24743,7 +24751,7 @@
           "type": "library",
           "name": "mime-types",
           "version": "2.1.18",
-          "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|mime-types@2.1.18",
+          "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|mime-types@2.1.18",
           "purl": "pkg:npm/mime-types@2.1.18",
           "externalReferences": [
             {
@@ -24769,7 +24777,7 @@
           "type": "library",
           "name": "path-to-regexp",
           "version": "3.3.0",
-          "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|path-to-regexp@3.3.0",
+          "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|path-to-regexp@3.3.0",
           "purl": "pkg:npm/path-to-regexp@3.3.0",
           "externalReferences": [
             {
@@ -24795,7 +24803,7 @@
           "type": "library",
           "name": "range-parser",
           "version": "1.2.0",
-          "bom-ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|range-parser@1.2.0",
+          "bom-ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|range-parser@1.2.0",
           "purl": "pkg:npm/range-parser@1.2.0",
           "externalReferences": [
             {
@@ -24823,7 +24831,7 @@
       "type": "library",
       "name": "serve-static",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|serve-static@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|serve-static@2.2.0",
       "purl": "pkg:npm/serve-static@2.2.0",
       "externalReferences": [
         {
@@ -24849,7 +24857,7 @@
       "type": "library",
       "name": "serve",
       "version": "14.2.5",
-      "bom-ref": "nachet-frontend@0.10.3|serve@14.2.5",
+      "bom-ref": "nachet-frontend@0.10.4|serve@14.2.5",
       "purl": "pkg:npm/serve@14.2.5",
       "externalReferences": [
         {
@@ -24875,7 +24883,7 @@
           "type": "library",
           "name": "ajv",
           "version": "8.12.0",
-          "bom-ref": "nachet-frontend@0.10.3|serve@14.2.5|ajv@8.12.0",
+          "bom-ref": "nachet-frontend@0.10.4|serve@14.2.5|ajv@8.12.0",
           "purl": "pkg:npm/ajv@8.12.0",
           "externalReferences": [
             {
@@ -24901,7 +24909,7 @@
           "type": "library",
           "name": "chalk",
           "version": "5.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|serve@14.2.5|chalk@5.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|serve@14.2.5|chalk@5.0.1",
           "purl": "pkg:npm/chalk@5.0.1",
           "externalReferences": [
             {
@@ -24929,7 +24937,7 @@
       "type": "library",
       "name": "set-cookie-parser",
       "version": "2.7.1",
-      "bom-ref": "nachet-frontend@0.10.3|set-cookie-parser@2.7.1",
+      "bom-ref": "nachet-frontend@0.10.4|set-cookie-parser@2.7.1",
       "purl": "pkg:npm/set-cookie-parser@2.7.1",
       "externalReferences": [
         {
@@ -24955,7 +24963,7 @@
       "type": "library",
       "name": "set-function-length",
       "version": "1.2.2",
-      "bom-ref": "nachet-frontend@0.10.3|set-function-length@1.2.2",
+      "bom-ref": "nachet-frontend@0.10.4|set-function-length@1.2.2",
       "purl": "pkg:npm/set-function-length@1.2.2",
       "externalReferences": [
         {
@@ -24985,7 +24993,7 @@
       "type": "library",
       "name": "set-function-name",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|set-function-name@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|set-function-name@2.0.2",
       "purl": "pkg:npm/set-function-name@2.0.2",
       "externalReferences": [
         {
@@ -25015,7 +25023,7 @@
       "type": "library",
       "name": "set-proto",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|set-proto@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|set-proto@1.0.0",
       "purl": "pkg:npm/set-proto@1.0.0",
       "externalReferences": [
         {
@@ -25045,7 +25053,7 @@
       "type": "library",
       "name": "setimmediate",
       "version": "1.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|setimmediate@1.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|setimmediate@1.0.5",
       "purl": "pkg:npm/setimmediate@1.0.5",
       "externalReferences": [
         {
@@ -25071,7 +25079,7 @@
       "type": "library",
       "name": "setprototypeof",
       "version": "1.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|setprototypeof@1.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|setprototypeof@1.2.0",
       "purl": "pkg:npm/setprototypeof@1.2.0",
       "externalReferences": [
         {
@@ -25097,7 +25105,7 @@
       "type": "library",
       "name": "shallowequal",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|shallowequal@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|shallowequal@1.1.0",
       "purl": "pkg:npm/shallowequal@1.1.0",
       "externalReferences": [
         {
@@ -25123,7 +25131,7 @@
       "type": "library",
       "name": "shebang-command",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|shebang-command@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|shebang-command@2.0.0",
       "purl": "pkg:npm/shebang-command@2.0.0",
       "externalReferences": [
         {
@@ -25149,7 +25157,7 @@
       "type": "library",
       "name": "shebang-regex",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|shebang-regex@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|shebang-regex@3.0.0",
       "purl": "pkg:npm/shebang-regex@3.0.0",
       "externalReferences": [
         {
@@ -25175,7 +25183,7 @@
       "type": "library",
       "name": "side-channel-list",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|side-channel-list@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|side-channel-list@1.0.0",
       "purl": "pkg:npm/side-channel-list@1.0.0",
       "externalReferences": [
         {
@@ -25201,7 +25209,7 @@
       "type": "library",
       "name": "side-channel-map",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|side-channel-map@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|side-channel-map@1.0.1",
       "purl": "pkg:npm/side-channel-map@1.0.1",
       "externalReferences": [
         {
@@ -25227,7 +25235,7 @@
       "type": "library",
       "name": "side-channel-weakmap",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|side-channel-weakmap@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|side-channel-weakmap@1.0.2",
       "purl": "pkg:npm/side-channel-weakmap@1.0.2",
       "externalReferences": [
         {
@@ -25253,7 +25261,7 @@
       "type": "library",
       "name": "side-channel",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|side-channel@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|side-channel@1.1.0",
       "purl": "pkg:npm/side-channel@1.1.0",
       "externalReferences": [
         {
@@ -25279,7 +25287,7 @@
       "type": "library",
       "name": "siginfo",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|siginfo@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|siginfo@2.0.0",
       "purl": "pkg:npm/siginfo@2.0.0",
       "externalReferences": [
         {
@@ -25309,7 +25317,7 @@
       "type": "library",
       "name": "signal-exit",
       "version": "3.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|signal-exit@3.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|signal-exit@3.0.7",
       "purl": "pkg:npm/signal-exit@3.0.7",
       "externalReferences": [
         {
@@ -25335,7 +25343,7 @@
       "type": "library",
       "name": "simple-concat",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|simple-concat@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|simple-concat@1.0.1",
       "scope": "optional",
       "purl": "pkg:npm/simple-concat@1.0.1",
       "externalReferences": [
@@ -25366,7 +25374,7 @@
       "type": "library",
       "name": "simple-get",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|simple-get@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|simple-get@4.0.1",
       "scope": "optional",
       "purl": "pkg:npm/simple-get@4.0.1",
       "externalReferences": [
@@ -25397,7 +25405,7 @@
       "type": "library",
       "name": "slash",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|slash@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|slash@3.0.0",
       "purl": "pkg:npm/slash@3.0.0",
       "externalReferences": [
         {
@@ -25427,7 +25435,7 @@
       "type": "library",
       "name": "smart-buffer",
       "version": "4.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|smart-buffer@4.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|smart-buffer@4.2.0",
       "scope": "optional",
       "purl": "pkg:npm/smart-buffer@4.2.0",
       "externalReferences": [
@@ -25458,7 +25466,7 @@
       "type": "library",
       "name": "smtp-address-parser",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|smtp-address-parser@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|smtp-address-parser@1.1.0",
       "scope": "optional",
       "purl": "pkg:npm/smtp-address-parser@1.1.0",
       "externalReferences": [
@@ -25489,7 +25497,7 @@
       "type": "library",
       "name": "socks-proxy-agent",
       "version": "8.0.5",
-      "bom-ref": "nachet-frontend@0.10.3|socks-proxy-agent@8.0.5",
+      "bom-ref": "nachet-frontend@0.10.4|socks-proxy-agent@8.0.5",
       "scope": "optional",
       "purl": "pkg:npm/socks-proxy-agent@8.0.5",
       "externalReferences": [
@@ -25520,7 +25528,7 @@
       "type": "library",
       "name": "socks",
       "version": "2.8.7",
-      "bom-ref": "nachet-frontend@0.10.3|socks@2.8.7",
+      "bom-ref": "nachet-frontend@0.10.4|socks@2.8.7",
       "scope": "optional",
       "purl": "pkg:npm/socks@2.8.7",
       "externalReferences": [
@@ -25551,7 +25559,7 @@
       "type": "library",
       "name": "source-map-js",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|source-map-js@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|source-map-js@1.2.1",
       "purl": "pkg:npm/source-map-js@1.2.1",
       "externalReferences": [
         {
@@ -25577,7 +25585,7 @@
       "type": "library",
       "name": "source-map",
       "version": "0.5.7",
-      "bom-ref": "nachet-frontend@0.10.3|source-map@0.5.7",
+      "bom-ref": "nachet-frontend@0.10.4|source-map@0.5.7",
       "purl": "pkg:npm/source-map@0.5.7",
       "externalReferences": [
         {
@@ -25603,7 +25611,7 @@
       "type": "library",
       "name": "spdx-correct",
       "version": "3.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|spdx-correct@3.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|spdx-correct@3.2.0",
       "purl": "pkg:npm/spdx-correct@3.2.0",
       "externalReferences": [
         {
@@ -25633,7 +25641,7 @@
           "type": "library",
           "name": "spdx-expression-parse",
           "version": "3.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|spdx-correct@3.2.0|spdx-expression-parse@3.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|spdx-correct@3.2.0|spdx-expression-parse@3.0.1",
           "purl": "pkg:npm/spdx-expression-parse@3.0.1",
           "externalReferences": [
             {
@@ -25665,7 +25673,7 @@
       "type": "library",
       "name": "spdx-exceptions",
       "version": "2.5.0",
-      "bom-ref": "nachet-frontend@0.10.3|spdx-exceptions@2.5.0",
+      "bom-ref": "nachet-frontend@0.10.4|spdx-exceptions@2.5.0",
       "purl": "pkg:npm/spdx-exceptions@2.5.0",
       "externalReferences": [
         {
@@ -25695,7 +25703,7 @@
       "type": "library",
       "name": "spdx-expression-parse",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|spdx-expression-parse@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|spdx-expression-parse@4.0.0",
       "purl": "pkg:npm/spdx-expression-parse@4.0.0",
       "externalReferences": [
         {
@@ -25725,7 +25733,7 @@
       "type": "library",
       "name": "spdx-license-ids",
       "version": "3.0.22",
-      "bom-ref": "nachet-frontend@0.10.3|spdx-license-ids@3.0.22",
+      "bom-ref": "nachet-frontend@0.10.4|spdx-license-ids@3.0.22",
       "purl": "pkg:npm/spdx-license-ids@3.0.22",
       "externalReferences": [
         {
@@ -25755,7 +25763,7 @@
       "type": "library",
       "name": "sprintf-js",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|sprintf-js@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|sprintf-js@1.0.3",
       "purl": "pkg:npm/sprintf-js@1.0.3",
       "externalReferences": [
         {
@@ -25785,7 +25793,7 @@
       "type": "library",
       "name": "ssri",
       "version": "12.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|ssri@12.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|ssri@12.0.0",
       "scope": "optional",
       "purl": "pkg:npm/ssri@12.0.0",
       "externalReferences": [
@@ -25816,7 +25824,7 @@
       "type": "library",
       "name": "stack-utils",
       "version": "2.0.6",
-      "bom-ref": "nachet-frontend@0.10.3|stack-utils@2.0.6",
+      "bom-ref": "nachet-frontend@0.10.4|stack-utils@2.0.6",
       "purl": "pkg:npm/stack-utils@2.0.6",
       "externalReferences": [
         {
@@ -25846,7 +25854,7 @@
           "type": "library",
           "name": "escape-string-regexp",
           "version": "2.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|stack-utils@2.0.6|escape-string-regexp@2.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|stack-utils@2.0.6|escape-string-regexp@2.0.0",
           "purl": "pkg:npm/escape-string-regexp@2.0.0",
           "externalReferences": [
             {
@@ -25878,7 +25886,7 @@
       "type": "library",
       "name": "stackback",
       "version": "0.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|stackback@0.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|stackback@0.0.2",
       "purl": "pkg:npm/stackback@0.0.2",
       "externalReferences": [
         {
@@ -25908,7 +25916,7 @@
       "type": "library",
       "name": "statuses",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|statuses@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|statuses@2.0.2",
       "purl": "pkg:npm/statuses@2.0.2",
       "externalReferences": [
         {
@@ -25934,7 +25942,7 @@
       "type": "library",
       "name": "std-env",
       "version": "3.9.0",
-      "bom-ref": "nachet-frontend@0.10.3|std-env@3.9.0",
+      "bom-ref": "nachet-frontend@0.10.4|std-env@3.9.0",
       "purl": "pkg:npm/std-env@3.9.0",
       "externalReferences": [
         {
@@ -25964,7 +25972,7 @@
       "type": "library",
       "name": "stop-iteration-iterator",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|stop-iteration-iterator@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|stop-iteration-iterator@1.1.0",
       "purl": "pkg:npm/stop-iteration-iterator@1.1.0",
       "externalReferences": [
         {
@@ -25994,7 +26002,7 @@
       "type": "library",
       "name": "string_decoder",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|string_decoder@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|string_decoder@1.1.1",
       "purl": "pkg:npm/string_decoder@1.1.1",
       "externalReferences": [
         {
@@ -26020,7 +26028,7 @@
           "type": "library",
           "name": "safe-buffer",
           "version": "5.1.2",
-          "bom-ref": "nachet-frontend@0.10.3|string_decoder@1.1.1|safe-buffer@5.1.2",
+          "bom-ref": "nachet-frontend@0.10.4|string_decoder@1.1.1|safe-buffer@5.1.2",
           "purl": "pkg:npm/safe-buffer@5.1.2",
           "externalReferences": [
             {
@@ -26048,7 +26056,7 @@
       "type": "library",
       "name": "string-width",
       "version": "4.2.3",
-      "bom-ref": "nachet-frontend@0.10.3|string-width@4.2.3",
+      "bom-ref": "nachet-frontend@0.10.4|string-width@4.2.3",
       "purl": "pkg:npm/string-width@4.2.3",
       "externalReferences": [
         {
@@ -26078,7 +26086,7 @@
           "type": "library",
           "name": "emoji-regex",
           "version": "8.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|string-width@4.2.3|emoji-regex@8.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|string-width@4.2.3|emoji-regex@8.0.0",
           "purl": "pkg:npm/emoji-regex@8.0.0",
           "externalReferences": [
             {
@@ -26108,7 +26116,7 @@
           "type": "library",
           "name": "strip-ansi",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|string-width@4.2.3|strip-ansi@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|string-width@4.2.3|strip-ansi@6.0.1",
           "purl": "pkg:npm/strip-ansi@6.0.1",
           "externalReferences": [
             {
@@ -26140,7 +26148,7 @@
       "type": "library",
       "name": "string-width",
       "version": "5.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|string-width@5.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|string-width@5.1.2",
       "purl": "pkg:npm/string-width@5.1.2",
       "externalReferences": [
         {
@@ -26166,7 +26174,7 @@
       "type": "library",
       "name": "string.prototype.matchall",
       "version": "4.0.12",
-      "bom-ref": "nachet-frontend@0.10.3|string.prototype.matchall@4.0.12",
+      "bom-ref": "nachet-frontend@0.10.4|string.prototype.matchall@4.0.12",
       "purl": "pkg:npm/string.prototype.matchall@4.0.12",
       "externalReferences": [
         {
@@ -26196,7 +26204,7 @@
       "type": "library",
       "name": "string.prototype.repeat",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|string.prototype.repeat@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|string.prototype.repeat@1.0.0",
       "purl": "pkg:npm/string.prototype.repeat@1.0.0",
       "externalReferences": [
         {
@@ -26226,7 +26234,7 @@
       "type": "library",
       "name": "string.prototype.trim",
       "version": "1.2.10",
-      "bom-ref": "nachet-frontend@0.10.3|string.prototype.trim@1.2.10",
+      "bom-ref": "nachet-frontend@0.10.4|string.prototype.trim@1.2.10",
       "purl": "pkg:npm/string.prototype.trim@1.2.10",
       "externalReferences": [
         {
@@ -26256,7 +26264,7 @@
       "type": "library",
       "name": "string.prototype.trimend",
       "version": "1.0.9",
-      "bom-ref": "nachet-frontend@0.10.3|string.prototype.trimend@1.0.9",
+      "bom-ref": "nachet-frontend@0.10.4|string.prototype.trimend@1.0.9",
       "purl": "pkg:npm/string.prototype.trimend@1.0.9",
       "externalReferences": [
         {
@@ -26286,7 +26294,7 @@
       "type": "library",
       "name": "string.prototype.trimstart",
       "version": "1.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|string.prototype.trimstart@1.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|string.prototype.trimstart@1.0.8",
       "purl": "pkg:npm/string.prototype.trimstart@1.0.8",
       "externalReferences": [
         {
@@ -26316,7 +26324,7 @@
       "type": "library",
       "name": "strip-ansi",
       "version": "6.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|strip-ansi@6.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|strip-ansi@6.0.1",
       "purl": "pkg:npm/strip-ansi@6.0.1",
       "externalReferences": [
         {
@@ -26346,7 +26354,7 @@
       "type": "library",
       "name": "strip-ansi",
       "version": "7.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|strip-ansi@7.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|strip-ansi@7.1.2",
       "purl": "pkg:npm/strip-ansi@7.1.2",
       "externalReferences": [
         {
@@ -26372,7 +26380,7 @@
           "type": "library",
           "name": "ansi-regex",
           "version": "6.2.2",
-          "bom-ref": "nachet-frontend@0.10.3|strip-ansi@7.1.2|ansi-regex@6.2.2",
+          "bom-ref": "nachet-frontend@0.10.4|strip-ansi@7.1.2|ansi-regex@6.2.2",
           "purl": "pkg:npm/ansi-regex@6.2.2",
           "externalReferences": [
             {
@@ -26400,7 +26408,7 @@
       "type": "library",
       "name": "strip-bom",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|strip-bom@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|strip-bom@3.0.0",
       "purl": "pkg:npm/strip-bom@3.0.0",
       "externalReferences": [
         {
@@ -26430,7 +26438,7 @@
       "type": "library",
       "name": "strip-eof",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|strip-eof@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|strip-eof@1.0.0",
       "purl": "pkg:npm/strip-eof@1.0.0",
       "externalReferences": [
         {
@@ -26456,7 +26464,7 @@
       "type": "library",
       "name": "strip-final-newline",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|strip-final-newline@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|strip-final-newline@2.0.0",
       "purl": "pkg:npm/strip-final-newline@2.0.0",
       "externalReferences": [
         {
@@ -26482,7 +26490,7 @@
       "type": "library",
       "name": "strip-indent",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|strip-indent@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|strip-indent@3.0.0",
       "purl": "pkg:npm/strip-indent@3.0.0",
       "externalReferences": [
         {
@@ -26508,7 +26516,7 @@
       "type": "library",
       "name": "strip-json-comments",
       "version": "3.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|strip-json-comments@3.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|strip-json-comments@3.1.1",
       "purl": "pkg:npm/strip-json-comments@3.1.1",
       "externalReferences": [
         {
@@ -26538,7 +26546,7 @@
       "type": "library",
       "name": "strip-literal",
       "version": "3.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|strip-literal@3.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|strip-literal@3.0.0",
       "purl": "pkg:npm/strip-literal@3.0.0",
       "externalReferences": [
         {
@@ -26568,7 +26576,7 @@
           "type": "library",
           "name": "js-tokens",
           "version": "9.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|strip-literal@3.0.0|js-tokens@9.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|strip-literal@3.0.0|js-tokens@9.0.1",
           "purl": "pkg:npm/js-tokens@9.0.1",
           "externalReferences": [
             {
@@ -26600,7 +26608,7 @@
       "type": "library",
       "name": "styled-components",
       "version": "6.1.19",
-      "bom-ref": "nachet-frontend@0.10.3|styled-components@6.1.19",
+      "bom-ref": "nachet-frontend@0.10.4|styled-components@6.1.19",
       "purl": "pkg:npm/styled-components@6.1.19",
       "externalReferences": [
         {
@@ -26627,7 +26635,7 @@
           "name": "is-prop-valid",
           "group": "@emotion",
           "version": "1.2.2",
-          "bom-ref": "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/is-prop-valid@1.2.2",
+          "bom-ref": "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/is-prop-valid@1.2.2",
           "purl": "pkg:npm/%40emotion/is-prop-valid@1.2.2",
           "externalReferences": [
             {
@@ -26654,7 +26662,7 @@
           "name": "memoize",
           "group": "@emotion",
           "version": "0.8.1",
-          "bom-ref": "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/memoize@0.8.1",
+          "bom-ref": "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/memoize@0.8.1",
           "purl": "pkg:npm/%40emotion/memoize@0.8.1",
           "externalReferences": [
             {
@@ -26681,7 +26689,7 @@
           "name": "unitless",
           "group": "@emotion",
           "version": "0.8.1",
-          "bom-ref": "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/unitless@0.8.1",
+          "bom-ref": "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/unitless@0.8.1",
           "purl": "pkg:npm/%40emotion/unitless@0.8.1",
           "externalReferences": [
             {
@@ -26707,7 +26715,7 @@
           "type": "library",
           "name": "postcss",
           "version": "8.4.49",
-          "bom-ref": "nachet-frontend@0.10.3|styled-components@6.1.19|postcss@8.4.49",
+          "bom-ref": "nachet-frontend@0.10.4|styled-components@6.1.19|postcss@8.4.49",
           "purl": "pkg:npm/postcss@8.4.49",
           "externalReferences": [
             {
@@ -26733,7 +26741,7 @@
           "type": "library",
           "name": "stylis",
           "version": "4.3.2",
-          "bom-ref": "nachet-frontend@0.10.3|styled-components@6.1.19|stylis@4.3.2",
+          "bom-ref": "nachet-frontend@0.10.4|styled-components@6.1.19|stylis@4.3.2",
           "purl": "pkg:npm/stylis@4.3.2",
           "externalReferences": [
             {
@@ -26761,7 +26769,7 @@
       "type": "library",
       "name": "stylis",
       "version": "4.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|stylis@4.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|stylis@4.2.0",
       "purl": "pkg:npm/stylis@4.2.0",
       "externalReferences": [
         {
@@ -26787,7 +26795,7 @@
       "type": "library",
       "name": "supports-color",
       "version": "7.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|supports-color@7.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|supports-color@7.2.0",
       "purl": "pkg:npm/supports-color@7.2.0",
       "externalReferences": [
         {
@@ -26813,7 +26821,7 @@
       "type": "library",
       "name": "supports-preserve-symlinks-flag",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|supports-preserve-symlinks-flag@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|supports-preserve-symlinks-flag@1.0.0",
       "purl": "pkg:npm/supports-preserve-symlinks-flag@1.0.0",
       "externalReferences": [
         {
@@ -26839,7 +26847,7 @@
       "type": "library",
       "name": "symbol-tree",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|symbol-tree@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|symbol-tree@3.2.4",
       "purl": "pkg:npm/symbol-tree@3.2.4",
       "externalReferences": [
         {
@@ -26869,7 +26877,7 @@
       "type": "library",
       "name": "synckit",
       "version": "0.11.11",
-      "bom-ref": "nachet-frontend@0.10.3|synckit@0.11.11",
+      "bom-ref": "nachet-frontend@0.10.4|synckit@0.11.11",
       "purl": "pkg:npm/synckit@0.11.11",
       "externalReferences": [
         {
@@ -26899,7 +26907,7 @@
       "type": "library",
       "name": "tar-fs",
       "version": "2.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|tar-fs@2.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|tar-fs@2.1.3",
       "scope": "optional",
       "purl": "pkg:npm/tar-fs@2.1.3",
       "externalReferences": [
@@ -26930,7 +26938,7 @@
           "type": "library",
           "name": "chownr",
           "version": "1.1.4",
-          "bom-ref": "nachet-frontend@0.10.3|tar-fs@2.1.3|chownr@1.1.4",
+          "bom-ref": "nachet-frontend@0.10.4|tar-fs@2.1.3|chownr@1.1.4",
           "scope": "optional",
           "purl": "pkg:npm/chownr@1.1.4",
           "externalReferences": [
@@ -26963,7 +26971,7 @@
       "type": "library",
       "name": "tar-stream",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|tar-stream@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|tar-stream@2.2.0",
       "scope": "optional",
       "purl": "pkg:npm/tar-stream@2.2.0",
       "externalReferences": [
@@ -26994,7 +27002,7 @@
           "type": "library",
           "name": "readable-stream",
           "version": "3.6.2",
-          "bom-ref": "nachet-frontend@0.10.3|tar-stream@2.2.0|readable-stream@3.6.2",
+          "bom-ref": "nachet-frontend@0.10.4|tar-stream@2.2.0|readable-stream@3.6.2",
           "scope": "optional",
           "purl": "pkg:npm/readable-stream@3.6.2",
           "externalReferences": [
@@ -27027,7 +27035,7 @@
       "type": "library",
       "name": "tar",
       "version": "7.4.3",
-      "bom-ref": "nachet-frontend@0.10.3|tar@7.4.3",
+      "bom-ref": "nachet-frontend@0.10.4|tar@7.4.3",
       "scope": "optional",
       "purl": "pkg:npm/tar@7.4.3",
       "externalReferences": [
@@ -27058,7 +27066,7 @@
           "type": "library",
           "name": "yallist",
           "version": "5.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|tar@7.4.3|yallist@5.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|tar@7.4.3|yallist@5.0.0",
           "scope": "optional",
           "purl": "pkg:npm/yallist@5.0.0",
           "externalReferences": [
@@ -27091,7 +27099,7 @@
       "type": "library",
       "name": "test-exclude",
       "version": "7.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|test-exclude@7.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|test-exclude@7.0.1",
       "purl": "pkg:npm/test-exclude@7.0.1",
       "externalReferences": [
         {
@@ -27121,7 +27129,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "2.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|test-exclude@7.0.1|brace-expansion@2.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|test-exclude@7.0.1|brace-expansion@2.0.2",
           "purl": "pkg:npm/brace-expansion@2.0.2",
           "externalReferences": [
             {
@@ -27151,7 +27159,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "9.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|test-exclude@7.0.1|minimatch@9.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|test-exclude@7.0.1|minimatch@9.0.5",
           "purl": "pkg:npm/minimatch@9.0.5",
           "externalReferences": [
             {
@@ -27183,7 +27191,7 @@
       "type": "library",
       "name": "tinybench",
       "version": "2.9.0",
-      "bom-ref": "nachet-frontend@0.10.3|tinybench@2.9.0",
+      "bom-ref": "nachet-frontend@0.10.4|tinybench@2.9.0",
       "purl": "pkg:npm/tinybench@2.9.0",
       "externalReferences": [
         {
@@ -27213,7 +27221,7 @@
       "type": "library",
       "name": "tinyexec",
       "version": "0.3.2",
-      "bom-ref": "nachet-frontend@0.10.3|tinyexec@0.3.2",
+      "bom-ref": "nachet-frontend@0.10.4|tinyexec@0.3.2",
       "purl": "pkg:npm/tinyexec@0.3.2",
       "externalReferences": [
         {
@@ -27243,7 +27251,7 @@
       "type": "library",
       "name": "tinyglobby",
       "version": "0.2.15",
-      "bom-ref": "nachet-frontend@0.10.3|tinyglobby@0.2.15",
+      "bom-ref": "nachet-frontend@0.10.4|tinyglobby@0.2.15",
       "purl": "pkg:npm/tinyglobby@0.2.15",
       "externalReferences": [
         {
@@ -27273,7 +27281,7 @@
       "type": "library",
       "name": "tinypool",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|tinypool@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|tinypool@1.1.1",
       "purl": "pkg:npm/tinypool@1.1.1",
       "externalReferences": [
         {
@@ -27303,7 +27311,7 @@
       "type": "library",
       "name": "tinyrainbow",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|tinyrainbow@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|tinyrainbow@2.0.0",
       "purl": "pkg:npm/tinyrainbow@2.0.0",
       "externalReferences": [
         {
@@ -27333,7 +27341,7 @@
       "type": "library",
       "name": "tinyspy",
       "version": "4.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|tinyspy@4.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|tinyspy@4.0.3",
       "purl": "pkg:npm/tinyspy@4.0.3",
       "externalReferences": [
         {
@@ -27363,7 +27371,7 @@
       "type": "library",
       "name": "tldts-core",
       "version": "6.1.86",
-      "bom-ref": "nachet-frontend@0.10.3|tldts-core@6.1.86",
+      "bom-ref": "nachet-frontend@0.10.4|tldts-core@6.1.86",
       "purl": "pkg:npm/tldts-core@6.1.86",
       "externalReferences": [
         {
@@ -27393,7 +27401,7 @@
       "type": "library",
       "name": "tldts",
       "version": "6.1.86",
-      "bom-ref": "nachet-frontend@0.10.3|tldts@6.1.86",
+      "bom-ref": "nachet-frontend@0.10.4|tldts@6.1.86",
       "purl": "pkg:npm/tldts@6.1.86",
       "externalReferences": [
         {
@@ -27423,7 +27431,7 @@
       "type": "library",
       "name": "to-regex-range",
       "version": "5.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|to-regex-range@5.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|to-regex-range@5.0.1",
       "purl": "pkg:npm/to-regex-range@5.0.1",
       "externalReferences": [
         {
@@ -27453,7 +27461,7 @@
       "type": "library",
       "name": "toidentifier",
       "version": "1.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|toidentifier@1.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|toidentifier@1.0.1",
       "purl": "pkg:npm/toidentifier@1.0.1",
       "externalReferences": [
         {
@@ -27479,7 +27487,7 @@
       "type": "library",
       "name": "tough-cookie",
       "version": "5.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|tough-cookie@5.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|tough-cookie@5.1.2",
       "purl": "pkg:npm/tough-cookie@5.1.2",
       "externalReferences": [
         {
@@ -27509,7 +27517,7 @@
       "type": "library",
       "name": "tr46",
       "version": "5.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|tr46@5.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|tr46@5.1.1",
       "purl": "pkg:npm/tr46@5.1.1",
       "externalReferences": [
         {
@@ -27539,7 +27547,7 @@
       "type": "library",
       "name": "ts-api-utils",
       "version": "2.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|ts-api-utils@2.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|ts-api-utils@2.1.0",
       "purl": "pkg:npm/ts-api-utils@2.1.0",
       "externalReferences": [
         {
@@ -27569,7 +27577,7 @@
       "type": "library",
       "name": "tsconfig-paths",
       "version": "3.15.0",
-      "bom-ref": "nachet-frontend@0.10.3|tsconfig-paths@3.15.0",
+      "bom-ref": "nachet-frontend@0.10.4|tsconfig-paths@3.15.0",
       "purl": "pkg:npm/tsconfig-paths@3.15.0",
       "externalReferences": [
         {
@@ -27599,7 +27607,7 @@
           "type": "library",
           "name": "json5",
           "version": "1.0.2",
-          "bom-ref": "nachet-frontend@0.10.3|tsconfig-paths@3.15.0|json5@1.0.2",
+          "bom-ref": "nachet-frontend@0.10.4|tsconfig-paths@3.15.0|json5@1.0.2",
           "purl": "pkg:npm/json5@1.0.2",
           "externalReferences": [
             {
@@ -27631,7 +27639,7 @@
       "type": "library",
       "name": "tslib",
       "version": "2.6.2",
-      "bom-ref": "nachet-frontend@0.10.3|tslib@2.6.2",
+      "bom-ref": "nachet-frontend@0.10.4|tslib@2.6.2",
       "purl": "pkg:npm/tslib@2.6.2",
       "externalReferences": [
         {
@@ -27657,7 +27665,7 @@
       "type": "library",
       "name": "tunnel-agent",
       "version": "0.6.0",
-      "bom-ref": "nachet-frontend@0.10.3|tunnel-agent@0.6.0",
+      "bom-ref": "nachet-frontend@0.10.4|tunnel-agent@0.6.0",
       "scope": "optional",
       "purl": "pkg:npm/tunnel-agent@0.6.0",
       "externalReferences": [
@@ -27688,7 +27696,7 @@
       "type": "library",
       "name": "type-check",
       "version": "0.4.0",
-      "bom-ref": "nachet-frontend@0.10.3|type-check@0.4.0",
+      "bom-ref": "nachet-frontend@0.10.4|type-check@0.4.0",
       "purl": "pkg:npm/type-check@0.4.0",
       "externalReferences": [
         {
@@ -27718,7 +27726,7 @@
       "type": "library",
       "name": "type-detect",
       "version": "4.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|type-detect@4.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|type-detect@4.0.8",
       "purl": "pkg:npm/type-detect@4.0.8",
       "externalReferences": [
         {
@@ -27748,7 +27756,7 @@
       "type": "library",
       "name": "type-fest",
       "version": "2.19.0",
-      "bom-ref": "nachet-frontend@0.10.3|type-fest@2.19.0",
+      "bom-ref": "nachet-frontend@0.10.4|type-fest@2.19.0",
       "purl": "pkg:npm/type-fest@2.19.0",
       "externalReferences": [
         {
@@ -27774,7 +27782,7 @@
       "type": "library",
       "name": "type-is",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|type-is@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|type-is@2.0.1",
       "purl": "pkg:npm/type-is@2.0.1",
       "externalReferences": [
         {
@@ -27800,7 +27808,7 @@
       "type": "library",
       "name": "typed-array-buffer",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|typed-array-buffer@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|typed-array-buffer@1.0.3",
       "purl": "pkg:npm/typed-array-buffer@1.0.3",
       "externalReferences": [
         {
@@ -27830,7 +27838,7 @@
       "type": "library",
       "name": "typed-array-byte-length",
       "version": "1.0.3",
-      "bom-ref": "nachet-frontend@0.10.3|typed-array-byte-length@1.0.3",
+      "bom-ref": "nachet-frontend@0.10.4|typed-array-byte-length@1.0.3",
       "purl": "pkg:npm/typed-array-byte-length@1.0.3",
       "externalReferences": [
         {
@@ -27860,7 +27868,7 @@
       "type": "library",
       "name": "typed-array-byte-offset",
       "version": "1.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|typed-array-byte-offset@1.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|typed-array-byte-offset@1.0.4",
       "purl": "pkg:npm/typed-array-byte-offset@1.0.4",
       "externalReferences": [
         {
@@ -27890,7 +27898,7 @@
       "type": "library",
       "name": "typed-array-length",
       "version": "1.0.7",
-      "bom-ref": "nachet-frontend@0.10.3|typed-array-length@1.0.7",
+      "bom-ref": "nachet-frontend@0.10.4|typed-array-length@1.0.7",
       "purl": "pkg:npm/typed-array-length@1.0.7",
       "externalReferences": [
         {
@@ -27920,7 +27928,7 @@
       "type": "library",
       "name": "typescript",
       "version": "5.9.2",
-      "bom-ref": "nachet-frontend@0.10.3|typescript@5.9.2",
+      "bom-ref": "nachet-frontend@0.10.4|typescript@5.9.2",
       "purl": "pkg:npm/typescript@5.9.2",
       "externalReferences": [
         {
@@ -27946,7 +27954,7 @@
       "type": "library",
       "name": "unbox-primitive",
       "version": "1.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|unbox-primitive@1.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|unbox-primitive@1.1.0",
       "purl": "pkg:npm/unbox-primitive@1.1.0",
       "externalReferences": [
         {
@@ -27976,7 +27984,7 @@
       "type": "library",
       "name": "undici-types",
       "version": "6.21.0",
-      "bom-ref": "nachet-frontend@0.10.3|undici-types@6.21.0",
+      "bom-ref": "nachet-frontend@0.10.4|undici-types@6.21.0",
       "purl": "pkg:npm/undici-types@6.21.0",
       "externalReferences": [
         {
@@ -28006,7 +28014,7 @@
       "type": "library",
       "name": "unicode-canonical-property-names-ecmascript",
       "version": "2.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|unicode-canonical-property-names-ecmascript@2.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|unicode-canonical-property-names-ecmascript@2.0.1",
       "purl": "pkg:npm/unicode-canonical-property-names-ecmascript@2.0.1",
       "externalReferences": [
         {
@@ -28036,7 +28044,7 @@
       "type": "library",
       "name": "unicode-match-property-ecmascript",
       "version": "2.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|unicode-match-property-ecmascript@2.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|unicode-match-property-ecmascript@2.0.0",
       "purl": "pkg:npm/unicode-match-property-ecmascript@2.0.0",
       "externalReferences": [
         {
@@ -28066,7 +28074,7 @@
       "type": "library",
       "name": "unicode-match-property-value-ecmascript",
       "version": "2.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|unicode-match-property-value-ecmascript@2.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|unicode-match-property-value-ecmascript@2.2.1",
       "purl": "pkg:npm/unicode-match-property-value-ecmascript@2.2.1",
       "externalReferences": [
         {
@@ -28096,7 +28104,7 @@
       "type": "library",
       "name": "unicode-property-aliases-ecmascript",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|unicode-property-aliases-ecmascript@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|unicode-property-aliases-ecmascript@2.2.0",
       "purl": "pkg:npm/unicode-property-aliases-ecmascript@2.2.0",
       "externalReferences": [
         {
@@ -28126,7 +28134,7 @@
       "type": "library",
       "name": "unique-filename",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|unique-filename@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|unique-filename@4.0.0",
       "scope": "optional",
       "purl": "pkg:npm/unique-filename@4.0.0",
       "externalReferences": [
@@ -28157,7 +28165,7 @@
       "type": "library",
       "name": "unique-slug",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|unique-slug@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|unique-slug@5.0.0",
       "scope": "optional",
       "purl": "pkg:npm/unique-slug@5.0.0",
       "externalReferences": [
@@ -28188,7 +28196,7 @@
       "type": "library",
       "name": "unpipe",
       "version": "1.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|unpipe@1.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|unpipe@1.0.0",
       "purl": "pkg:npm/unpipe@1.0.0",
       "externalReferences": [
         {
@@ -28214,7 +28222,7 @@
       "type": "library",
       "name": "update-browserslist-db",
       "version": "1.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|update-browserslist-db@1.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|update-browserslist-db@1.1.3",
       "purl": "pkg:npm/update-browserslist-db@1.1.3",
       "externalReferences": [
         {
@@ -28240,7 +28248,7 @@
       "type": "library",
       "name": "update-check",
       "version": "1.5.4",
-      "bom-ref": "nachet-frontend@0.10.3|update-check@1.5.4",
+      "bom-ref": "nachet-frontend@0.10.4|update-check@1.5.4",
       "purl": "pkg:npm/update-check@1.5.4",
       "externalReferences": [
         {
@@ -28266,7 +28274,7 @@
       "type": "library",
       "name": "uri-js",
       "version": "4.4.1",
-      "bom-ref": "nachet-frontend@0.10.3|uri-js@4.4.1",
+      "bom-ref": "nachet-frontend@0.10.4|uri-js@4.4.1",
       "purl": "pkg:npm/uri-js@4.4.1",
       "externalReferences": [
         {
@@ -28292,7 +28300,7 @@
       "type": "library",
       "name": "utif",
       "version": "3.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|utif@3.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|utif@3.1.0",
       "purl": "pkg:npm/utif@3.1.0",
       "externalReferences": [
         {
@@ -28318,7 +28326,7 @@
           "type": "library",
           "name": "pako",
           "version": "1.0.11",
-          "bom-ref": "nachet-frontend@0.10.3|utif@3.1.0|pako@1.0.11",
+          "bom-ref": "nachet-frontend@0.10.4|utif@3.1.0|pako@1.0.11",
           "purl": "pkg:npm/pako@1.0.11",
           "externalReferences": [
             {
@@ -28346,7 +28354,7 @@
       "type": "library",
       "name": "util-deprecate",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|util-deprecate@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|util-deprecate@1.0.2",
       "purl": "pkg:npm/util-deprecate@1.0.2",
       "externalReferences": [
         {
@@ -28372,7 +28380,7 @@
       "type": "library",
       "name": "uuid",
       "version": "11.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|uuid@11.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|uuid@11.1.0",
       "purl": "pkg:npm/uuid@11.1.0",
       "externalReferences": [
         {
@@ -28398,7 +28406,7 @@
       "type": "library",
       "name": "uzip",
       "version": "0.20201231.0",
-      "bom-ref": "nachet-frontend@0.10.3|uzip@0.20201231.0",
+      "bom-ref": "nachet-frontend@0.10.4|uzip@0.20201231.0",
       "purl": "pkg:npm/uzip@0.20201231.0",
       "externalReferences": [
         {
@@ -28424,7 +28432,7 @@
       "type": "library",
       "name": "validate-npm-package-license",
       "version": "3.0.4",
-      "bom-ref": "nachet-frontend@0.10.3|validate-npm-package-license@3.0.4",
+      "bom-ref": "nachet-frontend@0.10.4|validate-npm-package-license@3.0.4",
       "purl": "pkg:npm/validate-npm-package-license@3.0.4",
       "externalReferences": [
         {
@@ -28454,7 +28462,7 @@
           "type": "library",
           "name": "spdx-expression-parse",
           "version": "3.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|validate-npm-package-license@3.0.4|spdx-expression-parse@3.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|validate-npm-package-license@3.0.4|spdx-expression-parse@3.0.1",
           "purl": "pkg:npm/spdx-expression-parse@3.0.1",
           "externalReferences": [
             {
@@ -28486,7 +28494,7 @@
       "type": "library",
       "name": "vary",
       "version": "1.1.2",
-      "bom-ref": "nachet-frontend@0.10.3|vary@1.1.2",
+      "bom-ref": "nachet-frontend@0.10.4|vary@1.1.2",
       "purl": "pkg:npm/vary@1.1.2",
       "externalReferences": [
         {
@@ -28512,7 +28520,7 @@
       "type": "library",
       "name": "vite-node",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|vite-node@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|vite-node@3.2.4",
       "purl": "pkg:npm/vite-node@3.2.4",
       "externalReferences": [
         {
@@ -28542,7 +28550,7 @@
       "type": "library",
       "name": "vite-plugin-environment",
       "version": "1.1.3",
-      "bom-ref": "nachet-frontend@0.10.3|vite-plugin-environment@1.1.3",
+      "bom-ref": "nachet-frontend@0.10.4|vite-plugin-environment@1.1.3",
       "purl": "pkg:npm/vite-plugin-environment@1.1.3",
       "externalReferences": [
         {
@@ -28572,7 +28580,7 @@
       "type": "library",
       "name": "vite",
       "version": "7.1.5",
-      "bom-ref": "nachet-frontend@0.10.3|vite@7.1.5",
+      "bom-ref": "nachet-frontend@0.10.4|vite@7.1.5",
       "purl": "pkg:npm/vite@7.1.5",
       "externalReferences": [
         {
@@ -28602,7 +28610,7 @@
           "type": "library",
           "name": "fsevents",
           "version": "2.3.3",
-          "bom-ref": "nachet-frontend@0.10.3|vite@7.1.5|fsevents@2.3.3",
+          "bom-ref": "nachet-frontend@0.10.4|vite@7.1.5|fsevents@2.3.3",
           "scope": "optional",
           "purl": "pkg:npm/fsevents@2.3.3",
           "externalReferences": [
@@ -28635,7 +28643,7 @@
       "type": "library",
       "name": "vitest",
       "version": "3.2.4",
-      "bom-ref": "nachet-frontend@0.10.3|vitest@3.2.4",
+      "bom-ref": "nachet-frontend@0.10.4|vitest@3.2.4",
       "purl": "pkg:npm/vitest@3.2.4",
       "externalReferences": [
         {
@@ -28665,7 +28673,7 @@
       "type": "library",
       "name": "w3c-xmlserializer",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|w3c-xmlserializer@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|w3c-xmlserializer@5.0.0",
       "purl": "pkg:npm/w3c-xmlserializer@5.0.0",
       "externalReferences": [
         {
@@ -28695,7 +28703,7 @@
       "type": "library",
       "name": "web-streams-polyfill",
       "version": "3.3.3",
-      "bom-ref": "nachet-frontend@0.10.3|web-streams-polyfill@3.3.3",
+      "bom-ref": "nachet-frontend@0.10.4|web-streams-polyfill@3.3.3",
       "purl": "pkg:npm/web-streams-polyfill@3.3.3",
       "externalReferences": [
         {
@@ -28725,7 +28733,7 @@
       "type": "library",
       "name": "web-vitals",
       "version": "5.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|web-vitals@5.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|web-vitals@5.1.0",
       "purl": "pkg:npm/web-vitals@5.1.0",
       "externalReferences": [
         {
@@ -28751,7 +28759,7 @@
       "type": "library",
       "name": "webidl-conversions",
       "version": "7.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|webidl-conversions@7.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|webidl-conversions@7.0.0",
       "purl": "pkg:npm/webidl-conversions@7.0.0",
       "externalReferences": [
         {
@@ -28781,7 +28789,7 @@
       "type": "library",
       "name": "whatwg-encoding",
       "version": "3.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|whatwg-encoding@3.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|whatwg-encoding@3.1.1",
       "purl": "pkg:npm/whatwg-encoding@3.1.1",
       "externalReferences": [
         {
@@ -28811,7 +28819,7 @@
       "type": "library",
       "name": "whatwg-mimetype",
       "version": "4.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|whatwg-mimetype@4.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|whatwg-mimetype@4.0.0",
       "purl": "pkg:npm/whatwg-mimetype@4.0.0",
       "externalReferences": [
         {
@@ -28841,7 +28849,7 @@
       "type": "library",
       "name": "whatwg-url",
       "version": "14.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|whatwg-url@14.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|whatwg-url@14.2.0",
       "purl": "pkg:npm/whatwg-url@14.2.0",
       "externalReferences": [
         {
@@ -28871,7 +28879,7 @@
       "type": "library",
       "name": "which-boxed-primitive",
       "version": "1.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|which-boxed-primitive@1.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|which-boxed-primitive@1.1.1",
       "purl": "pkg:npm/which-boxed-primitive@1.1.1",
       "externalReferences": [
         {
@@ -28901,7 +28909,7 @@
       "type": "library",
       "name": "which-builtin-type",
       "version": "1.2.1",
-      "bom-ref": "nachet-frontend@0.10.3|which-builtin-type@1.2.1",
+      "bom-ref": "nachet-frontend@0.10.4|which-builtin-type@1.2.1",
       "purl": "pkg:npm/which-builtin-type@1.2.1",
       "externalReferences": [
         {
@@ -28931,7 +28939,7 @@
           "type": "library",
           "name": "isarray",
           "version": "2.0.5",
-          "bom-ref": "nachet-frontend@0.10.3|which-builtin-type@1.2.1|isarray@2.0.5",
+          "bom-ref": "nachet-frontend@0.10.4|which-builtin-type@1.2.1|isarray@2.0.5",
           "purl": "pkg:npm/isarray@2.0.5",
           "externalReferences": [
             {
@@ -28963,7 +28971,7 @@
       "type": "library",
       "name": "which-collection",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|which-collection@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|which-collection@1.0.2",
       "purl": "pkg:npm/which-collection@1.0.2",
       "externalReferences": [
         {
@@ -28993,7 +29001,7 @@
       "type": "library",
       "name": "which-typed-array",
       "version": "1.1.19",
-      "bom-ref": "nachet-frontend@0.10.3|which-typed-array@1.1.19",
+      "bom-ref": "nachet-frontend@0.10.4|which-typed-array@1.1.19",
       "purl": "pkg:npm/which-typed-array@1.1.19",
       "externalReferences": [
         {
@@ -29023,7 +29031,7 @@
       "type": "library",
       "name": "which",
       "version": "2.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|which@2.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|which@2.0.2",
       "purl": "pkg:npm/which@2.0.2",
       "externalReferences": [
         {
@@ -29049,7 +29057,7 @@
       "type": "library",
       "name": "why-is-node-running",
       "version": "2.3.0",
-      "bom-ref": "nachet-frontend@0.10.3|why-is-node-running@2.3.0",
+      "bom-ref": "nachet-frontend@0.10.4|why-is-node-running@2.3.0",
       "purl": "pkg:npm/why-is-node-running@2.3.0",
       "externalReferences": [
         {
@@ -29079,7 +29087,7 @@
       "type": "library",
       "name": "widest-line",
       "version": "4.0.1",
-      "bom-ref": "nachet-frontend@0.10.3|widest-line@4.0.1",
+      "bom-ref": "nachet-frontend@0.10.4|widest-line@4.0.1",
       "purl": "pkg:npm/widest-line@4.0.1",
       "externalReferences": [
         {
@@ -29105,7 +29113,7 @@
       "type": "library",
       "name": "word-wrap",
       "version": "1.2.5",
-      "bom-ref": "nachet-frontend@0.10.3|word-wrap@1.2.5",
+      "bom-ref": "nachet-frontend@0.10.4|word-wrap@1.2.5",
       "purl": "pkg:npm/word-wrap@1.2.5",
       "externalReferences": [
         {
@@ -29135,7 +29143,7 @@
       "type": "library",
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0",
       "purl": "pkg:npm/wrap-ansi@7.0.0",
       "externalReferences": [
         {
@@ -29165,7 +29173,7 @@
           "type": "library",
           "name": "emoji-regex",
           "version": "8.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0|emoji-regex@8.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0|emoji-regex@8.0.0",
           "purl": "pkg:npm/emoji-regex@8.0.0",
           "externalReferences": [
             {
@@ -29195,7 +29203,7 @@
           "type": "library",
           "name": "string-width",
           "version": "4.2.3",
-          "bom-ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0|string-width@4.2.3",
+          "bom-ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0|string-width@4.2.3",
           "purl": "pkg:npm/string-width@4.2.3",
           "externalReferences": [
             {
@@ -29225,7 +29233,7 @@
           "type": "library",
           "name": "strip-ansi",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0|strip-ansi@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0|strip-ansi@6.0.1",
           "purl": "pkg:npm/strip-ansi@6.0.1",
           "externalReferences": [
             {
@@ -29257,7 +29265,7 @@
       "type": "library",
       "name": "wrap-ansi",
       "version": "8.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|wrap-ansi@8.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|wrap-ansi@8.1.0",
       "purl": "pkg:npm/wrap-ansi@8.1.0",
       "externalReferences": [
         {
@@ -29283,7 +29291,7 @@
           "type": "library",
           "name": "ansi-styles",
           "version": "6.2.3",
-          "bom-ref": "nachet-frontend@0.10.3|wrap-ansi@8.1.0|ansi-styles@6.2.3",
+          "bom-ref": "nachet-frontend@0.10.4|wrap-ansi@8.1.0|ansi-styles@6.2.3",
           "purl": "pkg:npm/ansi-styles@6.2.3",
           "externalReferences": [
             {
@@ -29311,7 +29319,7 @@
       "type": "library",
       "name": "wrappy",
       "version": "1.0.2",
-      "bom-ref": "nachet-frontend@0.10.3|wrappy@1.0.2",
+      "bom-ref": "nachet-frontend@0.10.4|wrappy@1.0.2",
       "purl": "pkg:npm/wrappy@1.0.2",
       "externalReferences": [
         {
@@ -29337,7 +29345,7 @@
       "type": "library",
       "name": "ws",
       "version": "8.18.3",
-      "bom-ref": "nachet-frontend@0.10.3|ws@8.18.3",
+      "bom-ref": "nachet-frontend@0.10.4|ws@8.18.3",
       "purl": "pkg:npm/ws@8.18.3",
       "externalReferences": [
         {
@@ -29367,7 +29375,7 @@
       "type": "library",
       "name": "xml-name-validator",
       "version": "5.0.0",
-      "bom-ref": "nachet-frontend@0.10.3|xml-name-validator@5.0.0",
+      "bom-ref": "nachet-frontend@0.10.4|xml-name-validator@5.0.0",
       "purl": "pkg:npm/xml-name-validator@5.0.0",
       "externalReferences": [
         {
@@ -29397,7 +29405,7 @@
       "type": "library",
       "name": "xmlbuilder2",
       "version": "3.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|xmlbuilder2@3.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|xmlbuilder2@3.1.1",
       "purl": "pkg:npm/xmlbuilder2@3.1.1",
       "externalReferences": [
         {
@@ -29427,7 +29435,7 @@
           "type": "library",
           "name": "argparse",
           "version": "1.0.10",
-          "bom-ref": "nachet-frontend@0.10.3|xmlbuilder2@3.1.1|argparse@1.0.10",
+          "bom-ref": "nachet-frontend@0.10.4|xmlbuilder2@3.1.1|argparse@1.0.10",
           "purl": "pkg:npm/argparse@1.0.10",
           "externalReferences": [
             {
@@ -29457,7 +29465,7 @@
           "type": "library",
           "name": "js-yaml",
           "version": "3.14.1",
-          "bom-ref": "nachet-frontend@0.10.3|xmlbuilder2@3.1.1|js-yaml@3.14.1",
+          "bom-ref": "nachet-frontend@0.10.4|xmlbuilder2@3.1.1|js-yaml@3.14.1",
           "purl": "pkg:npm/js-yaml@3.14.1",
           "externalReferences": [
             {
@@ -29489,7 +29497,7 @@
       "type": "library",
       "name": "xmlchars",
       "version": "2.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|xmlchars@2.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|xmlchars@2.2.0",
       "purl": "pkg:npm/xmlchars@2.2.0",
       "externalReferences": [
         {
@@ -29519,7 +29527,7 @@
       "type": "library",
       "name": "y18n",
       "version": "5.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|y18n@5.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|y18n@5.0.8",
       "purl": "pkg:npm/y18n@5.0.8",
       "externalReferences": [
         {
@@ -29545,7 +29553,7 @@
       "type": "library",
       "name": "yallist",
       "version": "3.1.1",
-      "bom-ref": "nachet-frontend@0.10.3|yallist@3.1.1",
+      "bom-ref": "nachet-frontend@0.10.4|yallist@3.1.1",
       "purl": "pkg:npm/yallist@3.1.1",
       "externalReferences": [
         {
@@ -29571,7 +29579,7 @@
       "type": "library",
       "name": "yargs-parser",
       "version": "20.2.9",
-      "bom-ref": "nachet-frontend@0.10.3|yargs-parser@20.2.9",
+      "bom-ref": "nachet-frontend@0.10.4|yargs-parser@20.2.9",
       "purl": "pkg:npm/yargs-parser@20.2.9",
       "externalReferences": [
         {
@@ -29597,7 +29605,7 @@
       "type": "library",
       "name": "yargs",
       "version": "16.2.0",
-      "bom-ref": "nachet-frontend@0.10.3|yargs@16.2.0",
+      "bom-ref": "nachet-frontend@0.10.4|yargs@16.2.0",
       "purl": "pkg:npm/yargs@16.2.0",
       "externalReferences": [
         {
@@ -29623,7 +29631,7 @@
           "type": "library",
           "name": "emoji-regex",
           "version": "8.0.0",
-          "bom-ref": "nachet-frontend@0.10.3|yargs@16.2.0|emoji-regex@8.0.0",
+          "bom-ref": "nachet-frontend@0.10.4|yargs@16.2.0|emoji-regex@8.0.0",
           "purl": "pkg:npm/emoji-regex@8.0.0",
           "externalReferences": [
             {
@@ -29649,7 +29657,7 @@
           "type": "library",
           "name": "string-width",
           "version": "4.2.3",
-          "bom-ref": "nachet-frontend@0.10.3|yargs@16.2.0|string-width@4.2.3",
+          "bom-ref": "nachet-frontend@0.10.4|yargs@16.2.0|string-width@4.2.3",
           "purl": "pkg:npm/string-width@4.2.3",
           "externalReferences": [
             {
@@ -29675,7 +29683,7 @@
           "type": "library",
           "name": "strip-ansi",
           "version": "6.0.1",
-          "bom-ref": "nachet-frontend@0.10.3|yargs@16.2.0|strip-ansi@6.0.1",
+          "bom-ref": "nachet-frontend@0.10.4|yargs@16.2.0|strip-ansi@6.0.1",
           "purl": "pkg:npm/strip-ansi@6.0.1",
           "externalReferences": [
             {
@@ -29703,7 +29711,7 @@
       "type": "library",
       "name": "yocto-queue",
       "version": "0.1.0",
-      "bom-ref": "nachet-frontend@0.10.3|yocto-queue@0.1.0",
+      "bom-ref": "nachet-frontend@0.10.4|yocto-queue@0.1.0",
       "purl": "pkg:npm/yocto-queue@0.1.0",
       "externalReferences": [
         {
@@ -29733,7 +29741,7 @@
       "type": "library",
       "name": "zod",
       "version": "4.1.8",
-      "bom-ref": "nachet-frontend@0.10.3|zod@4.1.8",
+      "bom-ref": "nachet-frontend@0.10.4|zod@4.1.8",
       "purl": "pkg:npm/zod@4.1.8",
       "externalReferences": [
         {
@@ -29759,7 +29767,7 @@
       "type": "library",
       "name": "zustand",
       "version": "5.0.8",
-      "bom-ref": "nachet-frontend@0.10.3|zustand@5.0.8",
+      "bom-ref": "nachet-frontend@0.10.4|zustand@5.0.8",
       "purl": "pkg:npm/zustand@5.0.8",
       "externalReferences": [
         {
@@ -29784,6239 +29792,6239 @@
   ],
   "dependencies": [
     {
-      "ref": "nachet-frontend@0.10.3",
-      "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/plugin-transform-private-property-in-object@7.27.1",
-        "nachet-frontend@0.10.3|@babel/preset-env@7.28.3",
-        "nachet-frontend@0.10.3|@babel/preset-react@7.27.1",
-        "nachet-frontend@0.10.3|@babel/preset-typescript@7.27.1",
-        "nachet-frontend@0.10.3|@cyclonedx/cyclonedx-npm@4.0.2",
-        "nachet-frontend@0.10.3|@emotion/react@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/styled@11.14.1",
-        "nachet-frontend@0.10.3|@eslint/compat@1.3.2",
-        "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1",
-        "nachet-frontend@0.10.3|@eslint/js@9.35.0",
-        "nachet-frontend@0.10.3|@mui/icons-material@7.3.2",
-        "nachet-frontend@0.10.3|@mui/material@7.3.2",
-        "nachet-frontend@0.10.3|@saithodev/ts-appversion@2.2.0",
-        "nachet-frontend@0.10.3|@testing-library/jest-dom@6.8.0",
-        "nachet-frontend@0.10.3|@testing-library/react@16.3.0",
-        "nachet-frontend@0.10.3|@testing-library/user-event@14.6.1",
-        "nachet-frontend@0.10.3|@types/file-saver@2.0.7",
-        "nachet-frontend@0.10.3|@types/js-cookie@3.0.6",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|@types/pako@2.0.4",
-        "nachet-frontend@0.10.3|@types/react-dom@19.1.9",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|@types/sanitize-html@2.16.0",
-        "nachet-frontend@0.10.3|@types/utif@3.0.6",
-        "nachet-frontend@0.10.3|@types/uuid@10.0.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/eslint-plugin@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/parser@8.44.0",
-        "nachet-frontend@0.10.3|@vitejs/plugin-react-swc@4.0.1",
-        "nachet-frontend@0.10.3|@vitest/coverage-v8@3.2.4",
-        "nachet-frontend@0.10.3|axios@1.12.2",
-        "nachet-frontend@0.10.3|browser-image-compression@2.0.2",
-        "nachet-frontend@0.10.3|dompurify@3.2.6",
-        "nachet-frontend@0.10.3|eslint-config-prettier@10.1.8",
-        "nachet-frontend@0.10.3|eslint-plugin-import@2.32.0",
-        "nachet-frontend@0.10.3|eslint-plugin-prettier@5.5.4",
-        "nachet-frontend@0.10.3|eslint-plugin-react-hooks@5.2.0",
-        "nachet-frontend@0.10.3|eslint-plugin-react-refresh@0.4.20",
-        "nachet-frontend@0.10.3|eslint-plugin-react@7.37.5",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|express@5.1.0",
-        "nachet-frontend@0.10.3|file-saver@2.0.5",
-        "nachet-frontend@0.10.3|globals@16.4.0",
-        "nachet-frontend@0.10.3|identity-obj-proxy@3.0.0",
-        "nachet-frontend@0.10.3|jest-environment-jsdom@30.1.2",
-        "nachet-frontend@0.10.3|js-base64@3.7.8",
-        "nachet-frontend@0.10.3|js-cookie@3.0.5",
-        "nachet-frontend@0.10.3|jszip@3.10.1",
-        "nachet-frontend@0.10.3|jwt-decode@4.0.0",
-        "nachet-frontend@0.10.3|node-fetch@3.3.2",
-        "nachet-frontend@0.10.3|pako@2.1.0",
-        "nachet-frontend@0.10.3|playwright@1.55.0",
-        "nachet-frontend@0.10.3|prettier@3.6.2",
-        "nachet-frontend@0.10.3|re-resizable@6.11.2",
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react-draggable@4.5.0",
-        "nachet-frontend@0.10.3|react-icons@5.5.0",
-        "nachet-frontend@0.10.3|react-picture-annotation@1.2.0",
-        "nachet-frontend@0.10.3|react-router-dom@7.9.1",
-        "nachet-frontend@0.10.3|react-webcam@7.2.0",
-        "nachet-frontend@0.10.3|react@19.1.1",
-        "nachet-frontend@0.10.3|sanitize-html@2.17.0",
-        "nachet-frontend@0.10.3|serve@14.2.5",
-        "nachet-frontend@0.10.3|styled-components@6.1.19",
-        "nachet-frontend@0.10.3|typescript@5.9.2",
-        "nachet-frontend@0.10.3|utif@3.1.0",
-        "nachet-frontend@0.10.3|uuid@11.1.0",
-        "nachet-frontend@0.10.3|vite-plugin-environment@1.1.3",
-        "nachet-frontend@0.10.3|vite@7.1.5",
-        "nachet-frontend@0.10.3|vitest@3.2.4",
-        "nachet-frontend@0.10.3|web-vitals@5.1.0",
-        "nachet-frontend@0.10.3|zod@4.1.8",
-        "nachet-frontend@0.10.3|zustand@5.0.8"
-      ]
-    },
-    {
-      "ref": "nachet-frontend@0.10.3|@adobe/css-tools@4.4.4"
+      "ref": "nachet-frontend@0.10.4",
+      "dependsOn": [
+        "nachet-frontend@0.10.4|@babel/plugin-transform-private-property-in-object@7.27.1",
+        "nachet-frontend@0.10.4|@babel/preset-env@7.28.3",
+        "nachet-frontend@0.10.4|@babel/preset-react@7.27.1",
+        "nachet-frontend@0.10.4|@babel/preset-typescript@7.27.1",
+        "nachet-frontend@0.10.4|@cyclonedx/cyclonedx-npm@4.0.2",
+        "nachet-frontend@0.10.4|@emotion/react@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/styled@11.14.1",
+        "nachet-frontend@0.10.4|@eslint/compat@1.3.2",
+        "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1",
+        "nachet-frontend@0.10.4|@eslint/js@9.35.0",
+        "nachet-frontend@0.10.4|@mui/icons-material@7.3.2",
+        "nachet-frontend@0.10.4|@mui/material@7.3.2",
+        "nachet-frontend@0.10.4|@saithodev/ts-appversion@2.2.0",
+        "nachet-frontend@0.10.4|@testing-library/jest-dom@6.8.0",
+        "nachet-frontend@0.10.4|@testing-library/react@16.3.0",
+        "nachet-frontend@0.10.4|@testing-library/user-event@14.6.1",
+        "nachet-frontend@0.10.4|@types/file-saver@2.0.7",
+        "nachet-frontend@0.10.4|@types/js-cookie@3.0.6",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|@types/pako@2.0.4",
+        "nachet-frontend@0.10.4|@types/react-dom@19.1.9",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|@types/sanitize-html@2.16.0",
+        "nachet-frontend@0.10.4|@types/utif@3.0.6",
+        "nachet-frontend@0.10.4|@types/uuid@10.0.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/eslint-plugin@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/parser@8.44.0",
+        "nachet-frontend@0.10.4|@vitejs/plugin-react-swc@4.0.1",
+        "nachet-frontend@0.10.4|@vitest/coverage-v8@3.2.4",
+        "nachet-frontend@0.10.4|axios@1.12.2",
+        "nachet-frontend@0.10.4|browser-image-compression@2.0.2",
+        "nachet-frontend@0.10.4|dompurify@3.2.6",
+        "nachet-frontend@0.10.4|eslint-config-prettier@10.1.8",
+        "nachet-frontend@0.10.4|eslint-plugin-import@2.32.0",
+        "nachet-frontend@0.10.4|eslint-plugin-prettier@5.5.4",
+        "nachet-frontend@0.10.4|eslint-plugin-react-hooks@5.2.0",
+        "nachet-frontend@0.10.4|eslint-plugin-react-refresh@0.4.20",
+        "nachet-frontend@0.10.4|eslint-plugin-react@7.37.5",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|express@5.1.0",
+        "nachet-frontend@0.10.4|file-saver@2.0.5",
+        "nachet-frontend@0.10.4|globals@16.4.0",
+        "nachet-frontend@0.10.4|identity-obj-proxy@3.0.0",
+        "nachet-frontend@0.10.4|jest-environment-jsdom@30.1.2",
+        "nachet-frontend@0.10.4|js-base64@3.7.8",
+        "nachet-frontend@0.10.4|js-cookie@3.0.5",
+        "nachet-frontend@0.10.4|jszip@3.10.1",
+        "nachet-frontend@0.10.4|jwt-decode@4.0.0",
+        "nachet-frontend@0.10.4|node-fetch@3.3.2",
+        "nachet-frontend@0.10.4|pako@2.1.0",
+        "nachet-frontend@0.10.4|playwright@1.55.0",
+        "nachet-frontend@0.10.4|prettier@3.6.2",
+        "nachet-frontend@0.10.4|re-resizable@6.11.2",
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react-draggable@4.5.0",
+        "nachet-frontend@0.10.4|react-icons@5.5.0",
+        "nachet-frontend@0.10.4|react-picture-annotation@1.2.0",
+        "nachet-frontend@0.10.4|react-router-dom@7.9.1",
+        "nachet-frontend@0.10.4|react-webcam@7.2.0",
+        "nachet-frontend@0.10.4|react@19.1.1",
+        "nachet-frontend@0.10.4|sanitize-html@2.17.0",
+        "nachet-frontend@0.10.4|serve@14.2.5",
+        "nachet-frontend@0.10.4|styled-components@6.1.19",
+        "nachet-frontend@0.10.4|typescript@5.9.2",
+        "nachet-frontend@0.10.4|utif@3.1.0",
+        "nachet-frontend@0.10.4|uuid@11.1.0",
+        "nachet-frontend@0.10.4|vite-plugin-environment@1.1.3",
+        "nachet-frontend@0.10.4|vite@7.1.5",
+        "nachet-frontend@0.10.4|vitest@3.2.4",
+        "nachet-frontend@0.10.4|web-vitals@5.1.0",
+        "nachet-frontend@0.10.4|zod@4.1.8",
+        "nachet-frontend@0.10.4|zustand@5.0.8"
+      ]
+    },
+    {
+      "ref": "nachet-frontend@0.10.4|@adobe/css-tools@4.4.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@ampproject/remapping@2.3.0",
+      "ref": "nachet-frontend@0.10.4|@ampproject/remapping@2.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/gen-mapping@0.3.13",
-        "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31"
+        "nachet-frontend@0.10.4|@jridgewell/gen-mapping@0.3.13",
+        "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@asamuzakjp/css-color@3.2.0",
+      "ref": "nachet-frontend@0.10.4|@asamuzakjp/css-color@3.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@asamuzakjp/css-color@3.2.0|lru-cache@10.4.3",
-        "nachet-frontend@0.10.3|@csstools/css-calc@2.1.4",
-        "nachet-frontend@0.10.3|@csstools/css-color-parser@3.1.0",
-        "nachet-frontend@0.10.3|@csstools/css-parser-algorithms@3.0.5",
-        "nachet-frontend@0.10.3|@csstools/css-tokenizer@3.0.4"
+        "nachet-frontend@0.10.4|@asamuzakjp/css-color@3.2.0|lru-cache@10.4.3",
+        "nachet-frontend@0.10.4|@csstools/css-calc@2.1.4",
+        "nachet-frontend@0.10.4|@csstools/css-color-parser@3.1.0",
+        "nachet-frontend@0.10.4|@csstools/css-parser-algorithms@3.0.5",
+        "nachet-frontend@0.10.4|@csstools/css-tokenizer@3.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@asamuzakjp/css-color@3.2.0|lru-cache@10.4.3"
+      "ref": "nachet-frontend@0.10.4|@asamuzakjp/css-color@3.2.0|lru-cache@10.4.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/helper-validator-identifier@7.27.1",
-        "nachet-frontend@0.10.3|js-tokens@4.0.0",
-        "nachet-frontend@0.10.3|picocolors@1.1.1"
+        "nachet-frontend@0.10.4|@babel/helper-validator-identifier@7.27.1",
+        "nachet-frontend@0.10.4|js-tokens@4.0.0",
+        "nachet-frontend@0.10.4|picocolors@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/compat-data@7.28.4"
+      "ref": "nachet-frontend@0.10.4|@babel/compat-data@7.28.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/core@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/core@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
-        "nachet-frontend@0.10.3|@babel/generator@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
-        "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helpers@7.28.4",
-        "nachet-frontend@0.10.3|@babel/parser@7.28.4",
-        "nachet-frontend@0.10.3|@babel/template@7.27.2",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4",
-        "nachet-frontend@0.10.3|@jridgewell/remapping@2.3.5",
-        "nachet-frontend@0.10.3|convert-source-map@2.0.0",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|gensync@1.0.0-beta.2",
-        "nachet-frontend@0.10.3|json5@2.2.3",
-        "nachet-frontend@0.10.3|semver@6.3.1"
+        "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
+        "nachet-frontend@0.10.4|@babel/generator@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
+        "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helpers@7.28.4",
+        "nachet-frontend@0.10.4|@babel/parser@7.28.4",
+        "nachet-frontend@0.10.4|@babel/template@7.27.2",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4",
+        "nachet-frontend@0.10.4|@jridgewell/remapping@2.3.5",
+        "nachet-frontend@0.10.4|convert-source-map@2.0.0",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|gensync@1.0.0-beta.2",
+        "nachet-frontend@0.10.4|json5@2.2.3",
+        "nachet-frontend@0.10.4|semver@6.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/generator@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/generator@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/parser@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4",
-        "nachet-frontend@0.10.3|@jridgewell/gen-mapping@0.3.13",
-        "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31",
-        "nachet-frontend@0.10.3|jsesc@3.1.0"
+        "nachet-frontend@0.10.4|@babel/parser@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4",
+        "nachet-frontend@0.10.4|@jridgewell/gen-mapping@0.3.13",
+        "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31",
+        "nachet-frontend@0.10.4|jsesc@3.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/compat-data@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-validator-option@7.27.1",
-        "nachet-frontend@0.10.3|browserslist@4.26.2",
-        "nachet-frontend@0.10.3|lru-cache@5.1.1",
-        "nachet-frontend@0.10.3|semver@6.3.1"
+        "nachet-frontend@0.10.4|@babel/compat-data@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-validator-option@7.27.1",
+        "nachet-frontend@0.10.4|browserslist@4.26.2",
+        "nachet-frontend@0.10.4|lru-cache@5.1.1",
+        "nachet-frontend@0.10.4|semver@6.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-member-expression-to-functions@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-optimise-call-expression@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-replace-supers@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
-        "nachet-frontend@0.10.3|semver@6.3.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-member-expression-to-functions@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-optimise-call-expression@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-replace-supers@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
+        "nachet-frontend@0.10.4|semver@6.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|regexpu-core@6.3.1",
-        "nachet-frontend@0.10.3|semver@6.3.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|regexpu-core@6.3.1",
+        "nachet-frontend@0.10.4|semver@6.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-define-polyfill-provider@0.6.5",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-define-polyfill-provider@0.6.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|lodash.debounce@4.0.8",
-        "nachet-frontend@0.10.3|resolve@1.22.10"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|lodash.debounce@4.0.8",
+        "nachet-frontend@0.10.4|resolve@1.22.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-globals@7.28.0"
+      "ref": "nachet-frontend@0.10.4|@babel/helper-globals@7.28.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-member-expression-to-functions@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-member-expression-to-functions@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-module-imports@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-module-imports@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-module-imports@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-validator-identifier@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-module-imports@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-validator-identifier@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-optimise-call-expression@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-optimise-call-expression@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+      "ref": "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-remap-async-to-generator@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-remap-async-to-generator@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-wrap-function@7.28.3",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-wrap-function@7.28.3",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-replace-supers@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-replace-supers@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-member-expression-to-functions@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-optimise-call-expression@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-member-expression-to-functions@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-optimise-call-expression@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-string-parser@7.27.1"
+      "ref": "nachet-frontend@0.10.4|@babel/helper-string-parser@7.27.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-validator-identifier@7.27.1"
+      "ref": "nachet-frontend@0.10.4|@babel/helper-validator-identifier@7.27.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-validator-option@7.27.1"
+      "ref": "nachet-frontend@0.10.4|@babel/helper-validator-option@7.27.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helper-wrap-function@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/helper-wrap-function@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/template@7.27.2",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/template@7.27.2",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/helpers@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/helpers@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/template@7.27.2",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/template@7.27.2",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/parser@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/parser@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-optional-chaining@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-optional-chaining@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-import-assertions@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-import-assertions@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-import-attributes@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-import-attributes@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-jsx@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-jsx@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-typescript@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-typescript@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-syntax-unicode-sets-regex@7.18.6",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-syntax-unicode-sets-regex@7.18.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-arrow-functions@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-arrow-functions@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-async-generator-functions@7.28.0",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-async-generator-functions@7.28.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-remap-async-to-generator@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-remap-async-to-generator@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-async-to-generator@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-async-to-generator@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-module-imports@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-remap-async-to-generator@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-module-imports@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-remap-async-to-generator@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-block-scoped-functions@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-block-scoped-functions@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-block-scoping@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-block-scoping@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-class-properties@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-class-properties@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-class-static-block@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-class-static-block@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-classes@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-classes@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
-        "nachet-frontend@0.10.3|@babel/helper-globals@7.28.0",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-replace-supers@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
+        "nachet-frontend@0.10.4|@babel/helper-globals@7.28.0",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-replace-supers@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-computed-properties@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-computed-properties@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/template@7.27.2"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/template@7.27.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-destructuring@7.28.0",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-destructuring@7.28.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-dotall-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-dotall-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-duplicate-keys@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-duplicate-keys@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-dynamic-import@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-dynamic-import@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-explicit-resource-management@7.28.0",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-explicit-resource-management@7.28.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-destructuring@7.28.0"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-destructuring@7.28.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-exponentiation-operator@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-exponentiation-operator@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-export-namespace-from@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-export-namespace-from@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-for-of@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-for-of@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-function-name@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-function-name@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-json-strings@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-json-strings@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-literals@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-literals@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-logical-assignment-operators@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-logical-assignment-operators@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-member-expression-literals@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-member-expression-literals@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-amd@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-amd@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-commonjs@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-commonjs@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-systemjs@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-systemjs@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-validator-identifier@7.27.1",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-validator-identifier@7.27.1",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-modules-umd@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-modules-umd@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-module-transforms@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-module-transforms@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-named-capturing-groups-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-named-capturing-groups-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-new-target@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-new-target@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-nullish-coalescing-operator@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-nullish-coalescing-operator@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-numeric-separator@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-numeric-separator@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-object-rest-spread@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-object-rest-spread@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-destructuring@7.28.0",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-parameters@7.27.7",
-        "nachet-frontend@0.10.3|@babel/traverse@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-destructuring@7.28.0",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-parameters@7.27.7",
+        "nachet-frontend@0.10.4|@babel/traverse@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-object-super@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-object-super@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-replace-supers@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-replace-supers@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-optional-catch-binding@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-optional-catch-binding@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-optional-chaining@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-optional-chaining@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-parameters@7.27.7",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-parameters@7.27.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-private-methods@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-private-methods@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-private-property-in-object@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-private-property-in-object@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-property-literals@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-property-literals@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-display-name@7.28.0",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-display-name@7.28.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx-development@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx-development@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-module-imports@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-syntax-jsx@7.27.1",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-module-imports@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-syntax-jsx@7.27.1",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-react-pure-annotations@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-react-pure-annotations@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-regenerator@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-regenerator@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-regexp-modifiers@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-regexp-modifiers@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-reserved-words@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-reserved-words@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-shorthand-properties@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-shorthand-properties@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-spread@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-spread@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-sticky-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-sticky-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-template-literals@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-template-literals@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-typeof-symbol@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-typeof-symbol@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-typescript@7.28.0",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-typescript@7.28.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-annotate-as-pure@7.27.3",
-        "nachet-frontend@0.10.3|@babel/helper-create-class-features-plugin@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-syntax-typescript@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-annotate-as-pure@7.27.3",
+        "nachet-frontend@0.10.4|@babel/helper-create-class-features-plugin@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-skip-transparent-expression-wrappers@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-syntax-typescript@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-escapes@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-escapes@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-property-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-property-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-sets-regex@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-sets-regex@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-create-regexp-features-plugin@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-create-regexp-features-plugin@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/preset-env@7.28.3",
+      "ref": "nachet-frontend@0.10.4|@babel/preset-env@7.28.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/compat-data@7.28.4",
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-compilation-targets@7.27.2",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-validator-option@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
-        "nachet-frontend@0.10.3|@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
-        "nachet-frontend@0.10.3|@babel/plugin-syntax-import-assertions@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-syntax-import-attributes@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-syntax-unicode-sets-regex@7.18.6",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-arrow-functions@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-async-generator-functions@7.28.0",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-async-to-generator@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-block-scoped-functions@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-block-scoping@7.28.4",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-class-properties@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-class-static-block@7.28.3",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-classes@7.28.4",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-computed-properties@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-destructuring@7.28.0",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-dotall-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-duplicate-keys@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-dynamic-import@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-explicit-resource-management@7.28.0",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-exponentiation-operator@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-export-namespace-from@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-for-of@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-function-name@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-json-strings@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-literals@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-logical-assignment-operators@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-member-expression-literals@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-modules-amd@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-modules-commonjs@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-modules-systemjs@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-modules-umd@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-named-capturing-groups-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-new-target@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-nullish-coalescing-operator@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-numeric-separator@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-object-rest-spread@7.28.4",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-object-super@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-optional-catch-binding@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-optional-chaining@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-parameters@7.27.7",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-private-methods@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-private-property-in-object@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-property-literals@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-regenerator@7.28.4",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-regexp-modifiers@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-reserved-words@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-shorthand-properties@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-spread@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-sticky-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-template-literals@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-typeof-symbol@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-escapes@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-property-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-unicode-sets-regex@7.27.1",
-        "nachet-frontend@0.10.3|@babel/preset-modules@0.1.6-no-external-plugins",
-        "nachet-frontend@0.10.3|babel-plugin-polyfill-corejs2@0.4.14",
-        "nachet-frontend@0.10.3|babel-plugin-polyfill-corejs3@0.13.0",
-        "nachet-frontend@0.10.3|babel-plugin-polyfill-regenerator@0.6.5",
-        "nachet-frontend@0.10.3|core-js-compat@3.45.1",
-        "nachet-frontend@0.10.3|semver@6.3.1"
+        "nachet-frontend@0.10.4|@babel/compat-data@7.28.4",
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-compilation-targets@7.27.2",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-validator-option@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3",
+        "nachet-frontend@0.10.4|@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2",
+        "nachet-frontend@0.10.4|@babel/plugin-syntax-import-assertions@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-syntax-import-attributes@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-syntax-unicode-sets-regex@7.18.6",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-arrow-functions@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-async-generator-functions@7.28.0",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-async-to-generator@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-block-scoped-functions@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-block-scoping@7.28.4",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-class-properties@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-class-static-block@7.28.3",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-classes@7.28.4",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-computed-properties@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-destructuring@7.28.0",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-dotall-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-duplicate-keys@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-dynamic-import@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-explicit-resource-management@7.28.0",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-exponentiation-operator@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-export-namespace-from@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-for-of@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-function-name@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-json-strings@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-literals@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-logical-assignment-operators@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-member-expression-literals@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-modules-amd@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-modules-commonjs@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-modules-systemjs@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-modules-umd@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-named-capturing-groups-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-new-target@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-nullish-coalescing-operator@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-numeric-separator@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-object-rest-spread@7.28.4",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-object-super@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-optional-catch-binding@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-optional-chaining@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-parameters@7.27.7",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-private-methods@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-private-property-in-object@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-property-literals@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-regenerator@7.28.4",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-regexp-modifiers@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-reserved-words@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-shorthand-properties@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-spread@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-sticky-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-template-literals@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-typeof-symbol@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-escapes@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-property-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-unicode-sets-regex@7.27.1",
+        "nachet-frontend@0.10.4|@babel/preset-modules@0.1.6-no-external-plugins",
+        "nachet-frontend@0.10.4|babel-plugin-polyfill-corejs2@0.4.14",
+        "nachet-frontend@0.10.4|babel-plugin-polyfill-corejs3@0.13.0",
+        "nachet-frontend@0.10.4|babel-plugin-polyfill-regenerator@0.6.5",
+        "nachet-frontend@0.10.4|core-js-compat@3.45.1",
+        "nachet-frontend@0.10.4|semver@6.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/preset-modules@0.1.6-no-external-plugins",
+      "ref": "nachet-frontend@0.10.4|@babel/preset-modules@0.1.6-no-external-plugins",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4",
-        "nachet-frontend@0.10.3|esutils@2.0.3"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4",
+        "nachet-frontend@0.10.4|esutils@2.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/preset-react@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/preset-react@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-validator-option@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-react-display-name@7.28.0",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx-development@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-react-jsx@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-react-pure-annotations@7.27.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-validator-option@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-react-display-name@7.28.0",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx-development@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-react-jsx@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-react-pure-annotations@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/preset-typescript@7.27.1",
+      "ref": "nachet-frontend@0.10.4|@babel/preset-typescript@7.27.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-plugin-utils@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-validator-option@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-syntax-jsx@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-modules-commonjs@7.27.1",
-        "nachet-frontend@0.10.3|@babel/plugin-transform-typescript@7.28.0"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-plugin-utils@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-validator-option@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-syntax-jsx@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-modules-commonjs@7.27.1",
+        "nachet-frontend@0.10.4|@babel/plugin-transform-typescript@7.28.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/runtime@7.28.4"
+      "ref": "nachet-frontend@0.10.4|@babel/runtime@7.28.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/template@7.27.2",
+      "ref": "nachet-frontend@0.10.4|@babel/template@7.27.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
-        "nachet-frontend@0.10.3|@babel/parser@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4"
+        "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
+        "nachet-frontend@0.10.4|@babel/parser@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/traverse@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/traverse@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
-        "nachet-frontend@0.10.3|@babel/generator@7.28.3",
-        "nachet-frontend@0.10.3|@babel/helper-globals@7.28.0",
-        "nachet-frontend@0.10.3|@babel/parser@7.28.4",
-        "nachet-frontend@0.10.3|@babel/template@7.27.2",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4",
-        "nachet-frontend@0.10.3|debug@4.4.3"
+        "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
+        "nachet-frontend@0.10.4|@babel/generator@7.28.3",
+        "nachet-frontend@0.10.4|@babel/helper-globals@7.28.0",
+        "nachet-frontend@0.10.4|@babel/parser@7.28.4",
+        "nachet-frontend@0.10.4|@babel/template@7.27.2",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4",
+        "nachet-frontend@0.10.4|debug@4.4.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@babel/types@7.28.4",
+      "ref": "nachet-frontend@0.10.4|@babel/types@7.28.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/helper-string-parser@7.27.1",
-        "nachet-frontend@0.10.3|@babel/helper-validator-identifier@7.27.1"
+        "nachet-frontend@0.10.4|@babel/helper-string-parser@7.27.1",
+        "nachet-frontend@0.10.4|@babel/helper-validator-identifier@7.27.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@bcoe/v8-coverage@1.0.2"
+      "ref": "nachet-frontend@0.10.4|@bcoe/v8-coverage@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@csstools/color-helpers@5.1.0"
+      "ref": "nachet-frontend@0.10.4|@csstools/color-helpers@5.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@csstools/css-calc@2.1.4",
+      "ref": "nachet-frontend@0.10.4|@csstools/css-calc@2.1.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@csstools/css-parser-algorithms@3.0.5",
-        "nachet-frontend@0.10.3|@csstools/css-tokenizer@3.0.4"
+        "nachet-frontend@0.10.4|@csstools/css-parser-algorithms@3.0.5",
+        "nachet-frontend@0.10.4|@csstools/css-tokenizer@3.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@csstools/css-color-parser@3.1.0",
+      "ref": "nachet-frontend@0.10.4|@csstools/css-color-parser@3.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@csstools/color-helpers@5.1.0",
-        "nachet-frontend@0.10.3|@csstools/css-calc@2.1.4",
-        "nachet-frontend@0.10.3|@csstools/css-parser-algorithms@3.0.5",
-        "nachet-frontend@0.10.3|@csstools/css-tokenizer@3.0.4"
+        "nachet-frontend@0.10.4|@csstools/color-helpers@5.1.0",
+        "nachet-frontend@0.10.4|@csstools/css-calc@2.1.4",
+        "nachet-frontend@0.10.4|@csstools/css-parser-algorithms@3.0.5",
+        "nachet-frontend@0.10.4|@csstools/css-tokenizer@3.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@csstools/css-parser-algorithms@3.0.5",
+      "ref": "nachet-frontend@0.10.4|@csstools/css-parser-algorithms@3.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@csstools/css-tokenizer@3.0.4"
+        "nachet-frontend@0.10.4|@csstools/css-tokenizer@3.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@csstools/css-tokenizer@3.0.4"
+      "ref": "nachet-frontend@0.10.4|@csstools/css-tokenizer@3.0.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@cyclonedx/cyclonedx-library@9.0.0",
+      "ref": "nachet-frontend@0.10.4|@cyclonedx/cyclonedx-library@9.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ajv-formats-draft2019@1.6.1",
-        "nachet-frontend@0.10.3|ajv-formats@3.0.1",
-        "nachet-frontend@0.10.3|ajv@8.17.1",
-        "nachet-frontend@0.10.3|libxmljs2@0.37.0",
-        "nachet-frontend@0.10.3|packageurl-js@2.0.1",
-        "nachet-frontend@0.10.3|spdx-expression-parse@4.0.0",
-        "nachet-frontend@0.10.3|xmlbuilder2@3.1.1"
+        "nachet-frontend@0.10.4|ajv-formats-draft2019@1.6.1",
+        "nachet-frontend@0.10.4|ajv-formats@3.0.1",
+        "nachet-frontend@0.10.4|ajv@8.17.1",
+        "nachet-frontend@0.10.4|libxmljs2@0.37.0",
+        "nachet-frontend@0.10.4|packageurl-js@2.0.1",
+        "nachet-frontend@0.10.4|spdx-expression-parse@4.0.0",
+        "nachet-frontend@0.10.4|xmlbuilder2@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@cyclonedx/cyclonedx-npm@4.0.2",
+      "ref": "nachet-frontend@0.10.4|@cyclonedx/cyclonedx-npm@4.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@cyclonedx/cyclonedx-library@9.0.0",
-        "nachet-frontend@0.10.3|ajv-formats-draft2019@1.6.1",
-        "nachet-frontend@0.10.3|ajv-formats@3.0.1",
-        "nachet-frontend@0.10.3|ajv@8.17.1",
-        "nachet-frontend@0.10.3|commander@14.0.1",
-        "nachet-frontend@0.10.3|libxmljs2@0.37.0",
-        "nachet-frontend@0.10.3|normalize-package-data@8.0.0",
-        "nachet-frontend@0.10.3|xmlbuilder2@3.1.1"
+        "nachet-frontend@0.10.4|@cyclonedx/cyclonedx-library@9.0.0",
+        "nachet-frontend@0.10.4|ajv-formats-draft2019@1.6.1",
+        "nachet-frontend@0.10.4|ajv-formats@3.0.1",
+        "nachet-frontend@0.10.4|ajv@8.17.1",
+        "nachet-frontend@0.10.4|commander@14.0.1",
+        "nachet-frontend@0.10.4|libxmljs2@0.37.0",
+        "nachet-frontend@0.10.4|normalize-package-data@8.0.0",
+        "nachet-frontend@0.10.4|xmlbuilder2@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5",
+      "ref": "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/helper-module-imports@7.27.1",
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5|convert-source-map@1.9.0",
-        "nachet-frontend@0.10.3|@emotion/hash@0.9.2",
-        "nachet-frontend@0.10.3|@emotion/memoize@0.9.0",
-        "nachet-frontend@0.10.3|@emotion/serialize@1.3.3",
-        "nachet-frontend@0.10.3|babel-plugin-macros@3.1.0",
-        "nachet-frontend@0.10.3|escape-string-regexp@4.0.0",
-        "nachet-frontend@0.10.3|find-root@1.1.0",
-        "nachet-frontend@0.10.3|source-map@0.5.7",
-        "nachet-frontend@0.10.3|stylis@4.2.0"
+        "nachet-frontend@0.10.4|@babel/helper-module-imports@7.27.1",
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5|convert-source-map@1.9.0",
+        "nachet-frontend@0.10.4|@emotion/hash@0.9.2",
+        "nachet-frontend@0.10.4|@emotion/memoize@0.9.0",
+        "nachet-frontend@0.10.4|@emotion/serialize@1.3.3",
+        "nachet-frontend@0.10.4|babel-plugin-macros@3.1.0",
+        "nachet-frontend@0.10.4|escape-string-regexp@4.0.0",
+        "nachet-frontend@0.10.4|find-root@1.1.0",
+        "nachet-frontend@0.10.4|source-map@0.5.7",
+        "nachet-frontend@0.10.4|stylis@4.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5|convert-source-map@1.9.0"
+      "ref": "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5|convert-source-map@1.9.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/cache@11.14.0",
+      "ref": "nachet-frontend@0.10.4|@emotion/cache@11.14.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@emotion/memoize@0.9.0",
-        "nachet-frontend@0.10.3|@emotion/sheet@1.4.0",
-        "nachet-frontend@0.10.3|@emotion/utils@1.4.2",
-        "nachet-frontend@0.10.3|@emotion/weak-memoize@0.4.0",
-        "nachet-frontend@0.10.3|stylis@4.2.0"
+        "nachet-frontend@0.10.4|@emotion/memoize@0.9.0",
+        "nachet-frontend@0.10.4|@emotion/sheet@1.4.0",
+        "nachet-frontend@0.10.4|@emotion/utils@1.4.2",
+        "nachet-frontend@0.10.4|@emotion/weak-memoize@0.4.0",
+        "nachet-frontend@0.10.4|stylis@4.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/hash@0.9.2"
+      "ref": "nachet-frontend@0.10.4|@emotion/hash@0.9.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/is-prop-valid@1.4.0",
+      "ref": "nachet-frontend@0.10.4|@emotion/is-prop-valid@1.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@emotion/memoize@0.9.0"
+        "nachet-frontend@0.10.4|@emotion/memoize@0.9.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/memoize@0.9.0"
+      "ref": "nachet-frontend@0.10.4|@emotion/memoize@0.9.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/react@11.14.0",
+      "ref": "nachet-frontend@0.10.4|@emotion/react@11.14.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5",
-        "nachet-frontend@0.10.3|@emotion/cache@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/serialize@1.3.3",
-        "nachet-frontend@0.10.3|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
-        "nachet-frontend@0.10.3|@emotion/utils@1.4.2",
-        "nachet-frontend@0.10.3|@emotion/weak-memoize@0.4.0",
-        "nachet-frontend@0.10.3|hoist-non-react-statics@3.3.2",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5",
+        "nachet-frontend@0.10.4|@emotion/cache@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/serialize@1.3.3",
+        "nachet-frontend@0.10.4|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
+        "nachet-frontend@0.10.4|@emotion/utils@1.4.2",
+        "nachet-frontend@0.10.4|@emotion/weak-memoize@0.4.0",
+        "nachet-frontend@0.10.4|hoist-non-react-statics@3.3.2",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/serialize@1.3.3",
+      "ref": "nachet-frontend@0.10.4|@emotion/serialize@1.3.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@emotion/hash@0.9.2",
-        "nachet-frontend@0.10.3|@emotion/memoize@0.9.0",
-        "nachet-frontend@0.10.3|@emotion/unitless@0.10.0",
-        "nachet-frontend@0.10.3|@emotion/utils@1.4.2",
-        "nachet-frontend@0.10.3|csstype@3.1.3"
+        "nachet-frontend@0.10.4|@emotion/hash@0.9.2",
+        "nachet-frontend@0.10.4|@emotion/memoize@0.9.0",
+        "nachet-frontend@0.10.4|@emotion/unitless@0.10.0",
+        "nachet-frontend@0.10.4|@emotion/utils@1.4.2",
+        "nachet-frontend@0.10.4|csstype@3.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/sheet@1.4.0"
+      "ref": "nachet-frontend@0.10.4|@emotion/sheet@1.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/styled@11.14.1",
+      "ref": "nachet-frontend@0.10.4|@emotion/styled@11.14.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@emotion/babel-plugin@11.13.5",
-        "nachet-frontend@0.10.3|@emotion/is-prop-valid@1.4.0",
-        "nachet-frontend@0.10.3|@emotion/react@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/serialize@1.3.3",
-        "nachet-frontend@0.10.3|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
-        "nachet-frontend@0.10.3|@emotion/utils@1.4.2",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@emotion/babel-plugin@11.13.5",
+        "nachet-frontend@0.10.4|@emotion/is-prop-valid@1.4.0",
+        "nachet-frontend@0.10.4|@emotion/react@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/serialize@1.3.3",
+        "nachet-frontend@0.10.4|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
+        "nachet-frontend@0.10.4|@emotion/utils@1.4.2",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/unitless@0.10.0"
+      "ref": "nachet-frontend@0.10.4|@emotion/unitless@0.10.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
+      "ref": "nachet-frontend@0.10.4|@emotion/use-insertion-effect-with-fallbacks@1.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/utils@1.4.2"
+      "ref": "nachet-frontend@0.10.4|@emotion/utils@1.4.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@emotion/weak-memoize@0.4.0"
+      "ref": "nachet-frontend@0.10.4|@emotion/weak-memoize@0.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/aix-ppc64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/aix-ppc64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/android-arm@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/android-arm@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/android-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/android-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/android-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/android-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/darwin-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/darwin-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/darwin-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/darwin-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/freebsd-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/freebsd-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/freebsd-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/freebsd-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-arm@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-arm@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-ia32@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-ia32@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-loong64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-loong64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-mips64el@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-mips64el@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-ppc64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-ppc64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-riscv64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-riscv64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-s390x@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-s390x@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/linux-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/linux-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/netbsd-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/netbsd-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/netbsd-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/netbsd-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/openbsd-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/openbsd-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/openbsd-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/openbsd-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/openharmony-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/openharmony-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/sunos-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/sunos-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/win32-arm64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/win32-arm64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/win32-ia32@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/win32-ia32@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@esbuild/win32-x64@0.25.9"
+      "ref": "nachet-frontend@0.10.4|@esbuild/win32-x64@0.25.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint-community/eslint-utils@4.9.0",
+      "ref": "nachet-frontend@0.10.4|@eslint-community/eslint-utils@4.9.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint-visitor-keys@3.4.3",
-        "nachet-frontend@0.10.3|eslint@9.35.0"
+        "nachet-frontend@0.10.4|eslint-visitor-keys@3.4.3",
+        "nachet-frontend@0.10.4|eslint@9.35.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint-community/regexpp@4.12.1"
+      "ref": "nachet-frontend@0.10.4|@eslint-community/regexpp@4.12.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/compat@1.3.2",
+      "ref": "nachet-frontend@0.10.4|@eslint/compat@1.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint@9.35.0"
+        "nachet-frontend@0.10.4|eslint@9.35.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/config-array@0.21.0",
+      "ref": "nachet-frontend@0.10.4|@eslint/config-array@0.21.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint/object-schema@2.1.6",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|minimatch@3.1.2"
+        "nachet-frontend@0.10.4|@eslint/object-schema@2.1.6",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|minimatch@3.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/config-helpers@0.3.1"
+      "ref": "nachet-frontend@0.10.4|@eslint/config-helpers@0.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/core@0.15.2",
+      "ref": "nachet-frontend@0.10.4|@eslint/core@0.15.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/json-schema@7.0.15"
+        "nachet-frontend@0.10.4|@types/json-schema@7.0.15"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1",
+      "ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|ajv@6.12.6",
-        "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|globals@14.0.0",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|espree@10.4.0",
-        "nachet-frontend@0.10.3|ignore@5.3.2",
-        "nachet-frontend@0.10.3|import-fresh@3.3.1",
-        "nachet-frontend@0.10.3|js-yaml@4.1.0",
-        "nachet-frontend@0.10.3|minimatch@3.1.2",
-        "nachet-frontend@0.10.3|strip-json-comments@3.1.1"
+        "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|ajv@6.12.6",
+        "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|globals@14.0.0",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|espree@10.4.0",
+        "nachet-frontend@0.10.4|ignore@5.3.2",
+        "nachet-frontend@0.10.4|import-fresh@3.3.1",
+        "nachet-frontend@0.10.4|js-yaml@4.1.0",
+        "nachet-frontend@0.10.4|minimatch@3.1.2",
+        "nachet-frontend@0.10.4|strip-json-comments@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|ajv@6.12.6",
+      "ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|ajv@6.12.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|json-schema-traverse@0.4.1",
-        "nachet-frontend@0.10.3|fast-deep-equal@3.1.3",
-        "nachet-frontend@0.10.3|fast-json-stable-stringify@2.1.0",
-        "nachet-frontend@0.10.3|uri-js@4.4.1"
+        "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|json-schema-traverse@0.4.1",
+        "nachet-frontend@0.10.4|fast-deep-equal@3.1.3",
+        "nachet-frontend@0.10.4|fast-json-stable-stringify@2.1.0",
+        "nachet-frontend@0.10.4|uri-js@4.4.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|globals@14.0.0"
+      "ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|globals@14.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1|json-schema-traverse@0.4.1"
+      "ref": "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1|json-schema-traverse@0.4.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/js@9.35.0"
+      "ref": "nachet-frontend@0.10.4|@eslint/js@9.35.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/object-schema@2.1.6"
+      "ref": "nachet-frontend@0.10.4|@eslint/object-schema@2.1.6"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@eslint/plugin-kit@0.3.5",
+      "ref": "nachet-frontend@0.10.4|@eslint/plugin-kit@0.3.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint/core@0.15.2",
-        "nachet-frontend@0.10.3|levn@0.4.1"
+        "nachet-frontend@0.10.4|@eslint/core@0.15.2",
+        "nachet-frontend@0.10.4|levn@0.4.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@humanfs/core@0.19.1"
+      "ref": "nachet-frontend@0.10.4|@humanfs/core@0.19.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@humanfs/node@0.16.7",
+      "ref": "nachet-frontend@0.10.4|@humanfs/node@0.16.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@humanfs/core@0.19.1",
-        "nachet-frontend@0.10.3|@humanwhocodes/retry@0.4.3"
+        "nachet-frontend@0.10.4|@humanfs/core@0.19.1",
+        "nachet-frontend@0.10.4|@humanwhocodes/retry@0.4.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@humanwhocodes/module-importer@1.0.1"
+      "ref": "nachet-frontend@0.10.4|@humanwhocodes/module-importer@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@humanwhocodes/retry@0.4.3"
+      "ref": "nachet-frontend@0.10.4|@humanwhocodes/retry@0.4.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@isaacs/cliui@8.0.2",
+      "ref": "nachet-frontend@0.10.4|@isaacs/cliui@8.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|string-width@4.2.3",
-        "nachet-frontend@0.10.3|string-width@5.1.2",
-        "nachet-frontend@0.10.3|strip-ansi@6.0.1",
-        "nachet-frontend@0.10.3|strip-ansi@7.1.2",
-        "nachet-frontend@0.10.3|wrap-ansi@7.0.0",
-        "nachet-frontend@0.10.3|wrap-ansi@8.1.0"
+        "nachet-frontend@0.10.4|string-width@4.2.3",
+        "nachet-frontend@0.10.4|string-width@5.1.2",
+        "nachet-frontend@0.10.4|strip-ansi@6.0.1",
+        "nachet-frontend@0.10.4|strip-ansi@7.1.2",
+        "nachet-frontend@0.10.4|wrap-ansi@7.0.0",
+        "nachet-frontend@0.10.4|wrap-ansi@8.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@isaacs/fs-minipass@4.0.1",
+      "ref": "nachet-frontend@0.10.4|@isaacs/fs-minipass@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass@7.1.2"
+        "nachet-frontend@0.10.4|minipass@7.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@istanbuljs/schema@0.1.3"
+      "ref": "nachet-frontend@0.10.4|@istanbuljs/schema@0.1.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jest/environment-jsdom-abstract@30.1.2",
+      "ref": "nachet-frontend@0.10.4|@jest/environment-jsdom-abstract@30.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/environment@30.1.2",
-        "nachet-frontend@0.10.3|@jest/fake-timers@30.1.2",
-        "nachet-frontend@0.10.3|@jest/types@30.0.5",
-        "nachet-frontend@0.10.3|@types/jsdom@21.1.7",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|jest-mock@30.0.5",
-        "nachet-frontend@0.10.3|jest-util@30.0.5",
-        "nachet-frontend@0.10.3|jsdom@26.1.0"
+        "nachet-frontend@0.10.4|@jest/environment@30.1.2",
+        "nachet-frontend@0.10.4|@jest/fake-timers@30.1.2",
+        "nachet-frontend@0.10.4|@jest/types@30.0.5",
+        "nachet-frontend@0.10.4|@types/jsdom@21.1.7",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|jest-mock@30.0.5",
+        "nachet-frontend@0.10.4|jest-util@30.0.5",
+        "nachet-frontend@0.10.4|jsdom@26.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jest/environment@30.1.2",
+      "ref": "nachet-frontend@0.10.4|@jest/environment@30.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/fake-timers@30.1.2",
-        "nachet-frontend@0.10.3|@jest/types@30.0.5",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|jest-mock@30.0.5"
+        "nachet-frontend@0.10.4|@jest/fake-timers@30.1.2",
+        "nachet-frontend@0.10.4|@jest/types@30.0.5",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|jest-mock@30.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jest/fake-timers@30.1.2",
+      "ref": "nachet-frontend@0.10.4|@jest/fake-timers@30.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/types@30.0.5",
-        "nachet-frontend@0.10.3|@sinonjs/fake-timers@13.0.5",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|jest-message-util@30.1.0",
-        "nachet-frontend@0.10.3|jest-mock@30.0.5",
-        "nachet-frontend@0.10.3|jest-util@30.0.5"
+        "nachet-frontend@0.10.4|@jest/types@30.0.5",
+        "nachet-frontend@0.10.4|@sinonjs/fake-timers@13.0.5",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|jest-message-util@30.1.0",
+        "nachet-frontend@0.10.4|jest-mock@30.0.5",
+        "nachet-frontend@0.10.4|jest-util@30.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jest/pattern@30.0.1",
+      "ref": "nachet-frontend@0.10.4|@jest/pattern@30.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|jest-regex-util@30.0.1"
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|jest-regex-util@30.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jest/schemas@30.0.5",
+      "ref": "nachet-frontend@0.10.4|@jest/schemas@30.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@sinclair/typebox@0.34.41"
+        "nachet-frontend@0.10.4|@sinclair/typebox@0.34.41"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jest/types@30.0.5",
+      "ref": "nachet-frontend@0.10.4|@jest/types@30.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/pattern@30.0.1",
-        "nachet-frontend@0.10.3|@jest/schemas@30.0.5",
-        "nachet-frontend@0.10.3|@types/istanbul-lib-coverage@2.0.6",
-        "nachet-frontend@0.10.3|@types/istanbul-reports@3.0.4",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|@types/yargs@17.0.33",
-        "nachet-frontend@0.10.3|chalk@4.1.2"
+        "nachet-frontend@0.10.4|@jest/pattern@30.0.1",
+        "nachet-frontend@0.10.4|@jest/schemas@30.0.5",
+        "nachet-frontend@0.10.4|@types/istanbul-lib-coverage@2.0.6",
+        "nachet-frontend@0.10.4|@types/istanbul-reports@3.0.4",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|@types/yargs@17.0.33",
+        "nachet-frontend@0.10.4|chalk@4.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jridgewell/gen-mapping@0.3.13",
+      "ref": "nachet-frontend@0.10.4|@jridgewell/gen-mapping@0.3.13",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/sourcemap-codec@1.5.5",
-        "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31"
+        "nachet-frontend@0.10.4|@jridgewell/sourcemap-codec@1.5.5",
+        "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jridgewell/remapping@2.3.5",
+      "ref": "nachet-frontend@0.10.4|@jridgewell/remapping@2.3.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/gen-mapping@0.3.13",
-        "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31"
+        "nachet-frontend@0.10.4|@jridgewell/gen-mapping@0.3.13",
+        "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jridgewell/resolve-uri@3.1.2"
+      "ref": "nachet-frontend@0.10.4|@jridgewell/resolve-uri@3.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jridgewell/sourcemap-codec@1.5.5"
+      "ref": "nachet-frontend@0.10.4|@jridgewell/sourcemap-codec@1.5.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31",
+      "ref": "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/resolve-uri@3.1.2",
-        "nachet-frontend@0.10.3|@jridgewell/sourcemap-codec@1.5.5"
+        "nachet-frontend@0.10.4|@jridgewell/resolve-uri@3.1.2",
+        "nachet-frontend@0.10.4|@jridgewell/sourcemap-codec@1.5.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/core-downloads-tracker@7.3.2"
+      "ref": "nachet-frontend@0.10.4|@mui/core-downloads-tracker@7.3.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/icons-material@7.3.2",
+      "ref": "nachet-frontend@0.10.4|@mui/icons-material@7.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@mui/material@7.3.2",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@mui/material@7.3.2",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/material@7.3.2",
+      "ref": "nachet-frontend@0.10.4|@mui/material@7.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@emotion/react@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/styled@11.14.1",
-        "nachet-frontend@0.10.3|@mui/core-downloads-tracker@7.3.2",
-        "nachet-frontend@0.10.3|@mui/system@7.3.2",
-        "nachet-frontend@0.10.3|@mui/types@7.4.6",
-        "nachet-frontend@0.10.3|@mui/utils@7.3.2",
-        "nachet-frontend@0.10.3|@popperjs/core@2.11.8",
-        "nachet-frontend@0.10.3|@types/react-transition-group@4.4.12",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|clsx@2.1.1",
-        "nachet-frontend@0.10.3|csstype@3.1.3",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react-is@19.1.1",
-        "nachet-frontend@0.10.3|react-transition-group@4.4.5",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@emotion/react@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/styled@11.14.1",
+        "nachet-frontend@0.10.4|@mui/core-downloads-tracker@7.3.2",
+        "nachet-frontend@0.10.4|@mui/system@7.3.2",
+        "nachet-frontend@0.10.4|@mui/types@7.4.6",
+        "nachet-frontend@0.10.4|@mui/utils@7.3.2",
+        "nachet-frontend@0.10.4|@popperjs/core@2.11.8",
+        "nachet-frontend@0.10.4|@types/react-transition-group@4.4.12",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|clsx@2.1.1",
+        "nachet-frontend@0.10.4|csstype@3.1.3",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react-is@19.1.1",
+        "nachet-frontend@0.10.4|react-transition-group@4.4.5",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/private-theming@7.3.2",
+      "ref": "nachet-frontend@0.10.4|@mui/private-theming@7.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@mui/utils@7.3.2",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@mui/utils@7.3.2",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/styled-engine@7.3.2",
+      "ref": "nachet-frontend@0.10.4|@mui/styled-engine@7.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@emotion/cache@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/react@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/serialize@1.3.3",
-        "nachet-frontend@0.10.3|@emotion/sheet@1.4.0",
-        "nachet-frontend@0.10.3|@emotion/styled@11.14.1",
-        "nachet-frontend@0.10.3|csstype@3.1.3",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@emotion/cache@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/react@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/serialize@1.3.3",
+        "nachet-frontend@0.10.4|@emotion/sheet@1.4.0",
+        "nachet-frontend@0.10.4|@emotion/styled@11.14.1",
+        "nachet-frontend@0.10.4|csstype@3.1.3",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/system@7.3.2",
+      "ref": "nachet-frontend@0.10.4|@mui/system@7.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@emotion/react@11.14.0",
-        "nachet-frontend@0.10.3|@emotion/styled@11.14.1",
-        "nachet-frontend@0.10.3|@mui/private-theming@7.3.2",
-        "nachet-frontend@0.10.3|@mui/styled-engine@7.3.2",
-        "nachet-frontend@0.10.3|@mui/types@7.4.6",
-        "nachet-frontend@0.10.3|@mui/utils@7.3.2",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|clsx@2.1.1",
-        "nachet-frontend@0.10.3|csstype@3.1.3",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@emotion/react@11.14.0",
+        "nachet-frontend@0.10.4|@emotion/styled@11.14.1",
+        "nachet-frontend@0.10.4|@mui/private-theming@7.3.2",
+        "nachet-frontend@0.10.4|@mui/styled-engine@7.3.2",
+        "nachet-frontend@0.10.4|@mui/types@7.4.6",
+        "nachet-frontend@0.10.4|@mui/utils@7.3.2",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|clsx@2.1.1",
+        "nachet-frontend@0.10.4|csstype@3.1.3",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/types@7.4.6",
+      "ref": "nachet-frontend@0.10.4|@mui/types@7.4.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@types/react@19.1.13"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@types/react@19.1.13"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@mui/utils@7.3.2",
+      "ref": "nachet-frontend@0.10.4|@mui/utils@7.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@mui/types@7.4.6",
-        "nachet-frontend@0.10.3|@types/prop-types@15.7.15",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|clsx@2.1.1",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react-is@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@mui/types@7.4.6",
+        "nachet-frontend@0.10.4|@types/prop-types@15.7.15",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|clsx@2.1.1",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react-is@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@nodelib/fs.scandir@2.1.5",
+      "ref": "nachet-frontend@0.10.4|@nodelib/fs.scandir@2.1.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@nodelib/fs.stat@2.0.5",
-        "nachet-frontend@0.10.3|run-parallel@1.2.0"
+        "nachet-frontend@0.10.4|@nodelib/fs.stat@2.0.5",
+        "nachet-frontend@0.10.4|run-parallel@1.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@nodelib/fs.stat@2.0.5"
+      "ref": "nachet-frontend@0.10.4|@nodelib/fs.stat@2.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@nodelib/fs.walk@1.2.8",
+      "ref": "nachet-frontend@0.10.4|@nodelib/fs.walk@1.2.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@nodelib/fs.scandir@2.1.5",
-        "nachet-frontend@0.10.3|fastq@1.19.1"
+        "nachet-frontend@0.10.4|@nodelib/fs.scandir@2.1.5",
+        "nachet-frontend@0.10.4|fastq@1.19.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@npmcli/agent@3.0.0",
+      "ref": "nachet-frontend@0.10.4|@npmcli/agent@3.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@npmcli/agent@3.0.0|lru-cache@10.4.3",
-        "nachet-frontend@0.10.3|agent-base@7.1.4",
-        "nachet-frontend@0.10.3|http-proxy-agent@7.0.2",
-        "nachet-frontend@0.10.3|https-proxy-agent@7.0.6",
-        "nachet-frontend@0.10.3|socks-proxy-agent@8.0.5"
+        "nachet-frontend@0.10.4|@npmcli/agent@3.0.0|lru-cache@10.4.3",
+        "nachet-frontend@0.10.4|agent-base@7.1.4",
+        "nachet-frontend@0.10.4|http-proxy-agent@7.0.2",
+        "nachet-frontend@0.10.4|https-proxy-agent@7.0.6",
+        "nachet-frontend@0.10.4|socks-proxy-agent@8.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@npmcli/agent@3.0.0|lru-cache@10.4.3"
+      "ref": "nachet-frontend@0.10.4|@npmcli/agent@3.0.0|lru-cache@10.4.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@npmcli/fs@4.0.0",
+      "ref": "nachet-frontend@0.10.4|@npmcli/fs@4.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@npmcli/fs@4.0.0|semver@7.7.2"
+        "nachet-frontend@0.10.4|@npmcli/fs@4.0.0|semver@7.7.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@npmcli/fs@4.0.0|semver@7.7.2"
+      "ref": "nachet-frontend@0.10.4|@npmcli/fs@4.0.0|semver@7.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@oozcitak/dom@1.15.10",
+      "ref": "nachet-frontend@0.10.4|@oozcitak/dom@1.15.10",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@oozcitak/infra@1.0.8",
-        "nachet-frontend@0.10.3|@oozcitak/url@1.0.4",
-        "nachet-frontend@0.10.3|@oozcitak/util@8.3.8"
+        "nachet-frontend@0.10.4|@oozcitak/infra@1.0.8",
+        "nachet-frontend@0.10.4|@oozcitak/url@1.0.4",
+        "nachet-frontend@0.10.4|@oozcitak/util@8.3.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@oozcitak/infra@1.0.8",
+      "ref": "nachet-frontend@0.10.4|@oozcitak/infra@1.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@oozcitak/util@8.3.8"
+        "nachet-frontend@0.10.4|@oozcitak/util@8.3.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@oozcitak/url@1.0.4",
+      "ref": "nachet-frontend@0.10.4|@oozcitak/url@1.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@oozcitak/infra@1.0.8",
-        "nachet-frontend@0.10.3|@oozcitak/util@8.3.8"
+        "nachet-frontend@0.10.4|@oozcitak/infra@1.0.8",
+        "nachet-frontend@0.10.4|@oozcitak/util@8.3.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@oozcitak/util@8.3.8"
+      "ref": "nachet-frontend@0.10.4|@oozcitak/util@8.3.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@pkgjs/parseargs@0.11.0"
+      "ref": "nachet-frontend@0.10.4|@pkgjs/parseargs@0.11.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@pkgr/core@0.2.9"
+      "ref": "nachet-frontend@0.10.4|@pkgr/core@0.2.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@popperjs/core@2.11.8"
+      "ref": "nachet-frontend@0.10.4|@popperjs/core@2.11.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rolldown/pluginutils@1.0.0-beta.32"
+      "ref": "nachet-frontend@0.10.4|@rolldown/pluginutils@1.0.0-beta.32"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-android-arm-eabi@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-android-arm-eabi@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-android-arm64@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-android-arm64@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-darwin-arm64@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-darwin-arm64@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-darwin-x64@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-darwin-x64@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-freebsd-arm64@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-freebsd-arm64@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-freebsd-x64@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-freebsd-x64@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm-gnueabihf@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm-gnueabihf@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm-musleabihf@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm-musleabihf@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm64-gnu@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm64-gnu@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-arm64-musl@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-arm64-musl@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-loong64-gnu@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-loong64-gnu@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-ppc64-gnu@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-ppc64-gnu@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-riscv64-gnu@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-riscv64-gnu@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-riscv64-musl@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-riscv64-musl@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-s390x-gnu@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-s390x-gnu@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-x64-gnu@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-x64-gnu@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-linux-x64-musl@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-linux-x64-musl@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-openharmony-arm64@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-openharmony-arm64@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-win32-arm64-msvc@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-win32-arm64-msvc@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-win32-ia32-msvc@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-win32-ia32-msvc@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rollup/rollup-win32-x64-msvc@4.50.2"
+      "ref": "nachet-frontend@0.10.4|@rollup/rollup-win32-x64-msvc@4.50.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@rtsao/scc@1.1.0"
+      "ref": "nachet-frontend@0.10.4|@rtsao/scc@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@saithodev/ts-appversion@2.2.0",
+      "ref": "nachet-frontend@0.10.4|@saithodev/ts-appversion@2.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|colors@1.4.0",
-        "nachet-frontend@0.10.3|git-commit-info@2.0.2",
-        "nachet-frontend@0.10.3|git-describe@4.1.1",
-        "nachet-frontend@0.10.3|yargs@16.2.0"
+        "nachet-frontend@0.10.4|colors@1.4.0",
+        "nachet-frontend@0.10.4|git-commit-info@2.0.2",
+        "nachet-frontend@0.10.4|git-describe@4.1.1",
+        "nachet-frontend@0.10.4|yargs@16.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@sinclair/typebox@0.34.41"
+      "ref": "nachet-frontend@0.10.4|@sinclair/typebox@0.34.41"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@sinonjs/commons@3.0.1",
+      "ref": "nachet-frontend@0.10.4|@sinonjs/commons@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|type-detect@4.0.8"
+        "nachet-frontend@0.10.4|type-detect@4.0.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@sinonjs/fake-timers@13.0.5",
+      "ref": "nachet-frontend@0.10.4|@sinonjs/fake-timers@13.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@sinonjs/commons@3.0.1"
+        "nachet-frontend@0.10.4|@sinonjs/commons@3.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-darwin-arm64@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-darwin-arm64@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-darwin-x64@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-darwin-x64@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-linux-arm-gnueabihf@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-linux-arm-gnueabihf@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-linux-arm64-gnu@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-linux-arm64-gnu@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-linux-arm64-musl@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-linux-arm64-musl@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-linux-x64-gnu@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-linux-x64-gnu@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-linux-x64-musl@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-linux-x64-musl@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-win32-arm64-msvc@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-win32-arm64-msvc@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-win32-ia32-msvc@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-win32-ia32-msvc@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core-win32-x64-msvc@1.13.5"
+      "ref": "nachet-frontend@0.10.4|@swc/core-win32-x64-msvc@1.13.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/core@1.13.5",
+      "ref": "nachet-frontend@0.10.4|@swc/core@1.13.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@swc/core-darwin-arm64@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-darwin-x64@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-linux-arm-gnueabihf@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-linux-arm64-gnu@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-linux-arm64-musl@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-linux-x64-gnu@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-linux-x64-musl@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-win32-arm64-msvc@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-win32-ia32-msvc@1.13.5",
-        "nachet-frontend@0.10.3|@swc/core-win32-x64-msvc@1.13.5",
-        "nachet-frontend@0.10.3|@swc/counter@0.1.3",
-        "nachet-frontend@0.10.3|@swc/types@0.1.25"
+        "nachet-frontend@0.10.4|@swc/core-darwin-arm64@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-darwin-x64@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-linux-arm-gnueabihf@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-linux-arm64-gnu@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-linux-arm64-musl@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-linux-x64-gnu@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-linux-x64-musl@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-win32-arm64-msvc@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-win32-ia32-msvc@1.13.5",
+        "nachet-frontend@0.10.4|@swc/core-win32-x64-msvc@1.13.5",
+        "nachet-frontend@0.10.4|@swc/counter@0.1.3",
+        "nachet-frontend@0.10.4|@swc/types@0.1.25"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/counter@0.1.3"
+      "ref": "nachet-frontend@0.10.4|@swc/counter@0.1.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@swc/types@0.1.25",
+      "ref": "nachet-frontend@0.10.4|@swc/types@0.1.25",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@swc/counter@0.1.3"
+        "nachet-frontend@0.10.4|@swc/counter@0.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@testing-library/dom@10.4.1",
+      "ref": "nachet-frontend@0.10.4|@testing-library/dom@10.4.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@types/aria-query@5.0.4",
-        "nachet-frontend@0.10.3|aria-query@5.3.0",
-        "nachet-frontend@0.10.3|dom-accessibility-api@0.5.16",
-        "nachet-frontend@0.10.3|lz-string@1.5.0",
-        "nachet-frontend@0.10.3|picocolors@1.1.1",
-        "nachet-frontend@0.10.3|pretty-format@27.5.1"
+        "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@types/aria-query@5.0.4",
+        "nachet-frontend@0.10.4|aria-query@5.3.0",
+        "nachet-frontend@0.10.4|dom-accessibility-api@0.5.16",
+        "nachet-frontend@0.10.4|lz-string@1.5.0",
+        "nachet-frontend@0.10.4|picocolors@1.1.1",
+        "nachet-frontend@0.10.4|pretty-format@27.5.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@testing-library/jest-dom@6.8.0",
+      "ref": "nachet-frontend@0.10.4|@testing-library/jest-dom@6.8.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@adobe/css-tools@4.4.4",
-        "nachet-frontend@0.10.3|@testing-library/jest-dom@6.8.0|dom-accessibility-api@0.6.3",
-        "nachet-frontend@0.10.3|aria-query@5.3.0",
-        "nachet-frontend@0.10.3|css.escape@1.5.1",
-        "nachet-frontend@0.10.3|picocolors@1.1.1",
-        "nachet-frontend@0.10.3|redent@3.0.0"
+        "nachet-frontend@0.10.4|@adobe/css-tools@4.4.4",
+        "nachet-frontend@0.10.4|@testing-library/jest-dom@6.8.0|dom-accessibility-api@0.6.3",
+        "nachet-frontend@0.10.4|aria-query@5.3.0",
+        "nachet-frontend@0.10.4|css.escape@1.5.1",
+        "nachet-frontend@0.10.4|picocolors@1.1.1",
+        "nachet-frontend@0.10.4|redent@3.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@testing-library/jest-dom@6.8.0|dom-accessibility-api@0.6.3"
+      "ref": "nachet-frontend@0.10.4|@testing-library/jest-dom@6.8.0|dom-accessibility-api@0.6.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@testing-library/react@16.3.0",
+      "ref": "nachet-frontend@0.10.4|@testing-library/react@16.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|@testing-library/dom@10.4.1",
-        "nachet-frontend@0.10.3|@types/react-dom@19.1.9",
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|@testing-library/dom@10.4.1",
+        "nachet-frontend@0.10.4|@types/react-dom@19.1.9",
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@testing-library/user-event@14.6.1",
+      "ref": "nachet-frontend@0.10.4|@testing-library/user-event@14.6.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@testing-library/dom@10.4.1"
+        "nachet-frontend@0.10.4|@testing-library/dom@10.4.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/aria-query@5.0.4"
+      "ref": "nachet-frontend@0.10.4|@types/aria-query@5.0.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/chai@5.2.2",
+      "ref": "nachet-frontend@0.10.4|@types/chai@5.2.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/deep-eql@4.0.2"
+        "nachet-frontend@0.10.4|@types/deep-eql@4.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/deep-eql@4.0.2"
+      "ref": "nachet-frontend@0.10.4|@types/deep-eql@4.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/estree@1.0.8"
+      "ref": "nachet-frontend@0.10.4|@types/estree@1.0.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/file-saver@2.0.7"
+      "ref": "nachet-frontend@0.10.4|@types/file-saver@2.0.7"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/istanbul-lib-coverage@2.0.6"
+      "ref": "nachet-frontend@0.10.4|@types/istanbul-lib-coverage@2.0.6"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/istanbul-lib-report@3.0.3",
+      "ref": "nachet-frontend@0.10.4|@types/istanbul-lib-report@3.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/istanbul-lib-coverage@2.0.6"
+        "nachet-frontend@0.10.4|@types/istanbul-lib-coverage@2.0.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/istanbul-reports@3.0.4",
+      "ref": "nachet-frontend@0.10.4|@types/istanbul-reports@3.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/istanbul-lib-report@3.0.3"
+        "nachet-frontend@0.10.4|@types/istanbul-lib-report@3.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/js-cookie@3.0.6"
+      "ref": "nachet-frontend@0.10.4|@types/js-cookie@3.0.6"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/jsdom@21.1.7",
+      "ref": "nachet-frontend@0.10.4|@types/jsdom@21.1.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|@types/tough-cookie@4.0.5",
-        "nachet-frontend@0.10.3|parse5@7.3.0"
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|@types/tough-cookie@4.0.5",
+        "nachet-frontend@0.10.4|parse5@7.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/json-schema@7.0.15"
+      "ref": "nachet-frontend@0.10.4|@types/json-schema@7.0.15"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/json5@0.0.29"
+      "ref": "nachet-frontend@0.10.4|@types/json5@0.0.29"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/node@22.18.4",
+      "ref": "nachet-frontend@0.10.4|@types/node@22.18.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|undici-types@6.21.0"
+        "nachet-frontend@0.10.4|undici-types@6.21.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/pako@2.0.4"
+      "ref": "nachet-frontend@0.10.4|@types/pako@2.0.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/parse-json@4.0.2"
+      "ref": "nachet-frontend@0.10.4|@types/parse-json@4.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/prop-types@15.7.15"
+      "ref": "nachet-frontend@0.10.4|@types/prop-types@15.7.15"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/react-dom@19.1.9",
+      "ref": "nachet-frontend@0.10.4|@types/react-dom@19.1.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/react@19.1.13"
+        "nachet-frontend@0.10.4|@types/react@19.1.13"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/react-transition-group@4.4.12",
+      "ref": "nachet-frontend@0.10.4|@types/react-transition-group@4.4.12",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/react@19.1.13"
+        "nachet-frontend@0.10.4|@types/react@19.1.13"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/react@19.1.13",
+      "ref": "nachet-frontend@0.10.4|@types/react@19.1.13",
       "dependsOn": [
-        "nachet-frontend@0.10.3|csstype@3.1.3"
+        "nachet-frontend@0.10.4|csstype@3.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/sanitize-html@2.16.0",
+      "ref": "nachet-frontend@0.10.4|@types/sanitize-html@2.16.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|htmlparser2@8.0.2"
+        "nachet-frontend@0.10.4|htmlparser2@8.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/semver@7.7.1"
+      "ref": "nachet-frontend@0.10.4|@types/semver@7.7.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/stack-utils@2.0.3"
+      "ref": "nachet-frontend@0.10.4|@types/stack-utils@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/stylis@4.2.5"
+      "ref": "nachet-frontend@0.10.4|@types/stylis@4.2.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/tough-cookie@4.0.5"
+      "ref": "nachet-frontend@0.10.4|@types/tough-cookie@4.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/trusted-types@2.0.7"
+      "ref": "nachet-frontend@0.10.4|@types/trusted-types@2.0.7"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/utif@3.0.6",
+      "ref": "nachet-frontend@0.10.4|@types/utif@3.0.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/node@22.18.4"
+        "nachet-frontend@0.10.4|@types/node@22.18.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/uuid@10.0.0"
+      "ref": "nachet-frontend@0.10.4|@types/uuid@10.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/yargs-parser@21.0.3"
+      "ref": "nachet-frontend@0.10.4|@types/yargs-parser@21.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@types/yargs@17.0.33",
+      "ref": "nachet-frontend@0.10.4|@types/yargs@17.0.33",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/yargs-parser@21.0.3"
+        "nachet-frontend@0.10.4|@types/yargs-parser@21.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/eslint-plugin@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/eslint-plugin@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint-community/regexpp@4.12.1",
-        "nachet-frontend@0.10.3|@typescript-eslint/eslint-plugin@8.44.0|ignore@7.0.5",
-        "nachet-frontend@0.10.3|@typescript-eslint/parser@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/scope-manager@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/type-utils@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/utils@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|graphemer@1.4.0",
-        "nachet-frontend@0.10.3|natural-compare@1.4.0",
-        "nachet-frontend@0.10.3|ts-api-utils@2.1.0",
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|@eslint-community/regexpp@4.12.1",
+        "nachet-frontend@0.10.4|@typescript-eslint/eslint-plugin@8.44.0|ignore@7.0.5",
+        "nachet-frontend@0.10.4|@typescript-eslint/parser@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/scope-manager@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/type-utils@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/utils@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|graphemer@1.4.0",
+        "nachet-frontend@0.10.4|natural-compare@1.4.0",
+        "nachet-frontend@0.10.4|ts-api-utils@2.1.0",
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/eslint-plugin@8.44.0|ignore@7.0.5"
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/eslint-plugin@8.44.0|ignore@7.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/parser@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/parser@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/scope-manager@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|@typescript-eslint/scope-manager@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/project-service@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/project-service@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/tsconfig-utils@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|@typescript-eslint/tsconfig-utils@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/scope-manager@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/scope-manager@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0"
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/tsconfig-utils@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/tsconfig-utils@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/type-utils@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/type-utils@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/utils@8.44.0",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|ts-api-utils@2.1.0",
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/utils@8.44.0",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|ts-api-utils@2.1.0",
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0"
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/project-service@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/tsconfig-utils@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|minimatch@9.0.5",
-        "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|semver@7.7.2",
-        "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|fast-glob@3.3.3",
-        "nachet-frontend@0.10.3|is-glob@4.0.3",
-        "nachet-frontend@0.10.3|ts-api-utils@2.1.0",
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|@typescript-eslint/project-service@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/tsconfig-utils@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|minimatch@9.0.5",
+        "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|semver@7.7.2",
+        "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|fast-glob@3.3.3",
+        "nachet-frontend@0.10.4|is-glob@4.0.3",
+        "nachet-frontend@0.10.4|ts-api-utils@2.1.0",
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|brace-expansion@2.0.2",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|brace-expansion@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|balanced-match@1.0.2"
+        "nachet-frontend@0.10.4|balanced-match@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|minimatch@9.0.5",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|minimatch@9.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|brace-expansion@2.0.2"
+        "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|brace-expansion@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0|semver@7.7.2"
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0|semver@7.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/utils@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/utils@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint-community/eslint-utils@4.9.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/scope-manager@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/typescript-estree@8.44.0",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|@eslint-community/eslint-utils@4.9.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/scope-manager@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/typescript-estree@8.44.0",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0",
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@typescript-eslint/types@8.44.0",
-        "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0|eslint-visitor-keys@4.2.1"
+        "nachet-frontend@0.10.4|@typescript-eslint/types@8.44.0",
+        "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0|eslint-visitor-keys@4.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@typescript-eslint/visitor-keys@8.44.0|eslint-visitor-keys@4.2.1"
+      "ref": "nachet-frontend@0.10.4|@typescript-eslint/visitor-keys@8.44.0|eslint-visitor-keys@4.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitejs/plugin-react-swc@4.0.1",
+      "ref": "nachet-frontend@0.10.4|@vitejs/plugin-react-swc@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@rolldown/pluginutils@1.0.0-beta.32",
-        "nachet-frontend@0.10.3|@swc/core@1.13.5",
-        "nachet-frontend@0.10.3|vite@7.1.5"
+        "nachet-frontend@0.10.4|@rolldown/pluginutils@1.0.0-beta.32",
+        "nachet-frontend@0.10.4|@swc/core@1.13.5",
+        "nachet-frontend@0.10.4|vite@7.1.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/coverage-v8@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/coverage-v8@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@ampproject/remapping@2.3.0",
-        "nachet-frontend@0.10.3|@bcoe/v8-coverage@1.0.2",
-        "nachet-frontend@0.10.3|ast-v8-to-istanbul@0.3.5",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|istanbul-lib-coverage@3.2.2",
-        "nachet-frontend@0.10.3|istanbul-lib-report@3.0.1",
-        "nachet-frontend@0.10.3|istanbul-lib-source-maps@5.0.6",
-        "nachet-frontend@0.10.3|istanbul-reports@3.2.0",
-        "nachet-frontend@0.10.3|magic-string@0.30.19",
-        "nachet-frontend@0.10.3|magicast@0.3.5",
-        "nachet-frontend@0.10.3|std-env@3.9.0",
-        "nachet-frontend@0.10.3|test-exclude@7.0.1",
-        "nachet-frontend@0.10.3|tinyrainbow@2.0.0",
-        "nachet-frontend@0.10.3|vitest@3.2.4"
+        "nachet-frontend@0.10.4|@ampproject/remapping@2.3.0",
+        "nachet-frontend@0.10.4|@bcoe/v8-coverage@1.0.2",
+        "nachet-frontend@0.10.4|ast-v8-to-istanbul@0.3.5",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|istanbul-lib-coverage@3.2.2",
+        "nachet-frontend@0.10.4|istanbul-lib-report@3.0.1",
+        "nachet-frontend@0.10.4|istanbul-lib-source-maps@5.0.6",
+        "nachet-frontend@0.10.4|istanbul-reports@3.2.0",
+        "nachet-frontend@0.10.4|magic-string@0.30.19",
+        "nachet-frontend@0.10.4|magicast@0.3.5",
+        "nachet-frontend@0.10.4|std-env@3.9.0",
+        "nachet-frontend@0.10.4|test-exclude@7.0.1",
+        "nachet-frontend@0.10.4|tinyrainbow@2.0.0",
+        "nachet-frontend@0.10.4|vitest@3.2.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/expect@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/expect@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/chai@5.2.2",
-        "nachet-frontend@0.10.3|@vitest/spy@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/utils@3.2.4",
-        "nachet-frontend@0.10.3|chai@5.3.3",
-        "nachet-frontend@0.10.3|tinyrainbow@2.0.0"
+        "nachet-frontend@0.10.4|@types/chai@5.2.2",
+        "nachet-frontend@0.10.4|@vitest/spy@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/utils@3.2.4",
+        "nachet-frontend@0.10.4|chai@5.3.3",
+        "nachet-frontend@0.10.4|tinyrainbow@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/mocker@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/mocker@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@vitest/spy@3.2.4",
-        "nachet-frontend@0.10.3|estree-walker@3.0.3",
-        "nachet-frontend@0.10.3|magic-string@0.30.19",
-        "nachet-frontend@0.10.3|vite@7.1.5"
+        "nachet-frontend@0.10.4|@vitest/spy@3.2.4",
+        "nachet-frontend@0.10.4|estree-walker@3.0.3",
+        "nachet-frontend@0.10.4|magic-string@0.30.19",
+        "nachet-frontend@0.10.4|vite@7.1.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/pretty-format@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/pretty-format@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|tinyrainbow@2.0.0"
+        "nachet-frontend@0.10.4|tinyrainbow@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/runner@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/runner@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@vitest/utils@3.2.4",
-        "nachet-frontend@0.10.3|pathe@2.0.3",
-        "nachet-frontend@0.10.3|strip-literal@3.0.0"
+        "nachet-frontend@0.10.4|@vitest/utils@3.2.4",
+        "nachet-frontend@0.10.4|pathe@2.0.3",
+        "nachet-frontend@0.10.4|strip-literal@3.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/snapshot@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/snapshot@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@vitest/pretty-format@3.2.4",
-        "nachet-frontend@0.10.3|magic-string@0.30.19",
-        "nachet-frontend@0.10.3|pathe@2.0.3"
+        "nachet-frontend@0.10.4|@vitest/pretty-format@3.2.4",
+        "nachet-frontend@0.10.4|magic-string@0.30.19",
+        "nachet-frontend@0.10.4|pathe@2.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/spy@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/spy@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|tinyspy@4.0.3"
+        "nachet-frontend@0.10.4|tinyspy@4.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@vitest/utils@3.2.4",
+      "ref": "nachet-frontend@0.10.4|@vitest/utils@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@vitest/pretty-format@3.2.4",
-        "nachet-frontend@0.10.3|loupe@3.2.1",
-        "nachet-frontend@0.10.3|tinyrainbow@2.0.0"
+        "nachet-frontend@0.10.4|@vitest/pretty-format@3.2.4",
+        "nachet-frontend@0.10.4|loupe@3.2.1",
+        "nachet-frontend@0.10.4|tinyrainbow@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|@zeit/schemas@2.36.0"
+      "ref": "nachet-frontend@0.10.4|@zeit/schemas@2.36.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|abbrev@3.0.1"
+      "ref": "nachet-frontend@0.10.4|abbrev@3.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|accepts@2.0.0",
+      "ref": "nachet-frontend@0.10.4|accepts@2.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|mime-types@3.0.1",
-        "nachet-frontend@0.10.3|negotiator@1.0.0"
+        "nachet-frontend@0.10.4|mime-types@3.0.1",
+        "nachet-frontend@0.10.4|negotiator@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|acorn-jsx@5.3.2",
+      "ref": "nachet-frontend@0.10.4|acorn-jsx@5.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|acorn@8.15.0"
+        "nachet-frontend@0.10.4|acorn@8.15.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|acorn@8.15.0"
+      "ref": "nachet-frontend@0.10.4|acorn@8.15.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|agent-base@7.1.4"
+      "ref": "nachet-frontend@0.10.4|agent-base@7.1.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ajv-formats-draft2019@1.6.1",
+      "ref": "nachet-frontend@0.10.4|ajv-formats-draft2019@1.6.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ajv@8.17.1",
-        "nachet-frontend@0.10.3|punycode@2.3.1",
-        "nachet-frontend@0.10.3|schemes@1.4.0",
-        "nachet-frontend@0.10.3|smtp-address-parser@1.1.0",
-        "nachet-frontend@0.10.3|uri-js@4.4.1"
+        "nachet-frontend@0.10.4|ajv@8.17.1",
+        "nachet-frontend@0.10.4|punycode@2.3.1",
+        "nachet-frontend@0.10.4|schemes@1.4.0",
+        "nachet-frontend@0.10.4|smtp-address-parser@1.1.0",
+        "nachet-frontend@0.10.4|uri-js@4.4.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ajv-formats@3.0.1",
+      "ref": "nachet-frontend@0.10.4|ajv-formats@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ajv@8.17.1"
+        "nachet-frontend@0.10.4|ajv@8.17.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ajv@8.17.1",
+      "ref": "nachet-frontend@0.10.4|ajv@8.17.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fast-deep-equal@3.1.3",
-        "nachet-frontend@0.10.3|fast-uri@3.1.0",
-        "nachet-frontend@0.10.3|json-schema-traverse@1.0.0",
-        "nachet-frontend@0.10.3|require-from-string@2.0.2"
+        "nachet-frontend@0.10.4|fast-deep-equal@3.1.3",
+        "nachet-frontend@0.10.4|fast-uri@3.1.0",
+        "nachet-frontend@0.10.4|json-schema-traverse@1.0.0",
+        "nachet-frontend@0.10.4|require-from-string@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ansi-align@3.0.1",
+      "ref": "nachet-frontend@0.10.4|ansi-align@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-align@3.0.1|string-width@4.2.3"
+        "nachet-frontend@0.10.4|ansi-align@3.0.1|string-width@4.2.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ansi-align@3.0.1|emoji-regex@8.0.0"
+      "ref": "nachet-frontend@0.10.4|ansi-align@3.0.1|emoji-regex@8.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ansi-align@3.0.1|string-width@4.2.3",
+      "ref": "nachet-frontend@0.10.4|ansi-align@3.0.1|string-width@4.2.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-align@3.0.1|emoji-regex@8.0.0",
-        "nachet-frontend@0.10.3|ansi-align@3.0.1|strip-ansi@6.0.1",
-        "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0"
+        "nachet-frontend@0.10.4|ansi-align@3.0.1|emoji-regex@8.0.0",
+        "nachet-frontend@0.10.4|ansi-align@3.0.1|strip-ansi@6.0.1",
+        "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ansi-align@3.0.1|strip-ansi@6.0.1",
+      "ref": "nachet-frontend@0.10.4|ansi-align@3.0.1|strip-ansi@6.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+      "ref": "nachet-frontend@0.10.4|ansi-regex@5.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ansi-styles@4.3.0",
+      "ref": "nachet-frontend@0.10.4|ansi-styles@4.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|color-convert@2.0.1"
+        "nachet-frontend@0.10.4|color-convert@2.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|arch@2.2.0"
+      "ref": "nachet-frontend@0.10.4|arch@2.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|arg@5.0.2"
+      "ref": "nachet-frontend@0.10.4|arg@5.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|argparse@2.0.1"
+      "ref": "nachet-frontend@0.10.4|argparse@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|aria-query@5.3.0",
+      "ref": "nachet-frontend@0.10.4|aria-query@5.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|dequal@2.0.3"
+        "nachet-frontend@0.10.4|dequal@2.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array-buffer-byte-length@1.0.2",
+      "ref": "nachet-frontend@0.10.4|array-buffer-byte-length@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|is-array-buffer@3.0.5"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|is-array-buffer@3.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array-includes@3.1.9",
+      "ref": "nachet-frontend@0.10.4|array-includes@3.1.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|is-string@1.1.1",
-        "nachet-frontend@0.10.3|math-intrinsics@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|is-string@1.1.1",
+        "nachet-frontend@0.10.4|math-intrinsics@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array.prototype.findlast@1.2.5",
+      "ref": "nachet-frontend@0.10.4|array.prototype.findlast@1.2.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array.prototype.findlastindex@1.2.6",
+      "ref": "nachet-frontend@0.10.4|array.prototype.findlastindex@1.2.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array.prototype.flat@1.3.3",
+      "ref": "nachet-frontend@0.10.4|array.prototype.flat@1.3.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array.prototype.flatmap@1.3.3",
+      "ref": "nachet-frontend@0.10.4|array.prototype.flatmap@1.3.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|array.prototype.tosorted@1.1.4",
+      "ref": "nachet-frontend@0.10.4|array.prototype.tosorted@1.1.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|arraybuffer.prototype.slice@1.0.4",
+      "ref": "nachet-frontend@0.10.4|arraybuffer.prototype.slice@1.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|array-buffer-byte-length@1.0.2",
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|is-array-buffer@3.0.5"
+        "nachet-frontend@0.10.4|array-buffer-byte-length@1.0.2",
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|is-array-buffer@3.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|assertion-error@2.0.1"
+      "ref": "nachet-frontend@0.10.4|assertion-error@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ast-v8-to-istanbul@0.3.5",
+      "ref": "nachet-frontend@0.10.4|ast-v8-to-istanbul@0.3.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31",
-        "nachet-frontend@0.10.3|ast-v8-to-istanbul@0.3.5|js-tokens@9.0.1",
-        "nachet-frontend@0.10.3|estree-walker@3.0.3"
+        "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31",
+        "nachet-frontend@0.10.4|ast-v8-to-istanbul@0.3.5|js-tokens@9.0.1",
+        "nachet-frontend@0.10.4|estree-walker@3.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ast-v8-to-istanbul@0.3.5|js-tokens@9.0.1"
+      "ref": "nachet-frontend@0.10.4|ast-v8-to-istanbul@0.3.5|js-tokens@9.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|async-function@1.0.0"
+      "ref": "nachet-frontend@0.10.4|async-function@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|asynckit@0.4.0"
+      "ref": "nachet-frontend@0.10.4|asynckit@0.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|available-typed-arrays@1.0.7",
+      "ref": "nachet-frontend@0.10.4|available-typed-arrays@1.0.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|possible-typed-array-names@1.1.0"
+        "nachet-frontend@0.10.4|possible-typed-array-names@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|axios@1.12.2",
+      "ref": "nachet-frontend@0.10.4|axios@1.12.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|follow-redirects@1.15.11",
-        "nachet-frontend@0.10.3|form-data@4.0.4",
-        "nachet-frontend@0.10.3|proxy-from-env@1.1.0"
+        "nachet-frontend@0.10.4|follow-redirects@1.15.11",
+        "nachet-frontend@0.10.4|form-data@4.0.4",
+        "nachet-frontend@0.10.4|proxy-from-env@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|babel-plugin-macros@3.1.0",
+      "ref": "nachet-frontend@0.10.4|babel-plugin-macros@3.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|cosmiconfig@7.1.0",
-        "nachet-frontend@0.10.3|resolve@1.22.10"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|cosmiconfig@7.1.0",
+        "nachet-frontend@0.10.4|resolve@1.22.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|babel-plugin-polyfill-corejs2@0.4.14",
+      "ref": "nachet-frontend@0.10.4|babel-plugin-polyfill-corejs2@0.4.14",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/compat-data@7.28.4",
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-define-polyfill-provider@0.6.5",
-        "nachet-frontend@0.10.3|semver@6.3.1"
+        "nachet-frontend@0.10.4|@babel/compat-data@7.28.4",
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-define-polyfill-provider@0.6.5",
+        "nachet-frontend@0.10.4|semver@6.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|babel-plugin-polyfill-corejs3@0.13.0",
+      "ref": "nachet-frontend@0.10.4|babel-plugin-polyfill-corejs3@0.13.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-define-polyfill-provider@0.6.5",
-        "nachet-frontend@0.10.3|core-js-compat@3.45.1"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-define-polyfill-provider@0.6.5",
+        "nachet-frontend@0.10.4|core-js-compat@3.45.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|babel-plugin-polyfill-regenerator@0.6.5",
+      "ref": "nachet-frontend@0.10.4|babel-plugin-polyfill-regenerator@0.6.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/core@7.28.4",
-        "nachet-frontend@0.10.3|@babel/helper-define-polyfill-provider@0.6.5"
+        "nachet-frontend@0.10.4|@babel/core@7.28.4",
+        "nachet-frontend@0.10.4|@babel/helper-define-polyfill-provider@0.6.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|balanced-match@1.0.2"
+      "ref": "nachet-frontend@0.10.4|balanced-match@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|base64-js@1.5.1"
+      "ref": "nachet-frontend@0.10.4|base64-js@1.5.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|baseline-browser-mapping@2.8.4"
+      "ref": "nachet-frontend@0.10.4|baseline-browser-mapping@2.8.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|bindings@1.5.0",
+      "ref": "nachet-frontend@0.10.4|bindings@1.5.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|file-uri-to-path@1.0.0"
+        "nachet-frontend@0.10.4|file-uri-to-path@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|bl@4.1.0",
+      "ref": "nachet-frontend@0.10.4|bl@4.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|bl@4.1.0|readable-stream@3.6.2",
-        "nachet-frontend@0.10.3|buffer@5.7.1",
-        "nachet-frontend@0.10.3|inherits@2.0.4"
+        "nachet-frontend@0.10.4|bl@4.1.0|readable-stream@3.6.2",
+        "nachet-frontend@0.10.4|buffer@5.7.1",
+        "nachet-frontend@0.10.4|inherits@2.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|bl@4.1.0|readable-stream@3.6.2",
+      "ref": "nachet-frontend@0.10.4|bl@4.1.0|readable-stream@3.6.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|inherits@2.0.4",
-        "nachet-frontend@0.10.3|string_decoder@1.1.1",
-        "nachet-frontend@0.10.3|util-deprecate@1.0.2"
+        "nachet-frontend@0.10.4|inherits@2.0.4",
+        "nachet-frontend@0.10.4|string_decoder@1.1.1",
+        "nachet-frontend@0.10.4|util-deprecate@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|body-parser@2.2.0",
+      "ref": "nachet-frontend@0.10.4|body-parser@2.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|bytes@3.1.2",
-        "nachet-frontend@0.10.3|content-type@1.0.5",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|http-errors@2.0.0",
-        "nachet-frontend@0.10.3|iconv-lite@0.6.3",
-        "nachet-frontend@0.10.3|on-finished@2.4.1",
-        "nachet-frontend@0.10.3|qs@6.14.0",
-        "nachet-frontend@0.10.3|raw-body@3.0.1",
-        "nachet-frontend@0.10.3|type-is@2.0.1"
+        "nachet-frontend@0.10.4|bytes@3.1.2",
+        "nachet-frontend@0.10.4|content-type@1.0.5",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|http-errors@2.0.0",
+        "nachet-frontend@0.10.4|iconv-lite@0.6.3",
+        "nachet-frontend@0.10.4|on-finished@2.4.1",
+        "nachet-frontend@0.10.4|qs@6.14.0",
+        "nachet-frontend@0.10.4|raw-body@3.0.1",
+        "nachet-frontend@0.10.4|type-is@2.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|boxen@7.0.0",
+      "ref": "nachet-frontend@0.10.4|boxen@7.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-align@3.0.1",
-        "nachet-frontend@0.10.3|boxen@7.0.0|chalk@5.6.2",
-        "nachet-frontend@0.10.3|camelcase@7.0.1",
-        "nachet-frontend@0.10.3|cli-boxes@3.0.0",
-        "nachet-frontend@0.10.3|string-width@5.1.2",
-        "nachet-frontend@0.10.3|type-fest@2.19.0",
-        "nachet-frontend@0.10.3|widest-line@4.0.1",
-        "nachet-frontend@0.10.3|wrap-ansi@8.1.0"
+        "nachet-frontend@0.10.4|ansi-align@3.0.1",
+        "nachet-frontend@0.10.4|boxen@7.0.0|chalk@5.6.2",
+        "nachet-frontend@0.10.4|camelcase@7.0.1",
+        "nachet-frontend@0.10.4|cli-boxes@3.0.0",
+        "nachet-frontend@0.10.4|string-width@5.1.2",
+        "nachet-frontend@0.10.4|type-fest@2.19.0",
+        "nachet-frontend@0.10.4|widest-line@4.0.1",
+        "nachet-frontend@0.10.4|wrap-ansi@8.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|boxen@7.0.0|chalk@5.6.2"
+      "ref": "nachet-frontend@0.10.4|boxen@7.0.0|chalk@5.6.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|brace-expansion@1.1.12",
+      "ref": "nachet-frontend@0.10.4|brace-expansion@1.1.12",
       "dependsOn": [
-        "nachet-frontend@0.10.3|balanced-match@1.0.2",
-        "nachet-frontend@0.10.3|concat-map@0.0.1"
+        "nachet-frontend@0.10.4|balanced-match@1.0.2",
+        "nachet-frontend@0.10.4|concat-map@0.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|braces@3.0.3",
+      "ref": "nachet-frontend@0.10.4|braces@3.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fill-range@7.1.1"
+        "nachet-frontend@0.10.4|fill-range@7.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|browser-image-compression@2.0.2",
+      "ref": "nachet-frontend@0.10.4|browser-image-compression@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|uzip@0.20201231.0"
+        "nachet-frontend@0.10.4|uzip@0.20201231.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|browserslist@4.26.2",
+      "ref": "nachet-frontend@0.10.4|browserslist@4.26.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|baseline-browser-mapping@2.8.4",
-        "nachet-frontend@0.10.3|caniuse-lite@1.0.30001743",
-        "nachet-frontend@0.10.3|electron-to-chromium@1.5.218",
-        "nachet-frontend@0.10.3|node-releases@2.0.21",
-        "nachet-frontend@0.10.3|update-browserslist-db@1.1.3"
+        "nachet-frontend@0.10.4|baseline-browser-mapping@2.8.4",
+        "nachet-frontend@0.10.4|caniuse-lite@1.0.30001743",
+        "nachet-frontend@0.10.4|electron-to-chromium@1.5.218",
+        "nachet-frontend@0.10.4|node-releases@2.0.21",
+        "nachet-frontend@0.10.4|update-browserslist-db@1.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|buffer@5.7.1",
+      "ref": "nachet-frontend@0.10.4|buffer@5.7.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|base64-js@1.5.1",
-        "nachet-frontend@0.10.3|ieee754@1.2.1"
+        "nachet-frontend@0.10.4|base64-js@1.5.1",
+        "nachet-frontend@0.10.4|ieee754@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|bytes@3.1.2"
+      "ref": "nachet-frontend@0.10.4|bytes@3.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cac@6.7.14"
+      "ref": "nachet-frontend@0.10.4|cac@6.7.14"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cacache@19.0.1",
+      "ref": "nachet-frontend@0.10.4|cacache@19.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@npmcli/fs@4.0.0",
-        "nachet-frontend@0.10.3|cacache@19.0.1|lru-cache@10.4.3",
-        "nachet-frontend@0.10.3|fs-minipass@3.0.3",
-        "nachet-frontend@0.10.3|glob@10.4.5",
-        "nachet-frontend@0.10.3|minipass-collect@2.0.1",
-        "nachet-frontend@0.10.3|minipass-flush@1.0.5",
-        "nachet-frontend@0.10.3|minipass-pipeline@1.2.4",
-        "nachet-frontend@0.10.3|minipass@7.1.2",
-        "nachet-frontend@0.10.3|p-map@7.0.3",
-        "nachet-frontend@0.10.3|ssri@12.0.0",
-        "nachet-frontend@0.10.3|tar@7.4.3",
-        "nachet-frontend@0.10.3|unique-filename@4.0.0"
+        "nachet-frontend@0.10.4|@npmcli/fs@4.0.0",
+        "nachet-frontend@0.10.4|cacache@19.0.1|lru-cache@10.4.3",
+        "nachet-frontend@0.10.4|fs-minipass@3.0.3",
+        "nachet-frontend@0.10.4|glob@10.4.5",
+        "nachet-frontend@0.10.4|minipass-collect@2.0.1",
+        "nachet-frontend@0.10.4|minipass-flush@1.0.5",
+        "nachet-frontend@0.10.4|minipass-pipeline@1.2.4",
+        "nachet-frontend@0.10.4|minipass@7.1.2",
+        "nachet-frontend@0.10.4|p-map@7.0.3",
+        "nachet-frontend@0.10.4|ssri@12.0.0",
+        "nachet-frontend@0.10.4|tar@7.4.3",
+        "nachet-frontend@0.10.4|unique-filename@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|cacache@19.0.1|lru-cache@10.4.3"
+      "ref": "nachet-frontend@0.10.4|cacache@19.0.1|lru-cache@10.4.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|call-bind-apply-helpers@1.0.2",
+      "ref": "nachet-frontend@0.10.4|call-bind-apply-helpers@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|function-bind@1.1.2"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|function-bind@1.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|call-bind@1.0.8",
+      "ref": "nachet-frontend@0.10.4|call-bind@1.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind-apply-helpers@1.0.2",
-        "nachet-frontend@0.10.3|es-define-property@1.0.1",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|set-function-length@1.2.2"
+        "nachet-frontend@0.10.4|call-bind-apply-helpers@1.0.2",
+        "nachet-frontend@0.10.4|es-define-property@1.0.1",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|set-function-length@1.2.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|call-bound@1.0.4",
+      "ref": "nachet-frontend@0.10.4|call-bound@1.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind-apply-helpers@1.0.2",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0"
+        "nachet-frontend@0.10.4|call-bind-apply-helpers@1.0.2",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|callsites@3.1.0"
+      "ref": "nachet-frontend@0.10.4|callsites@3.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|camelcase@7.0.1"
+      "ref": "nachet-frontend@0.10.4|camelcase@7.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|camelize@1.0.1"
+      "ref": "nachet-frontend@0.10.4|camelize@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|caniuse-lite@1.0.30001743"
+      "ref": "nachet-frontend@0.10.4|caniuse-lite@1.0.30001743"
     },
     {
-      "ref": "nachet-frontend@0.10.3|chai@5.3.3",
+      "ref": "nachet-frontend@0.10.4|chai@5.3.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|assertion-error@2.0.1",
-        "nachet-frontend@0.10.3|check-error@2.1.1",
-        "nachet-frontend@0.10.3|deep-eql@5.0.2",
-        "nachet-frontend@0.10.3|loupe@3.2.1",
-        "nachet-frontend@0.10.3|pathval@2.0.1"
+        "nachet-frontend@0.10.4|assertion-error@2.0.1",
+        "nachet-frontend@0.10.4|check-error@2.1.1",
+        "nachet-frontend@0.10.4|deep-eql@5.0.2",
+        "nachet-frontend@0.10.4|loupe@3.2.1",
+        "nachet-frontend@0.10.4|pathval@2.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|chalk-template@0.4.0",
+      "ref": "nachet-frontend@0.10.4|chalk-template@0.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|chalk@4.1.2"
+        "nachet-frontend@0.10.4|chalk@4.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|chalk@4.1.2",
+      "ref": "nachet-frontend@0.10.4|chalk@4.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-styles@4.3.0",
-        "nachet-frontend@0.10.3|supports-color@7.2.0"
+        "nachet-frontend@0.10.4|ansi-styles@4.3.0",
+        "nachet-frontend@0.10.4|supports-color@7.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|check-error@2.1.1"
+      "ref": "nachet-frontend@0.10.4|check-error@2.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|chownr@3.0.0"
+      "ref": "nachet-frontend@0.10.4|chownr@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ci-info@4.3.0"
+      "ref": "nachet-frontend@0.10.4|ci-info@4.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cli-boxes@3.0.0"
+      "ref": "nachet-frontend@0.10.4|cli-boxes@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|clipboardy@3.0.0",
+      "ref": "nachet-frontend@0.10.4|clipboardy@3.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|arch@2.2.0",
-        "nachet-frontend@0.10.3|clipboardy@3.0.0|execa@5.1.1",
-        "nachet-frontend@0.10.3|is-wsl@2.2.0"
+        "nachet-frontend@0.10.4|arch@2.2.0",
+        "nachet-frontend@0.10.4|clipboardy@3.0.0|execa@5.1.1",
+        "nachet-frontend@0.10.4|is-wsl@2.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|clipboardy@3.0.0|execa@5.1.1",
+      "ref": "nachet-frontend@0.10.4|clipboardy@3.0.0|execa@5.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|clipboardy@3.0.0|get-stream@6.0.1",
-        "nachet-frontend@0.10.3|clipboardy@3.0.0|human-signals@2.1.0",
-        "nachet-frontend@0.10.3|cross-spawn@7.0.6",
-        "nachet-frontend@0.10.3|is-stream@2.0.1",
-        "nachet-frontend@0.10.3|merge-stream@2.0.0",
-        "nachet-frontend@0.10.3|npm-run-path@4.0.1",
-        "nachet-frontend@0.10.3|onetime@5.1.2",
-        "nachet-frontend@0.10.3|signal-exit@3.0.7",
-        "nachet-frontend@0.10.3|strip-final-newline@2.0.0"
+        "nachet-frontend@0.10.4|clipboardy@3.0.0|get-stream@6.0.1",
+        "nachet-frontend@0.10.4|clipboardy@3.0.0|human-signals@2.1.0",
+        "nachet-frontend@0.10.4|cross-spawn@7.0.6",
+        "nachet-frontend@0.10.4|is-stream@2.0.1",
+        "nachet-frontend@0.10.4|merge-stream@2.0.0",
+        "nachet-frontend@0.10.4|npm-run-path@4.0.1",
+        "nachet-frontend@0.10.4|onetime@5.1.2",
+        "nachet-frontend@0.10.4|signal-exit@3.0.7",
+        "nachet-frontend@0.10.4|strip-final-newline@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|clipboardy@3.0.0|get-stream@6.0.1"
+      "ref": "nachet-frontend@0.10.4|clipboardy@3.0.0|get-stream@6.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|clipboardy@3.0.0|human-signals@2.1.0"
+      "ref": "nachet-frontend@0.10.4|clipboardy@3.0.0|human-signals@2.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cliui@7.0.4",
+      "ref": "nachet-frontend@0.10.4|cliui@7.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cliui@7.0.4|string-width@4.2.3",
-        "nachet-frontend@0.10.3|cliui@7.0.4|strip-ansi@6.0.1",
-        "nachet-frontend@0.10.3|cliui@7.0.4|wrap-ansi@7.0.0"
+        "nachet-frontend@0.10.4|cliui@7.0.4|string-width@4.2.3",
+        "nachet-frontend@0.10.4|cliui@7.0.4|strip-ansi@6.0.1",
+        "nachet-frontend@0.10.4|cliui@7.0.4|wrap-ansi@7.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|cliui@7.0.4|emoji-regex@8.0.0"
+      "ref": "nachet-frontend@0.10.4|cliui@7.0.4|emoji-regex@8.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cliui@7.0.4|string-width@4.2.3",
+      "ref": "nachet-frontend@0.10.4|cliui@7.0.4|string-width@4.2.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cliui@7.0.4|emoji-regex@8.0.0",
-        "nachet-frontend@0.10.3|cliui@7.0.4|strip-ansi@6.0.1",
-        "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0"
+        "nachet-frontend@0.10.4|cliui@7.0.4|emoji-regex@8.0.0",
+        "nachet-frontend@0.10.4|cliui@7.0.4|strip-ansi@6.0.1",
+        "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|cliui@7.0.4|strip-ansi@6.0.1",
+      "ref": "nachet-frontend@0.10.4|cliui@7.0.4|strip-ansi@6.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|cliui@7.0.4|wrap-ansi@7.0.0",
+      "ref": "nachet-frontend@0.10.4|cliui@7.0.4|wrap-ansi@7.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-styles@4.3.0",
-        "nachet-frontend@0.10.3|cliui@7.0.4|string-width@4.2.3",
-        "nachet-frontend@0.10.3|cliui@7.0.4|strip-ansi@6.0.1"
+        "nachet-frontend@0.10.4|ansi-styles@4.3.0",
+        "nachet-frontend@0.10.4|cliui@7.0.4|string-width@4.2.3",
+        "nachet-frontend@0.10.4|cliui@7.0.4|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|clsx@2.1.1"
+      "ref": "nachet-frontend@0.10.4|clsx@2.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|color-convert@2.0.1",
+      "ref": "nachet-frontend@0.10.4|color-convert@2.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|color-name@1.1.4"
+        "nachet-frontend@0.10.4|color-name@1.1.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|color-name@1.1.4"
+      "ref": "nachet-frontend@0.10.4|color-name@1.1.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|colors@1.4.0"
+      "ref": "nachet-frontend@0.10.4|colors@1.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|combined-stream@1.0.8",
+      "ref": "nachet-frontend@0.10.4|combined-stream@1.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|delayed-stream@1.0.0"
+        "nachet-frontend@0.10.4|delayed-stream@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|commander@14.0.1"
+      "ref": "nachet-frontend@0.10.4|commander@14.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|compressible@2.0.18",
+      "ref": "nachet-frontend@0.10.4|compressible@2.0.18",
       "dependsOn": [
-        "nachet-frontend@0.10.3|mime-db@1.54.0"
+        "nachet-frontend@0.10.4|mime-db@1.54.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|compression@1.8.1",
+      "ref": "nachet-frontend@0.10.4|compression@1.8.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|bytes@3.1.2",
-        "nachet-frontend@0.10.3|compressible@2.0.18",
-        "nachet-frontend@0.10.3|compression@1.8.1|debug@2.6.9",
-        "nachet-frontend@0.10.3|compression@1.8.1|negotiator@0.6.4",
-        "nachet-frontend@0.10.3|on-headers@1.1.0",
-        "nachet-frontend@0.10.3|safe-buffer@5.2.1",
-        "nachet-frontend@0.10.3|vary@1.1.2"
+        "nachet-frontend@0.10.4|bytes@3.1.2",
+        "nachet-frontend@0.10.4|compressible@2.0.18",
+        "nachet-frontend@0.10.4|compression@1.8.1|debug@2.6.9",
+        "nachet-frontend@0.10.4|compression@1.8.1|negotiator@0.6.4",
+        "nachet-frontend@0.10.4|on-headers@1.1.0",
+        "nachet-frontend@0.10.4|safe-buffer@5.2.1",
+        "nachet-frontend@0.10.4|vary@1.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|compression@1.8.1|debug@2.6.9",
+      "ref": "nachet-frontend@0.10.4|compression@1.8.1|debug@2.6.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|compression@1.8.1|ms@2.0.0"
+        "nachet-frontend@0.10.4|compression@1.8.1|ms@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|compression@1.8.1|ms@2.0.0"
+      "ref": "nachet-frontend@0.10.4|compression@1.8.1|ms@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|compression@1.8.1|negotiator@0.6.4"
+      "ref": "nachet-frontend@0.10.4|compression@1.8.1|negotiator@0.6.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|concat-map@0.0.1"
+      "ref": "nachet-frontend@0.10.4|concat-map@0.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|content-disposition@1.0.0",
+      "ref": "nachet-frontend@0.10.4|content-disposition@1.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|safe-buffer@5.2.1"
+        "nachet-frontend@0.10.4|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|content-type@1.0.5"
+      "ref": "nachet-frontend@0.10.4|content-type@1.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|convert-source-map@2.0.0"
+      "ref": "nachet-frontend@0.10.4|convert-source-map@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cookie-signature@1.2.2"
+      "ref": "nachet-frontend@0.10.4|cookie-signature@1.2.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cookie@0.7.2"
+      "ref": "nachet-frontend@0.10.4|cookie@0.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|core-js-compat@3.45.1",
+      "ref": "nachet-frontend@0.10.4|core-js-compat@3.45.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|browserslist@4.26.2"
+        "nachet-frontend@0.10.4|browserslist@4.26.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|core-util-is@1.0.3"
+      "ref": "nachet-frontend@0.10.4|core-util-is@1.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cosmiconfig@7.1.0",
+      "ref": "nachet-frontend@0.10.4|cosmiconfig@7.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/parse-json@4.0.2",
-        "nachet-frontend@0.10.3|cosmiconfig@7.1.0|yaml@1.10.2",
-        "nachet-frontend@0.10.3|import-fresh@3.3.1",
-        "nachet-frontend@0.10.3|parse-json@5.2.0",
-        "nachet-frontend@0.10.3|path-type@4.0.0"
+        "nachet-frontend@0.10.4|@types/parse-json@4.0.2",
+        "nachet-frontend@0.10.4|cosmiconfig@7.1.0|yaml@1.10.2",
+        "nachet-frontend@0.10.4|import-fresh@3.3.1",
+        "nachet-frontend@0.10.4|parse-json@5.2.0",
+        "nachet-frontend@0.10.4|path-type@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|cosmiconfig@7.1.0|yaml@1.10.2"
+      "ref": "nachet-frontend@0.10.4|cosmiconfig@7.1.0|yaml@1.10.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cross-spawn@7.0.6",
+      "ref": "nachet-frontend@0.10.4|cross-spawn@7.0.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|path-key@3.1.1",
-        "nachet-frontend@0.10.3|shebang-command@2.0.0",
-        "nachet-frontend@0.10.3|which@2.0.2"
+        "nachet-frontend@0.10.4|path-key@3.1.1",
+        "nachet-frontend@0.10.4|shebang-command@2.0.0",
+        "nachet-frontend@0.10.4|which@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|css-color-keywords@1.0.0"
+      "ref": "nachet-frontend@0.10.4|css-color-keywords@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|css-to-react-native@3.2.0",
+      "ref": "nachet-frontend@0.10.4|css-to-react-native@3.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|camelize@1.0.1",
-        "nachet-frontend@0.10.3|css-color-keywords@1.0.0",
-        "nachet-frontend@0.10.3|postcss-value-parser@4.2.0"
+        "nachet-frontend@0.10.4|camelize@1.0.1",
+        "nachet-frontend@0.10.4|css-color-keywords@1.0.0",
+        "nachet-frontend@0.10.4|postcss-value-parser@4.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|css.escape@1.5.1"
+      "ref": "nachet-frontend@0.10.4|css.escape@1.5.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|cssstyle@4.6.0",
+      "ref": "nachet-frontend@0.10.4|cssstyle@4.6.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@asamuzakjp/css-color@3.2.0",
-        "nachet-frontend@0.10.3|rrweb-cssom@0.8.0"
+        "nachet-frontend@0.10.4|@asamuzakjp/css-color@3.2.0",
+        "nachet-frontend@0.10.4|rrweb-cssom@0.8.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|csstype@3.1.3"
+      "ref": "nachet-frontend@0.10.4|csstype@3.1.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|data-uri-to-buffer@4.0.1"
+      "ref": "nachet-frontend@0.10.4|data-uri-to-buffer@4.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|data-urls@5.0.0",
+      "ref": "nachet-frontend@0.10.4|data-urls@5.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|whatwg-mimetype@4.0.0",
-        "nachet-frontend@0.10.3|whatwg-url@14.2.0"
+        "nachet-frontend@0.10.4|whatwg-mimetype@4.0.0",
+        "nachet-frontend@0.10.4|whatwg-url@14.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|data-view-buffer@1.0.2",
+      "ref": "nachet-frontend@0.10.4|data-view-buffer@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|is-data-view@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|is-data-view@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|data-view-byte-length@1.0.2",
+      "ref": "nachet-frontend@0.10.4|data-view-byte-length@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|is-data-view@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|is-data-view@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|data-view-byte-offset@1.0.1",
+      "ref": "nachet-frontend@0.10.4|data-view-byte-offset@1.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|is-data-view@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|is-data-view@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|debug@4.4.3",
+      "ref": "nachet-frontend@0.10.4|debug@4.4.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ms@2.1.3"
+        "nachet-frontend@0.10.4|ms@2.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|decimal.js@10.6.0"
+      "ref": "nachet-frontend@0.10.4|decimal.js@10.6.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|decompress-response@6.0.0",
+      "ref": "nachet-frontend@0.10.4|decompress-response@6.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|mimic-response@3.1.0"
+        "nachet-frontend@0.10.4|mimic-response@3.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|deep-eql@5.0.2"
+      "ref": "nachet-frontend@0.10.4|deep-eql@5.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|deep-extend@0.6.0"
+      "ref": "nachet-frontend@0.10.4|deep-extend@0.6.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|deep-is@0.1.4"
+      "ref": "nachet-frontend@0.10.4|deep-is@0.1.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|deepmerge@4.3.1"
+      "ref": "nachet-frontend@0.10.4|deepmerge@4.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|define-data-property@1.1.4",
+      "ref": "nachet-frontend@0.10.4|define-data-property@1.1.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-define-property@1.0.1",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|gopd@1.2.0"
+        "nachet-frontend@0.10.4|es-define-property@1.0.1",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|gopd@1.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|define-properties@1.2.1",
+      "ref": "nachet-frontend@0.10.4|define-properties@1.2.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|define-data-property@1.1.4",
-        "nachet-frontend@0.10.3|has-property-descriptors@1.0.2",
-        "nachet-frontend@0.10.3|object-keys@1.1.1"
+        "nachet-frontend@0.10.4|define-data-property@1.1.4",
+        "nachet-frontend@0.10.4|has-property-descriptors@1.0.2",
+        "nachet-frontend@0.10.4|object-keys@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|delayed-stream@1.0.0"
+      "ref": "nachet-frontend@0.10.4|delayed-stream@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|depd@2.0.0"
+      "ref": "nachet-frontend@0.10.4|depd@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|dequal@2.0.3"
+      "ref": "nachet-frontend@0.10.4|dequal@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|detect-libc@2.1.0"
+      "ref": "nachet-frontend@0.10.4|detect-libc@2.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|discontinuous-range@1.0.0"
+      "ref": "nachet-frontend@0.10.4|discontinuous-range@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|doctrine@2.1.0",
+      "ref": "nachet-frontend@0.10.4|doctrine@2.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|esutils@2.0.3"
+        "nachet-frontend@0.10.4|esutils@2.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|dom-accessibility-api@0.5.16"
+      "ref": "nachet-frontend@0.10.4|dom-accessibility-api@0.5.16"
     },
     {
-      "ref": "nachet-frontend@0.10.3|dom-helpers@5.2.1",
+      "ref": "nachet-frontend@0.10.4|dom-helpers@5.2.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|csstype@3.1.3"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|csstype@3.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|dom-serializer@2.0.0",
+      "ref": "nachet-frontend@0.10.4|dom-serializer@2.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|domelementtype@2.3.0",
-        "nachet-frontend@0.10.3|domhandler@5.0.3",
-        "nachet-frontend@0.10.3|entities@4.5.0"
+        "nachet-frontend@0.10.4|domelementtype@2.3.0",
+        "nachet-frontend@0.10.4|domhandler@5.0.3",
+        "nachet-frontend@0.10.4|entities@4.5.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|domelementtype@2.3.0"
+      "ref": "nachet-frontend@0.10.4|domelementtype@2.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|domhandler@5.0.3",
+      "ref": "nachet-frontend@0.10.4|domhandler@5.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|domelementtype@2.3.0"
+        "nachet-frontend@0.10.4|domelementtype@2.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|dompurify@3.2.6",
+      "ref": "nachet-frontend@0.10.4|dompurify@3.2.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/trusted-types@2.0.7"
+        "nachet-frontend@0.10.4|@types/trusted-types@2.0.7"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|domutils@3.2.2",
+      "ref": "nachet-frontend@0.10.4|domutils@3.2.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|dom-serializer@2.0.0",
-        "nachet-frontend@0.10.3|domelementtype@2.3.0",
-        "nachet-frontend@0.10.3|domhandler@5.0.3"
+        "nachet-frontend@0.10.4|dom-serializer@2.0.0",
+        "nachet-frontend@0.10.4|domelementtype@2.3.0",
+        "nachet-frontend@0.10.4|domhandler@5.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|dunder-proto@1.0.1",
+      "ref": "nachet-frontend@0.10.4|dunder-proto@1.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind-apply-helpers@1.0.2",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|gopd@1.2.0"
+        "nachet-frontend@0.10.4|call-bind-apply-helpers@1.0.2",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|gopd@1.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eastasianwidth@0.2.0"
+      "ref": "nachet-frontend@0.10.4|eastasianwidth@0.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ee-first@1.1.1"
+      "ref": "nachet-frontend@0.10.4|ee-first@1.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|electron-to-chromium@1.5.218"
+      "ref": "nachet-frontend@0.10.4|electron-to-chromium@1.5.218"
     },
     {
-      "ref": "nachet-frontend@0.10.3|emoji-regex@9.2.2"
+      "ref": "nachet-frontend@0.10.4|emoji-regex@9.2.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|encodeurl@2.0.0"
+      "ref": "nachet-frontend@0.10.4|encodeurl@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|encoding@0.1.13",
+      "ref": "nachet-frontend@0.10.4|encoding@0.1.13",
       "dependsOn": [
-        "nachet-frontend@0.10.3|iconv-lite@0.6.3"
+        "nachet-frontend@0.10.4|iconv-lite@0.6.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|end-of-stream@1.4.5",
+      "ref": "nachet-frontend@0.10.4|end-of-stream@1.4.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|once@1.4.0"
+        "nachet-frontend@0.10.4|once@1.4.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|entities@4.5.0"
+      "ref": "nachet-frontend@0.10.4|entities@4.5.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|env-paths@2.2.1"
+      "ref": "nachet-frontend@0.10.4|env-paths@2.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|err-code@2.0.3"
+      "ref": "nachet-frontend@0.10.4|err-code@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|error-ex@1.3.4",
+      "ref": "nachet-frontend@0.10.4|error-ex@1.3.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-arrayish@0.2.1"
+        "nachet-frontend@0.10.4|is-arrayish@0.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-abstract@1.24.0",
+      "ref": "nachet-frontend@0.10.4|es-abstract@1.24.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|array-buffer-byte-length@1.0.2",
-        "nachet-frontend@0.10.3|arraybuffer.prototype.slice@1.0.4",
-        "nachet-frontend@0.10.3|available-typed-arrays@1.0.7",
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|data-view-buffer@1.0.2",
-        "nachet-frontend@0.10.3|data-view-byte-length@1.0.2",
-        "nachet-frontend@0.10.3|data-view-byte-offset@1.0.1",
-        "nachet-frontend@0.10.3|es-define-property@1.0.1",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|es-set-tostringtag@2.1.0",
-        "nachet-frontend@0.10.3|es-to-primitive@1.3.0",
-        "nachet-frontend@0.10.3|function.prototype.name@1.1.8",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|get-symbol-description@1.1.0",
-        "nachet-frontend@0.10.3|globalthis@1.0.4",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-property-descriptors@1.0.2",
-        "nachet-frontend@0.10.3|has-proto@1.2.0",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|hasown@2.0.2",
-        "nachet-frontend@0.10.3|internal-slot@1.1.0",
-        "nachet-frontend@0.10.3|is-array-buffer@3.0.5",
-        "nachet-frontend@0.10.3|is-callable@1.2.7",
-        "nachet-frontend@0.10.3|is-data-view@1.0.2",
-        "nachet-frontend@0.10.3|is-negative-zero@2.0.3",
-        "nachet-frontend@0.10.3|is-regex@1.2.1",
-        "nachet-frontend@0.10.3|is-set@2.0.3",
-        "nachet-frontend@0.10.3|is-shared-array-buffer@1.0.4",
-        "nachet-frontend@0.10.3|is-string@1.1.1",
-        "nachet-frontend@0.10.3|is-typed-array@1.1.15",
-        "nachet-frontend@0.10.3|is-weakref@1.1.1",
-        "nachet-frontend@0.10.3|math-intrinsics@1.1.0",
-        "nachet-frontend@0.10.3|object-inspect@1.13.4",
-        "nachet-frontend@0.10.3|object-keys@1.1.1",
-        "nachet-frontend@0.10.3|object.assign@4.1.7",
-        "nachet-frontend@0.10.3|own-keys@1.0.1",
-        "nachet-frontend@0.10.3|regexp.prototype.flags@1.5.4",
-        "nachet-frontend@0.10.3|safe-array-concat@1.1.3",
-        "nachet-frontend@0.10.3|safe-push-apply@1.0.0",
-        "nachet-frontend@0.10.3|safe-regex-test@1.1.0",
-        "nachet-frontend@0.10.3|set-proto@1.0.0",
-        "nachet-frontend@0.10.3|stop-iteration-iterator@1.1.0",
-        "nachet-frontend@0.10.3|string.prototype.trim@1.2.10",
-        "nachet-frontend@0.10.3|string.prototype.trimend@1.0.9",
-        "nachet-frontend@0.10.3|string.prototype.trimstart@1.0.8",
-        "nachet-frontend@0.10.3|typed-array-buffer@1.0.3",
-        "nachet-frontend@0.10.3|typed-array-byte-length@1.0.3",
-        "nachet-frontend@0.10.3|typed-array-byte-offset@1.0.4",
-        "nachet-frontend@0.10.3|typed-array-length@1.0.7",
-        "nachet-frontend@0.10.3|unbox-primitive@1.1.0",
-        "nachet-frontend@0.10.3|which-typed-array@1.1.19"
+        "nachet-frontend@0.10.4|array-buffer-byte-length@1.0.2",
+        "nachet-frontend@0.10.4|arraybuffer.prototype.slice@1.0.4",
+        "nachet-frontend@0.10.4|available-typed-arrays@1.0.7",
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|data-view-buffer@1.0.2",
+        "nachet-frontend@0.10.4|data-view-byte-length@1.0.2",
+        "nachet-frontend@0.10.4|data-view-byte-offset@1.0.1",
+        "nachet-frontend@0.10.4|es-define-property@1.0.1",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|es-set-tostringtag@2.1.0",
+        "nachet-frontend@0.10.4|es-to-primitive@1.3.0",
+        "nachet-frontend@0.10.4|function.prototype.name@1.1.8",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|get-symbol-description@1.1.0",
+        "nachet-frontend@0.10.4|globalthis@1.0.4",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-property-descriptors@1.0.2",
+        "nachet-frontend@0.10.4|has-proto@1.2.0",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|hasown@2.0.2",
+        "nachet-frontend@0.10.4|internal-slot@1.1.0",
+        "nachet-frontend@0.10.4|is-array-buffer@3.0.5",
+        "nachet-frontend@0.10.4|is-callable@1.2.7",
+        "nachet-frontend@0.10.4|is-data-view@1.0.2",
+        "nachet-frontend@0.10.4|is-negative-zero@2.0.3",
+        "nachet-frontend@0.10.4|is-regex@1.2.1",
+        "nachet-frontend@0.10.4|is-set@2.0.3",
+        "nachet-frontend@0.10.4|is-shared-array-buffer@1.0.4",
+        "nachet-frontend@0.10.4|is-string@1.1.1",
+        "nachet-frontend@0.10.4|is-typed-array@1.1.15",
+        "nachet-frontend@0.10.4|is-weakref@1.1.1",
+        "nachet-frontend@0.10.4|math-intrinsics@1.1.0",
+        "nachet-frontend@0.10.4|object-inspect@1.13.4",
+        "nachet-frontend@0.10.4|object-keys@1.1.1",
+        "nachet-frontend@0.10.4|object.assign@4.1.7",
+        "nachet-frontend@0.10.4|own-keys@1.0.1",
+        "nachet-frontend@0.10.4|regexp.prototype.flags@1.5.4",
+        "nachet-frontend@0.10.4|safe-array-concat@1.1.3",
+        "nachet-frontend@0.10.4|safe-push-apply@1.0.0",
+        "nachet-frontend@0.10.4|safe-regex-test@1.1.0",
+        "nachet-frontend@0.10.4|set-proto@1.0.0",
+        "nachet-frontend@0.10.4|stop-iteration-iterator@1.1.0",
+        "nachet-frontend@0.10.4|string.prototype.trim@1.2.10",
+        "nachet-frontend@0.10.4|string.prototype.trimend@1.0.9",
+        "nachet-frontend@0.10.4|string.prototype.trimstart@1.0.8",
+        "nachet-frontend@0.10.4|typed-array-buffer@1.0.3",
+        "nachet-frontend@0.10.4|typed-array-byte-length@1.0.3",
+        "nachet-frontend@0.10.4|typed-array-byte-offset@1.0.4",
+        "nachet-frontend@0.10.4|typed-array-length@1.0.7",
+        "nachet-frontend@0.10.4|unbox-primitive@1.1.0",
+        "nachet-frontend@0.10.4|which-typed-array@1.1.19"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-define-property@1.0.1"
+      "ref": "nachet-frontend@0.10.4|es-define-property@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-errors@1.3.0"
+      "ref": "nachet-frontend@0.10.4|es-errors@1.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-iterator-helpers@1.2.1",
+      "ref": "nachet-frontend@0.10.4|es-iterator-helpers@1.2.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-set-tostringtag@2.1.0",
-        "nachet-frontend@0.10.3|function-bind@1.1.2",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|globalthis@1.0.4",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-property-descriptors@1.0.2",
-        "nachet-frontend@0.10.3|has-proto@1.2.0",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|internal-slot@1.1.0",
-        "nachet-frontend@0.10.3|iterator.prototype@1.1.5",
-        "nachet-frontend@0.10.3|safe-array-concat@1.1.3"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-set-tostringtag@2.1.0",
+        "nachet-frontend@0.10.4|function-bind@1.1.2",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|globalthis@1.0.4",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-property-descriptors@1.0.2",
+        "nachet-frontend@0.10.4|has-proto@1.2.0",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|internal-slot@1.1.0",
+        "nachet-frontend@0.10.4|iterator.prototype@1.1.5",
+        "nachet-frontend@0.10.4|safe-array-concat@1.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-module-lexer@1.7.0"
+      "ref": "nachet-frontend@0.10.4|es-module-lexer@1.7.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
+      "ref": "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0"
+        "nachet-frontend@0.10.4|es-errors@1.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-set-tostringtag@2.1.0",
+      "ref": "nachet-frontend@0.10.4|es-set-tostringtag@2.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
-        "nachet-frontend@0.10.3|hasown@2.0.2"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
+        "nachet-frontend@0.10.4|hasown@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-shim-unscopables@1.1.0",
+      "ref": "nachet-frontend@0.10.4|es-shim-unscopables@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|hasown@2.0.2"
+        "nachet-frontend@0.10.4|hasown@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|es-to-primitive@1.3.0",
+      "ref": "nachet-frontend@0.10.4|es-to-primitive@1.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-callable@1.2.7",
-        "nachet-frontend@0.10.3|is-date-object@1.1.0",
-        "nachet-frontend@0.10.3|is-symbol@1.1.1"
+        "nachet-frontend@0.10.4|is-callable@1.2.7",
+        "nachet-frontend@0.10.4|is-date-object@1.1.0",
+        "nachet-frontend@0.10.4|is-symbol@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|esbuild@0.25.9",
+      "ref": "nachet-frontend@0.10.4|esbuild@0.25.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@esbuild/aix-ppc64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/android-arm@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/android-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/android-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/darwin-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/darwin-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/freebsd-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/freebsd-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-arm@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-ia32@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-loong64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-mips64el@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-ppc64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-riscv64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-s390x@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/linux-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/netbsd-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/netbsd-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/openbsd-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/openbsd-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/openharmony-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/sunos-x64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/win32-arm64@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/win32-ia32@0.25.9",
-        "nachet-frontend@0.10.3|@esbuild/win32-x64@0.25.9"
+        "nachet-frontend@0.10.4|@esbuild/aix-ppc64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/android-arm@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/android-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/android-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/darwin-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/darwin-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/freebsd-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/freebsd-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-arm@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-ia32@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-loong64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-mips64el@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-ppc64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-riscv64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-s390x@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/linux-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/netbsd-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/netbsd-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/openbsd-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/openbsd-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/openharmony-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/sunos-x64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/win32-arm64@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/win32-ia32@0.25.9",
+        "nachet-frontend@0.10.4|@esbuild/win32-x64@0.25.9"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|escalade@3.2.0"
+      "ref": "nachet-frontend@0.10.4|escalade@3.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|escape-html@1.0.3"
+      "ref": "nachet-frontend@0.10.4|escape-html@1.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|escape-string-regexp@4.0.0"
+      "ref": "nachet-frontend@0.10.4|escape-string-regexp@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-config-prettier@10.1.8",
+      "ref": "nachet-frontend@0.10.4|eslint-config-prettier@10.1.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint@9.35.0"
+        "nachet-frontend@0.10.4|eslint@9.35.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-import-resolver-node@0.3.9",
+      "ref": "nachet-frontend@0.10.4|eslint-import-resolver-node@0.3.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint-import-resolver-node@0.3.9|debug@3.2.7",
-        "nachet-frontend@0.10.3|is-core-module@2.16.1",
-        "nachet-frontend@0.10.3|resolve@1.22.10"
+        "nachet-frontend@0.10.4|eslint-import-resolver-node@0.3.9|debug@3.2.7",
+        "nachet-frontend@0.10.4|is-core-module@2.16.1",
+        "nachet-frontend@0.10.4|resolve@1.22.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-import-resolver-node@0.3.9|debug@3.2.7",
+      "ref": "nachet-frontend@0.10.4|eslint-import-resolver-node@0.3.9|debug@3.2.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ms@2.1.3"
+        "nachet-frontend@0.10.4|ms@2.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-module-utils@2.12.1",
+      "ref": "nachet-frontend@0.10.4|eslint-module-utils@2.12.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint-module-utils@2.12.1|debug@3.2.7"
+        "nachet-frontend@0.10.4|eslint-module-utils@2.12.1|debug@3.2.7"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-module-utils@2.12.1|debug@3.2.7",
+      "ref": "nachet-frontend@0.10.4|eslint-module-utils@2.12.1|debug@3.2.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ms@2.1.3"
+        "nachet-frontend@0.10.4|ms@2.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-import@2.32.0",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-import@2.32.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@rtsao/scc@1.1.0",
-        "nachet-frontend@0.10.3|array-includes@3.1.9",
-        "nachet-frontend@0.10.3|array.prototype.findlastindex@1.2.6",
-        "nachet-frontend@0.10.3|array.prototype.flat@1.3.3",
-        "nachet-frontend@0.10.3|array.prototype.flatmap@1.3.3",
-        "nachet-frontend@0.10.3|doctrine@2.1.0",
-        "nachet-frontend@0.10.3|eslint-import-resolver-node@0.3.9",
-        "nachet-frontend@0.10.3|eslint-module-utils@2.12.1",
-        "nachet-frontend@0.10.3|eslint-plugin-import@2.32.0|debug@3.2.7",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|hasown@2.0.2",
-        "nachet-frontend@0.10.3|is-core-module@2.16.1",
-        "nachet-frontend@0.10.3|is-glob@4.0.3",
-        "nachet-frontend@0.10.3|minimatch@3.1.2",
-        "nachet-frontend@0.10.3|object.fromentries@2.0.8",
-        "nachet-frontend@0.10.3|object.groupby@1.0.3",
-        "nachet-frontend@0.10.3|object.values@1.2.1",
-        "nachet-frontend@0.10.3|semver@6.3.1",
-        "nachet-frontend@0.10.3|string.prototype.trimend@1.0.9",
-        "nachet-frontend@0.10.3|tsconfig-paths@3.15.0"
+        "nachet-frontend@0.10.4|@rtsao/scc@1.1.0",
+        "nachet-frontend@0.10.4|array-includes@3.1.9",
+        "nachet-frontend@0.10.4|array.prototype.findlastindex@1.2.6",
+        "nachet-frontend@0.10.4|array.prototype.flat@1.3.3",
+        "nachet-frontend@0.10.4|array.prototype.flatmap@1.3.3",
+        "nachet-frontend@0.10.4|doctrine@2.1.0",
+        "nachet-frontend@0.10.4|eslint-import-resolver-node@0.3.9",
+        "nachet-frontend@0.10.4|eslint-module-utils@2.12.1",
+        "nachet-frontend@0.10.4|eslint-plugin-import@2.32.0|debug@3.2.7",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|hasown@2.0.2",
+        "nachet-frontend@0.10.4|is-core-module@2.16.1",
+        "nachet-frontend@0.10.4|is-glob@4.0.3",
+        "nachet-frontend@0.10.4|minimatch@3.1.2",
+        "nachet-frontend@0.10.4|object.fromentries@2.0.8",
+        "nachet-frontend@0.10.4|object.groupby@1.0.3",
+        "nachet-frontend@0.10.4|object.values@1.2.1",
+        "nachet-frontend@0.10.4|semver@6.3.1",
+        "nachet-frontend@0.10.4|string.prototype.trimend@1.0.9",
+        "nachet-frontend@0.10.4|tsconfig-paths@3.15.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-import@2.32.0|debug@3.2.7",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-import@2.32.0|debug@3.2.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ms@2.1.3"
+        "nachet-frontend@0.10.4|ms@2.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-prettier@5.5.4",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-prettier@5.5.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint-config-prettier@10.1.8",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|prettier-linter-helpers@1.0.0",
-        "nachet-frontend@0.10.3|prettier@3.6.2",
-        "nachet-frontend@0.10.3|synckit@0.11.11"
+        "nachet-frontend@0.10.4|eslint-config-prettier@10.1.8",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|prettier-linter-helpers@1.0.0",
+        "nachet-frontend@0.10.4|prettier@3.6.2",
+        "nachet-frontend@0.10.4|synckit@0.11.11"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-react-hooks@5.2.0",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-react-hooks@5.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint@9.35.0"
+        "nachet-frontend@0.10.4|eslint@9.35.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-react-refresh@0.4.20",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-react-refresh@0.4.20",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint@9.35.0"
+        "nachet-frontend@0.10.4|eslint@9.35.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-react@7.37.5",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-react@7.37.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|array-includes@3.1.9",
-        "nachet-frontend@0.10.3|array.prototype.findlast@1.2.5",
-        "nachet-frontend@0.10.3|array.prototype.flatmap@1.3.3",
-        "nachet-frontend@0.10.3|array.prototype.tosorted@1.1.4",
-        "nachet-frontend@0.10.3|doctrine@2.1.0",
-        "nachet-frontend@0.10.3|es-iterator-helpers@1.2.1",
-        "nachet-frontend@0.10.3|eslint-plugin-react@7.37.5|resolve@2.0.0-next.5",
-        "nachet-frontend@0.10.3|eslint@9.35.0",
-        "nachet-frontend@0.10.3|estraverse@5.3.0",
-        "nachet-frontend@0.10.3|hasown@2.0.2",
-        "nachet-frontend@0.10.3|jsx-ast-utils@3.3.5",
-        "nachet-frontend@0.10.3|minimatch@3.1.2",
-        "nachet-frontend@0.10.3|object.entries@1.1.9",
-        "nachet-frontend@0.10.3|object.fromentries@2.0.8",
-        "nachet-frontend@0.10.3|object.values@1.2.1",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|semver@6.3.1",
-        "nachet-frontend@0.10.3|string.prototype.matchall@4.0.12",
-        "nachet-frontend@0.10.3|string.prototype.repeat@1.0.0"
+        "nachet-frontend@0.10.4|array-includes@3.1.9",
+        "nachet-frontend@0.10.4|array.prototype.findlast@1.2.5",
+        "nachet-frontend@0.10.4|array.prototype.flatmap@1.3.3",
+        "nachet-frontend@0.10.4|array.prototype.tosorted@1.1.4",
+        "nachet-frontend@0.10.4|doctrine@2.1.0",
+        "nachet-frontend@0.10.4|es-iterator-helpers@1.2.1",
+        "nachet-frontend@0.10.4|eslint-plugin-react@7.37.5|resolve@2.0.0-next.5",
+        "nachet-frontend@0.10.4|eslint@9.35.0",
+        "nachet-frontend@0.10.4|estraverse@5.3.0",
+        "nachet-frontend@0.10.4|hasown@2.0.2",
+        "nachet-frontend@0.10.4|jsx-ast-utils@3.3.5",
+        "nachet-frontend@0.10.4|minimatch@3.1.2",
+        "nachet-frontend@0.10.4|object.entries@1.1.9",
+        "nachet-frontend@0.10.4|object.fromentries@2.0.8",
+        "nachet-frontend@0.10.4|object.values@1.2.1",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|semver@6.3.1",
+        "nachet-frontend@0.10.4|string.prototype.matchall@4.0.12",
+        "nachet-frontend@0.10.4|string.prototype.repeat@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-plugin-react@7.37.5|resolve@2.0.0-next.5",
+      "ref": "nachet-frontend@0.10.4|eslint-plugin-react@7.37.5|resolve@2.0.0-next.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-core-module@2.16.1",
-        "nachet-frontend@0.10.3|path-parse@1.0.7",
-        "nachet-frontend@0.10.3|supports-preserve-symlinks-flag@1.0.0"
+        "nachet-frontend@0.10.4|is-core-module@2.16.1",
+        "nachet-frontend@0.10.4|path-parse@1.0.7",
+        "nachet-frontend@0.10.4|supports-preserve-symlinks-flag@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-scope@8.4.0",
+      "ref": "nachet-frontend@0.10.4|eslint-scope@8.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|esrecurse@4.3.0",
-        "nachet-frontend@0.10.3|estraverse@5.3.0"
+        "nachet-frontend@0.10.4|esrecurse@4.3.0",
+        "nachet-frontend@0.10.4|estraverse@5.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint-visitor-keys@3.4.3"
+      "ref": "nachet-frontend@0.10.4|eslint-visitor-keys@3.4.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint@9.35.0",
+      "ref": "nachet-frontend@0.10.4|eslint@9.35.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@eslint-community/eslint-utils@4.9.0",
-        "nachet-frontend@0.10.3|@eslint-community/regexpp@4.12.1",
-        "nachet-frontend@0.10.3|@eslint/config-array@0.21.0",
-        "nachet-frontend@0.10.3|@eslint/config-helpers@0.3.1",
-        "nachet-frontend@0.10.3|@eslint/core@0.15.2",
-        "nachet-frontend@0.10.3|@eslint/eslintrc@3.3.1",
-        "nachet-frontend@0.10.3|@eslint/js@9.35.0",
-        "nachet-frontend@0.10.3|@eslint/plugin-kit@0.3.5",
-        "nachet-frontend@0.10.3|@humanfs/node@0.16.7",
-        "nachet-frontend@0.10.3|@humanwhocodes/module-importer@1.0.1",
-        "nachet-frontend@0.10.3|@humanwhocodes/retry@0.4.3",
-        "nachet-frontend@0.10.3|@types/estree@1.0.8",
-        "nachet-frontend@0.10.3|@types/json-schema@7.0.15",
-        "nachet-frontend@0.10.3|chalk@4.1.2",
-        "nachet-frontend@0.10.3|cross-spawn@7.0.6",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|escape-string-regexp@4.0.0",
-        "nachet-frontend@0.10.3|eslint-scope@8.4.0",
-        "nachet-frontend@0.10.3|eslint@9.35.0|ajv@6.12.6",
-        "nachet-frontend@0.10.3|eslint@9.35.0|eslint-visitor-keys@4.2.1",
-        "nachet-frontend@0.10.3|espree@10.4.0",
-        "nachet-frontend@0.10.3|esquery@1.6.0",
-        "nachet-frontend@0.10.3|esutils@2.0.3",
-        "nachet-frontend@0.10.3|fast-deep-equal@3.1.3",
-        "nachet-frontend@0.10.3|file-entry-cache@8.0.0",
-        "nachet-frontend@0.10.3|find-up@5.0.0",
-        "nachet-frontend@0.10.3|glob-parent@6.0.2",
-        "nachet-frontend@0.10.3|ignore@5.3.2",
-        "nachet-frontend@0.10.3|imurmurhash@0.1.4",
-        "nachet-frontend@0.10.3|is-glob@4.0.3",
-        "nachet-frontend@0.10.3|json-stable-stringify-without-jsonify@1.0.1",
-        "nachet-frontend@0.10.3|lodash.merge@4.6.2",
-        "nachet-frontend@0.10.3|minimatch@3.1.2",
-        "nachet-frontend@0.10.3|natural-compare@1.4.0",
-        "nachet-frontend@0.10.3|optionator@0.9.4"
+        "nachet-frontend@0.10.4|@eslint-community/eslint-utils@4.9.0",
+        "nachet-frontend@0.10.4|@eslint-community/regexpp@4.12.1",
+        "nachet-frontend@0.10.4|@eslint/config-array@0.21.0",
+        "nachet-frontend@0.10.4|@eslint/config-helpers@0.3.1",
+        "nachet-frontend@0.10.4|@eslint/core@0.15.2",
+        "nachet-frontend@0.10.4|@eslint/eslintrc@3.3.1",
+        "nachet-frontend@0.10.4|@eslint/js@9.35.0",
+        "nachet-frontend@0.10.4|@eslint/plugin-kit@0.3.5",
+        "nachet-frontend@0.10.4|@humanfs/node@0.16.7",
+        "nachet-frontend@0.10.4|@humanwhocodes/module-importer@1.0.1",
+        "nachet-frontend@0.10.4|@humanwhocodes/retry@0.4.3",
+        "nachet-frontend@0.10.4|@types/estree@1.0.8",
+        "nachet-frontend@0.10.4|@types/json-schema@7.0.15",
+        "nachet-frontend@0.10.4|chalk@4.1.2",
+        "nachet-frontend@0.10.4|cross-spawn@7.0.6",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|escape-string-regexp@4.0.0",
+        "nachet-frontend@0.10.4|eslint-scope@8.4.0",
+        "nachet-frontend@0.10.4|eslint@9.35.0|ajv@6.12.6",
+        "nachet-frontend@0.10.4|eslint@9.35.0|eslint-visitor-keys@4.2.1",
+        "nachet-frontend@0.10.4|espree@10.4.0",
+        "nachet-frontend@0.10.4|esquery@1.6.0",
+        "nachet-frontend@0.10.4|esutils@2.0.3",
+        "nachet-frontend@0.10.4|fast-deep-equal@3.1.3",
+        "nachet-frontend@0.10.4|file-entry-cache@8.0.0",
+        "nachet-frontend@0.10.4|find-up@5.0.0",
+        "nachet-frontend@0.10.4|glob-parent@6.0.2",
+        "nachet-frontend@0.10.4|ignore@5.3.2",
+        "nachet-frontend@0.10.4|imurmurhash@0.1.4",
+        "nachet-frontend@0.10.4|is-glob@4.0.3",
+        "nachet-frontend@0.10.4|json-stable-stringify-without-jsonify@1.0.1",
+        "nachet-frontend@0.10.4|lodash.merge@4.6.2",
+        "nachet-frontend@0.10.4|minimatch@3.1.2",
+        "nachet-frontend@0.10.4|natural-compare@1.4.0",
+        "nachet-frontend@0.10.4|optionator@0.9.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint@9.35.0|ajv@6.12.6",
+      "ref": "nachet-frontend@0.10.4|eslint@9.35.0|ajv@6.12.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eslint@9.35.0|json-schema-traverse@0.4.1",
-        "nachet-frontend@0.10.3|fast-deep-equal@3.1.3",
-        "nachet-frontend@0.10.3|fast-json-stable-stringify@2.1.0",
-        "nachet-frontend@0.10.3|uri-js@4.4.1"
+        "nachet-frontend@0.10.4|eslint@9.35.0|json-schema-traverse@0.4.1",
+        "nachet-frontend@0.10.4|fast-deep-equal@3.1.3",
+        "nachet-frontend@0.10.4|fast-json-stable-stringify@2.1.0",
+        "nachet-frontend@0.10.4|uri-js@4.4.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint@9.35.0|eslint-visitor-keys@4.2.1"
+      "ref": "nachet-frontend@0.10.4|eslint@9.35.0|eslint-visitor-keys@4.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|eslint@9.35.0|json-schema-traverse@0.4.1"
+      "ref": "nachet-frontend@0.10.4|eslint@9.35.0|json-schema-traverse@0.4.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|espree@10.4.0",
+      "ref": "nachet-frontend@0.10.4|espree@10.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|acorn-jsx@5.3.2",
-        "nachet-frontend@0.10.3|acorn@8.15.0",
-        "nachet-frontend@0.10.3|espree@10.4.0|eslint-visitor-keys@4.2.1"
+        "nachet-frontend@0.10.4|acorn-jsx@5.3.2",
+        "nachet-frontend@0.10.4|acorn@8.15.0",
+        "nachet-frontend@0.10.4|espree@10.4.0|eslint-visitor-keys@4.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|espree@10.4.0|eslint-visitor-keys@4.2.1"
+      "ref": "nachet-frontend@0.10.4|espree@10.4.0|eslint-visitor-keys@4.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|esprima@4.0.1"
+      "ref": "nachet-frontend@0.10.4|esprima@4.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|esquery@1.6.0",
+      "ref": "nachet-frontend@0.10.4|esquery@1.6.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|estraverse@5.3.0"
+        "nachet-frontend@0.10.4|estraverse@5.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|esrecurse@4.3.0",
+      "ref": "nachet-frontend@0.10.4|esrecurse@4.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|estraverse@5.3.0"
+        "nachet-frontend@0.10.4|estraverse@5.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|estraverse@5.3.0"
+      "ref": "nachet-frontend@0.10.4|estraverse@5.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|estree-walker@3.0.3",
+      "ref": "nachet-frontend@0.10.4|estree-walker@3.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/estree@1.0.8"
+        "nachet-frontend@0.10.4|@types/estree@1.0.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|esutils@2.0.3"
+      "ref": "nachet-frontend@0.10.4|esutils@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|etag@1.8.1"
+      "ref": "nachet-frontend@0.10.4|etag@1.8.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|execa@4.1.0",
+      "ref": "nachet-frontend@0.10.4|execa@4.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cross-spawn@7.0.6",
-        "nachet-frontend@0.10.3|get-stream@5.2.0",
-        "nachet-frontend@0.10.3|human-signals@1.1.1",
-        "nachet-frontend@0.10.3|is-stream@2.0.1",
-        "nachet-frontend@0.10.3|merge-stream@2.0.0",
-        "nachet-frontend@0.10.3|npm-run-path@4.0.1",
-        "nachet-frontend@0.10.3|onetime@5.1.2",
-        "nachet-frontend@0.10.3|signal-exit@3.0.7",
-        "nachet-frontend@0.10.3|strip-final-newline@2.0.0"
+        "nachet-frontend@0.10.4|cross-spawn@7.0.6",
+        "nachet-frontend@0.10.4|get-stream@5.2.0",
+        "nachet-frontend@0.10.4|human-signals@1.1.1",
+        "nachet-frontend@0.10.4|is-stream@2.0.1",
+        "nachet-frontend@0.10.4|merge-stream@2.0.0",
+        "nachet-frontend@0.10.4|npm-run-path@4.0.1",
+        "nachet-frontend@0.10.4|onetime@5.1.2",
+        "nachet-frontend@0.10.4|signal-exit@3.0.7",
+        "nachet-frontend@0.10.4|strip-final-newline@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|expand-template@2.0.3"
+      "ref": "nachet-frontend@0.10.4|expand-template@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|expect-type@1.2.2"
+      "ref": "nachet-frontend@0.10.4|expect-type@1.2.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|exponential-backoff@3.1.2"
+      "ref": "nachet-frontend@0.10.4|exponential-backoff@3.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|express@5.1.0",
+      "ref": "nachet-frontend@0.10.4|express@5.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|accepts@2.0.0",
-        "nachet-frontend@0.10.3|body-parser@2.2.0",
-        "nachet-frontend@0.10.3|content-disposition@1.0.0",
-        "nachet-frontend@0.10.3|content-type@1.0.5",
-        "nachet-frontend@0.10.3|cookie-signature@1.2.2",
-        "nachet-frontend@0.10.3|cookie@0.7.2",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|encodeurl@2.0.0",
-        "nachet-frontend@0.10.3|escape-html@1.0.3",
-        "nachet-frontend@0.10.3|etag@1.8.1",
-        "nachet-frontend@0.10.3|finalhandler@2.1.0",
-        "nachet-frontend@0.10.3|fresh@2.0.0",
-        "nachet-frontend@0.10.3|http-errors@2.0.0",
-        "nachet-frontend@0.10.3|merge-descriptors@2.0.0",
-        "nachet-frontend@0.10.3|mime-types@3.0.1",
-        "nachet-frontend@0.10.3|on-finished@2.4.1",
-        "nachet-frontend@0.10.3|once@1.4.0",
-        "nachet-frontend@0.10.3|parseurl@1.3.3",
-        "nachet-frontend@0.10.3|proxy-addr@2.0.7",
-        "nachet-frontend@0.10.3|qs@6.14.0",
-        "nachet-frontend@0.10.3|range-parser@1.2.1",
-        "nachet-frontend@0.10.3|router@2.2.0",
-        "nachet-frontend@0.10.3|send@1.2.0",
-        "nachet-frontend@0.10.3|serve-static@2.2.0",
-        "nachet-frontend@0.10.3|statuses@2.0.2",
-        "nachet-frontend@0.10.3|type-is@2.0.1",
-        "nachet-frontend@0.10.3|vary@1.1.2"
+        "nachet-frontend@0.10.4|accepts@2.0.0",
+        "nachet-frontend@0.10.4|body-parser@2.2.0",
+        "nachet-frontend@0.10.4|content-disposition@1.0.0",
+        "nachet-frontend@0.10.4|content-type@1.0.5",
+        "nachet-frontend@0.10.4|cookie-signature@1.2.2",
+        "nachet-frontend@0.10.4|cookie@0.7.2",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|encodeurl@2.0.0",
+        "nachet-frontend@0.10.4|escape-html@1.0.3",
+        "nachet-frontend@0.10.4|etag@1.8.1",
+        "nachet-frontend@0.10.4|finalhandler@2.1.0",
+        "nachet-frontend@0.10.4|fresh@2.0.0",
+        "nachet-frontend@0.10.4|http-errors@2.0.0",
+        "nachet-frontend@0.10.4|merge-descriptors@2.0.0",
+        "nachet-frontend@0.10.4|mime-types@3.0.1",
+        "nachet-frontend@0.10.4|on-finished@2.4.1",
+        "nachet-frontend@0.10.4|once@1.4.0",
+        "nachet-frontend@0.10.4|parseurl@1.3.3",
+        "nachet-frontend@0.10.4|proxy-addr@2.0.7",
+        "nachet-frontend@0.10.4|qs@6.14.0",
+        "nachet-frontend@0.10.4|range-parser@1.2.1",
+        "nachet-frontend@0.10.4|router@2.2.0",
+        "nachet-frontend@0.10.4|send@1.2.0",
+        "nachet-frontend@0.10.4|serve-static@2.2.0",
+        "nachet-frontend@0.10.4|statuses@2.0.2",
+        "nachet-frontend@0.10.4|type-is@2.0.1",
+        "nachet-frontend@0.10.4|vary@1.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|extend@3.0.2"
+      "ref": "nachet-frontend@0.10.4|extend@3.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-deep-equal@3.1.3"
+      "ref": "nachet-frontend@0.10.4|fast-deep-equal@3.1.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-diff@1.3.0"
+      "ref": "nachet-frontend@0.10.4|fast-diff@1.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-glob@3.3.3",
+      "ref": "nachet-frontend@0.10.4|fast-glob@3.3.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@nodelib/fs.stat@2.0.5",
-        "nachet-frontend@0.10.3|@nodelib/fs.walk@1.2.8",
-        "nachet-frontend@0.10.3|fast-glob@3.3.3|glob-parent@5.1.2",
-        "nachet-frontend@0.10.3|merge2@1.4.1",
-        "nachet-frontend@0.10.3|micromatch@4.0.8"
+        "nachet-frontend@0.10.4|@nodelib/fs.stat@2.0.5",
+        "nachet-frontend@0.10.4|@nodelib/fs.walk@1.2.8",
+        "nachet-frontend@0.10.4|fast-glob@3.3.3|glob-parent@5.1.2",
+        "nachet-frontend@0.10.4|merge2@1.4.1",
+        "nachet-frontend@0.10.4|micromatch@4.0.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-glob@3.3.3|glob-parent@5.1.2",
+      "ref": "nachet-frontend@0.10.4|fast-glob@3.3.3|glob-parent@5.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-glob@4.0.3"
+        "nachet-frontend@0.10.4|is-glob@4.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-json-stable-stringify@2.1.0"
+      "ref": "nachet-frontend@0.10.4|fast-json-stable-stringify@2.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-levenshtein@2.0.6"
+      "ref": "nachet-frontend@0.10.4|fast-levenshtein@2.0.6"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fast-uri@3.1.0"
+      "ref": "nachet-frontend@0.10.4|fast-uri@3.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fastq@1.19.1",
+      "ref": "nachet-frontend@0.10.4|fastq@1.19.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|reusify@1.1.0"
+        "nachet-frontend@0.10.4|reusify@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|fdir@6.5.0",
+      "ref": "nachet-frontend@0.10.4|fdir@6.5.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|picomatch@4.0.3"
+        "nachet-frontend@0.10.4|picomatch@4.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|fetch-blob@3.2.0",
+      "ref": "nachet-frontend@0.10.4|fetch-blob@3.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|node-domexception@1.0.0",
-        "nachet-frontend@0.10.3|web-streams-polyfill@3.3.3"
+        "nachet-frontend@0.10.4|node-domexception@1.0.0",
+        "nachet-frontend@0.10.4|web-streams-polyfill@3.3.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|file-entry-cache@8.0.0",
+      "ref": "nachet-frontend@0.10.4|file-entry-cache@8.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|flat-cache@4.0.1"
+        "nachet-frontend@0.10.4|flat-cache@4.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|file-saver@2.0.5"
+      "ref": "nachet-frontend@0.10.4|file-saver@2.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|file-uri-to-path@1.0.0"
+      "ref": "nachet-frontend@0.10.4|file-uri-to-path@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fill-range@7.1.1",
+      "ref": "nachet-frontend@0.10.4|fill-range@7.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|to-regex-range@5.0.1"
+        "nachet-frontend@0.10.4|to-regex-range@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|finalhandler@2.1.0",
+      "ref": "nachet-frontend@0.10.4|finalhandler@2.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|encodeurl@2.0.0",
-        "nachet-frontend@0.10.3|escape-html@1.0.3",
-        "nachet-frontend@0.10.3|on-finished@2.4.1",
-        "nachet-frontend@0.10.3|parseurl@1.3.3",
-        "nachet-frontend@0.10.3|statuses@2.0.2"
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|encodeurl@2.0.0",
+        "nachet-frontend@0.10.4|escape-html@1.0.3",
+        "nachet-frontend@0.10.4|on-finished@2.4.1",
+        "nachet-frontend@0.10.4|parseurl@1.3.3",
+        "nachet-frontend@0.10.4|statuses@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|find-root@1.1.0"
+      "ref": "nachet-frontend@0.10.4|find-root@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|find-up@5.0.0",
+      "ref": "nachet-frontend@0.10.4|find-up@5.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|locate-path@6.0.0",
-        "nachet-frontend@0.10.3|path-exists@4.0.0"
+        "nachet-frontend@0.10.4|locate-path@6.0.0",
+        "nachet-frontend@0.10.4|path-exists@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|flat-cache@4.0.1",
+      "ref": "nachet-frontend@0.10.4|flat-cache@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|flatted@3.3.3",
-        "nachet-frontend@0.10.3|keyv@4.5.4"
+        "nachet-frontend@0.10.4|flatted@3.3.3",
+        "nachet-frontend@0.10.4|keyv@4.5.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|flatted@3.3.3"
+      "ref": "nachet-frontend@0.10.4|flatted@3.3.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|follow-redirects@1.15.11"
+      "ref": "nachet-frontend@0.10.4|follow-redirects@1.15.11"
     },
     {
-      "ref": "nachet-frontend@0.10.3|for-each@0.3.5",
+      "ref": "nachet-frontend@0.10.4|for-each@0.3.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-callable@1.2.7"
+        "nachet-frontend@0.10.4|is-callable@1.2.7"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|foreground-child@3.3.1",
+      "ref": "nachet-frontend@0.10.4|foreground-child@3.3.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cross-spawn@7.0.6",
-        "nachet-frontend@0.10.3|foreground-child@3.3.1|signal-exit@4.1.0"
+        "nachet-frontend@0.10.4|cross-spawn@7.0.6",
+        "nachet-frontend@0.10.4|foreground-child@3.3.1|signal-exit@4.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|foreground-child@3.3.1|signal-exit@4.1.0"
+      "ref": "nachet-frontend@0.10.4|foreground-child@3.3.1|signal-exit@4.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|form-data@4.0.4",
+      "ref": "nachet-frontend@0.10.4|form-data@4.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|asynckit@0.4.0",
-        "nachet-frontend@0.10.3|combined-stream@1.0.8",
-        "nachet-frontend@0.10.3|es-set-tostringtag@2.1.0",
-        "nachet-frontend@0.10.3|form-data@4.0.4|mime-types@2.1.35",
-        "nachet-frontend@0.10.3|hasown@2.0.2"
+        "nachet-frontend@0.10.4|asynckit@0.4.0",
+        "nachet-frontend@0.10.4|combined-stream@1.0.8",
+        "nachet-frontend@0.10.4|es-set-tostringtag@2.1.0",
+        "nachet-frontend@0.10.4|form-data@4.0.4|mime-types@2.1.35",
+        "nachet-frontend@0.10.4|hasown@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|form-data@4.0.4|mime-db@1.52.0"
+      "ref": "nachet-frontend@0.10.4|form-data@4.0.4|mime-db@1.52.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|form-data@4.0.4|mime-types@2.1.35",
+      "ref": "nachet-frontend@0.10.4|form-data@4.0.4|mime-types@2.1.35",
       "dependsOn": [
-        "nachet-frontend@0.10.3|form-data@4.0.4|mime-db@1.52.0"
+        "nachet-frontend@0.10.4|form-data@4.0.4|mime-db@1.52.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|formdata-polyfill@4.0.10",
+      "ref": "nachet-frontend@0.10.4|formdata-polyfill@4.0.10",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fetch-blob@3.2.0"
+        "nachet-frontend@0.10.4|fetch-blob@3.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|forwarded@0.2.0"
+      "ref": "nachet-frontend@0.10.4|forwarded@0.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fresh@2.0.0"
+      "ref": "nachet-frontend@0.10.4|fresh@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fs-constants@1.0.0"
+      "ref": "nachet-frontend@0.10.4|fs-constants@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|fs-minipass@3.0.3",
+      "ref": "nachet-frontend@0.10.4|fs-minipass@3.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass@7.1.2"
+        "nachet-frontend@0.10.4|minipass@7.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|fsevents@2.3.2"
+      "ref": "nachet-frontend@0.10.4|fsevents@2.3.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|function-bind@1.1.2"
+      "ref": "nachet-frontend@0.10.4|function-bind@1.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|function.prototype.name@1.1.8",
+      "ref": "nachet-frontend@0.10.4|function.prototype.name@1.1.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|functions-have-names@1.2.3",
-        "nachet-frontend@0.10.3|hasown@2.0.2",
-        "nachet-frontend@0.10.3|is-callable@1.2.7"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|functions-have-names@1.2.3",
+        "nachet-frontend@0.10.4|hasown@2.0.2",
+        "nachet-frontend@0.10.4|is-callable@1.2.7"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|functions-have-names@1.2.3"
+      "ref": "nachet-frontend@0.10.4|functions-have-names@1.2.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|gensync@1.0.0-beta.2"
+      "ref": "nachet-frontend@0.10.4|gensync@1.0.0-beta.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|get-caller-file@2.0.5"
+      "ref": "nachet-frontend@0.10.4|get-caller-file@2.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
+      "ref": "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind-apply-helpers@1.0.2",
-        "nachet-frontend@0.10.3|es-define-property@1.0.1",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|function-bind@1.1.2",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|hasown@2.0.2",
-        "nachet-frontend@0.10.3|math-intrinsics@1.1.0"
+        "nachet-frontend@0.10.4|call-bind-apply-helpers@1.0.2",
+        "nachet-frontend@0.10.4|es-define-property@1.0.1",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|function-bind@1.1.2",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|hasown@2.0.2",
+        "nachet-frontend@0.10.4|math-intrinsics@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|get-proto@1.0.1",
+      "ref": "nachet-frontend@0.10.4|get-proto@1.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|dunder-proto@1.0.1",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|dunder-proto@1.0.1",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|get-stream@5.2.0",
+      "ref": "nachet-frontend@0.10.4|get-stream@5.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|pump@3.0.3"
+        "nachet-frontend@0.10.4|pump@3.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|get-symbol-description@1.1.0",
+      "ref": "nachet-frontend@0.10.4|get-symbol-description@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|git-commit-info@2.0.2",
+      "ref": "nachet-frontend@0.10.4|git-commit-info@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|execa@4.1.0",
-        "nachet-frontend@0.10.3|is-git-repository@1.1.1",
-        "nachet-frontend@0.10.3|path-is-absolute@1.0.1"
+        "nachet-frontend@0.10.4|execa@4.1.0",
+        "nachet-frontend@0.10.4|is-git-repository@1.1.1",
+        "nachet-frontend@0.10.4|path-is-absolute@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|git-describe@4.1.1",
+      "ref": "nachet-frontend@0.10.4|git-describe@4.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/semver@7.7.1",
-        "nachet-frontend@0.10.3|git-describe@4.1.1|semver@5.7.2",
-        "nachet-frontend@0.10.3|lodash@4.17.21"
+        "nachet-frontend@0.10.4|@types/semver@7.7.1",
+        "nachet-frontend@0.10.4|git-describe@4.1.1|semver@5.7.2",
+        "nachet-frontend@0.10.4|lodash@4.17.21"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|git-describe@4.1.1|semver@5.7.2"
+      "ref": "nachet-frontend@0.10.4|git-describe@4.1.1|semver@5.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|github-from-package@0.0.0"
+      "ref": "nachet-frontend@0.10.4|github-from-package@0.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|glob-parent@6.0.2",
+      "ref": "nachet-frontend@0.10.4|glob-parent@6.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-glob@4.0.3"
+        "nachet-frontend@0.10.4|is-glob@4.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|glob@10.4.5",
+      "ref": "nachet-frontend@0.10.4|glob@10.4.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|foreground-child@3.3.1",
-        "nachet-frontend@0.10.3|glob@10.4.5|minimatch@9.0.5",
-        "nachet-frontend@0.10.3|jackspeak@3.4.3",
-        "nachet-frontend@0.10.3|minipass@7.1.2",
-        "nachet-frontend@0.10.3|package-json-from-dist@1.0.1",
-        "nachet-frontend@0.10.3|path-scurry@1.11.1"
+        "nachet-frontend@0.10.4|foreground-child@3.3.1",
+        "nachet-frontend@0.10.4|glob@10.4.5|minimatch@9.0.5",
+        "nachet-frontend@0.10.4|jackspeak@3.4.3",
+        "nachet-frontend@0.10.4|minipass@7.1.2",
+        "nachet-frontend@0.10.4|package-json-from-dist@1.0.1",
+        "nachet-frontend@0.10.4|path-scurry@1.11.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|glob@10.4.5|brace-expansion@2.0.2",
+      "ref": "nachet-frontend@0.10.4|glob@10.4.5|brace-expansion@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|balanced-match@1.0.2"
+        "nachet-frontend@0.10.4|balanced-match@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|glob@10.4.5|minimatch@9.0.5",
+      "ref": "nachet-frontend@0.10.4|glob@10.4.5|minimatch@9.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|glob@10.4.5|brace-expansion@2.0.2"
+        "nachet-frontend@0.10.4|glob@10.4.5|brace-expansion@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|globals@16.4.0"
+      "ref": "nachet-frontend@0.10.4|globals@16.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|globalthis@1.0.4",
+      "ref": "nachet-frontend@0.10.4|globalthis@1.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|gopd@1.2.0"
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|gopd@1.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|gopd@1.2.0"
+      "ref": "nachet-frontend@0.10.4|gopd@1.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|graceful-fs@4.2.11"
+      "ref": "nachet-frontend@0.10.4|graceful-fs@4.2.11"
     },
     {
-      "ref": "nachet-frontend@0.10.3|graphemer@1.4.0"
+      "ref": "nachet-frontend@0.10.4|graphemer@1.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|harmony-reflect@1.6.2"
+      "ref": "nachet-frontend@0.10.4|harmony-reflect@1.6.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|has-bigints@1.1.0"
+      "ref": "nachet-frontend@0.10.4|has-bigints@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|has-flag@4.0.0"
+      "ref": "nachet-frontend@0.10.4|has-flag@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|has-property-descriptors@1.0.2",
+      "ref": "nachet-frontend@0.10.4|has-property-descriptors@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-define-property@1.0.1"
+        "nachet-frontend@0.10.4|es-define-property@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|has-proto@1.2.0",
+      "ref": "nachet-frontend@0.10.4|has-proto@1.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|dunder-proto@1.0.1"
+        "nachet-frontend@0.10.4|dunder-proto@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|has-symbols@1.1.0"
+      "ref": "nachet-frontend@0.10.4|has-symbols@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
+      "ref": "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|has-symbols@1.1.0"
+        "nachet-frontend@0.10.4|has-symbols@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|hasown@2.0.2",
+      "ref": "nachet-frontend@0.10.4|hasown@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|function-bind@1.1.2"
+        "nachet-frontend@0.10.4|function-bind@1.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|hoist-non-react-statics@3.3.2",
+      "ref": "nachet-frontend@0.10.4|hoist-non-react-statics@3.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|hoist-non-react-statics@3.3.2|react-is@16.13.1"
+        "nachet-frontend@0.10.4|hoist-non-react-statics@3.3.2|react-is@16.13.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|hoist-non-react-statics@3.3.2|react-is@16.13.1"
+      "ref": "nachet-frontend@0.10.4|hoist-non-react-statics@3.3.2|react-is@16.13.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|hosted-git-info@9.0.0",
+      "ref": "nachet-frontend@0.10.4|hosted-git-info@9.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|hosted-git-info@9.0.0|lru-cache@11.2.1"
+        "nachet-frontend@0.10.4|hosted-git-info@9.0.0|lru-cache@11.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|hosted-git-info@9.0.0|lru-cache@11.2.1"
+      "ref": "nachet-frontend@0.10.4|hosted-git-info@9.0.0|lru-cache@11.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|html-encoding-sniffer@4.0.0",
+      "ref": "nachet-frontend@0.10.4|html-encoding-sniffer@4.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|whatwg-encoding@3.1.1"
+        "nachet-frontend@0.10.4|whatwg-encoding@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|html-escaper@2.0.2"
+      "ref": "nachet-frontend@0.10.4|html-escaper@2.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|htmlparser2@8.0.2",
+      "ref": "nachet-frontend@0.10.4|htmlparser2@8.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|domelementtype@2.3.0",
-        "nachet-frontend@0.10.3|domhandler@5.0.3",
-        "nachet-frontend@0.10.3|domutils@3.2.2",
-        "nachet-frontend@0.10.3|entities@4.5.0"
+        "nachet-frontend@0.10.4|domelementtype@2.3.0",
+        "nachet-frontend@0.10.4|domhandler@5.0.3",
+        "nachet-frontend@0.10.4|domutils@3.2.2",
+        "nachet-frontend@0.10.4|entities@4.5.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|http-cache-semantics@4.2.0"
+      "ref": "nachet-frontend@0.10.4|http-cache-semantics@4.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|http-errors@2.0.0",
+      "ref": "nachet-frontend@0.10.4|http-errors@2.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|depd@2.0.0",
-        "nachet-frontend@0.10.3|http-errors@2.0.0|statuses@2.0.1",
-        "nachet-frontend@0.10.3|inherits@2.0.4",
-        "nachet-frontend@0.10.3|setprototypeof@1.2.0",
-        "nachet-frontend@0.10.3|toidentifier@1.0.1"
+        "nachet-frontend@0.10.4|depd@2.0.0",
+        "nachet-frontend@0.10.4|http-errors@2.0.0|statuses@2.0.1",
+        "nachet-frontend@0.10.4|inherits@2.0.4",
+        "nachet-frontend@0.10.4|setprototypeof@1.2.0",
+        "nachet-frontend@0.10.4|toidentifier@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|http-errors@2.0.0|statuses@2.0.1"
+      "ref": "nachet-frontend@0.10.4|http-errors@2.0.0|statuses@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|http-proxy-agent@7.0.2",
+      "ref": "nachet-frontend@0.10.4|http-proxy-agent@7.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|agent-base@7.1.4",
-        "nachet-frontend@0.10.3|debug@4.4.3"
+        "nachet-frontend@0.10.4|agent-base@7.1.4",
+        "nachet-frontend@0.10.4|debug@4.4.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|https-proxy-agent@7.0.6",
+      "ref": "nachet-frontend@0.10.4|https-proxy-agent@7.0.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|agent-base@7.1.4",
-        "nachet-frontend@0.10.3|debug@4.4.3"
+        "nachet-frontend@0.10.4|agent-base@7.1.4",
+        "nachet-frontend@0.10.4|debug@4.4.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|human-signals@1.1.1"
+      "ref": "nachet-frontend@0.10.4|human-signals@1.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|iconv-lite@0.6.3",
+      "ref": "nachet-frontend@0.10.4|iconv-lite@0.6.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|safer-buffer@2.1.2"
+        "nachet-frontend@0.10.4|safer-buffer@2.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|identity-obj-proxy@3.0.0",
+      "ref": "nachet-frontend@0.10.4|identity-obj-proxy@3.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|harmony-reflect@1.6.2"
+        "nachet-frontend@0.10.4|harmony-reflect@1.6.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ieee754@1.2.1"
+      "ref": "nachet-frontend@0.10.4|ieee754@1.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ignore@5.3.2"
+      "ref": "nachet-frontend@0.10.4|ignore@5.3.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|immediate@3.0.6"
+      "ref": "nachet-frontend@0.10.4|immediate@3.0.6"
     },
     {
-      "ref": "nachet-frontend@0.10.3|import-fresh@3.3.1",
+      "ref": "nachet-frontend@0.10.4|import-fresh@3.3.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|parent-module@1.0.1",
-        "nachet-frontend@0.10.3|resolve-from@4.0.0"
+        "nachet-frontend@0.10.4|parent-module@1.0.1",
+        "nachet-frontend@0.10.4|resolve-from@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|imurmurhash@0.1.4"
+      "ref": "nachet-frontend@0.10.4|imurmurhash@0.1.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|indent-string@4.0.0"
+      "ref": "nachet-frontend@0.10.4|indent-string@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|inherits@2.0.4"
+      "ref": "nachet-frontend@0.10.4|inherits@2.0.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ini@1.3.8"
+      "ref": "nachet-frontend@0.10.4|ini@1.3.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|internal-slot@1.1.0",
+      "ref": "nachet-frontend@0.10.4|internal-slot@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|hasown@2.0.2",
-        "nachet-frontend@0.10.3|side-channel@1.1.0"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|hasown@2.0.2",
+        "nachet-frontend@0.10.4|side-channel@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ip-address@10.0.1"
+      "ref": "nachet-frontend@0.10.4|ip-address@10.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ipaddr.js@1.9.1"
+      "ref": "nachet-frontend@0.10.4|ipaddr.js@1.9.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-array-buffer@3.0.5",
+      "ref": "nachet-frontend@0.10.4|is-array-buffer@3.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-arrayish@0.2.1"
+      "ref": "nachet-frontend@0.10.4|is-arrayish@0.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-async-function@2.1.1",
+      "ref": "nachet-frontend@0.10.4|is-async-function@2.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|async-function@1.0.0",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
-        "nachet-frontend@0.10.3|safe-regex-test@1.1.0"
+        "nachet-frontend@0.10.4|async-function@1.0.0",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
+        "nachet-frontend@0.10.4|safe-regex-test@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-bigint@1.1.0",
+      "ref": "nachet-frontend@0.10.4|is-bigint@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|has-bigints@1.1.0"
+        "nachet-frontend@0.10.4|has-bigints@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-boolean-object@1.2.2",
+      "ref": "nachet-frontend@0.10.4|is-boolean-object@1.2.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-callable@1.2.7"
+      "ref": "nachet-frontend@0.10.4|is-callable@1.2.7"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-core-module@2.16.1",
+      "ref": "nachet-frontend@0.10.4|is-core-module@2.16.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|hasown@2.0.2"
+        "nachet-frontend@0.10.4|hasown@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-data-view@1.0.2",
+      "ref": "nachet-frontend@0.10.4|is-data-view@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|is-typed-array@1.1.15"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|is-typed-array@1.1.15"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-date-object@1.1.0",
+      "ref": "nachet-frontend@0.10.4|is-date-object@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-docker@2.2.1"
+      "ref": "nachet-frontend@0.10.4|is-docker@2.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-extglob@2.1.1"
+      "ref": "nachet-frontend@0.10.4|is-extglob@2.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-finalizationregistry@1.1.1",
+      "ref": "nachet-frontend@0.10.4|is-finalizationregistry@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4"
+        "nachet-frontend@0.10.4|call-bound@1.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0"
+      "ref": "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-generator-function@1.1.0",
+      "ref": "nachet-frontend@0.10.4|is-generator-function@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
-        "nachet-frontend@0.10.3|safe-regex-test@1.1.0"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
+        "nachet-frontend@0.10.4|safe-regex-test@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1",
+      "ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-git-repository@1.1.1|execa@0.6.3",
-        "nachet-frontend@0.10.3|path-is-absolute@1.0.1"
+        "nachet-frontend@0.10.4|is-git-repository@1.1.1|execa@0.6.3",
+        "nachet-frontend@0.10.4|path-is-absolute@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|execa@0.6.3",
+      "ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|execa@0.6.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cross-spawn@7.0.6",
-        "nachet-frontend@0.10.3|is-git-repository@1.1.1|get-stream@3.0.0",
-        "nachet-frontend@0.10.3|is-git-repository@1.1.1|is-stream@1.1.0",
-        "nachet-frontend@0.10.3|is-git-repository@1.1.1|npm-run-path@2.0.2",
-        "nachet-frontend@0.10.3|p-finally@1.0.0",
-        "nachet-frontend@0.10.3|signal-exit@3.0.7",
-        "nachet-frontend@0.10.3|strip-eof@1.0.0"
+        "nachet-frontend@0.10.4|cross-spawn@7.0.6",
+        "nachet-frontend@0.10.4|is-git-repository@1.1.1|get-stream@3.0.0",
+        "nachet-frontend@0.10.4|is-git-repository@1.1.1|is-stream@1.1.0",
+        "nachet-frontend@0.10.4|is-git-repository@1.1.1|npm-run-path@2.0.2",
+        "nachet-frontend@0.10.4|p-finally@1.0.0",
+        "nachet-frontend@0.10.4|signal-exit@3.0.7",
+        "nachet-frontend@0.10.4|strip-eof@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|get-stream@3.0.0"
+      "ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|get-stream@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|is-stream@1.1.0"
+      "ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|is-stream@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|npm-run-path@2.0.2",
+      "ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|npm-run-path@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-git-repository@1.1.1|path-key@2.0.1"
+        "nachet-frontend@0.10.4|is-git-repository@1.1.1|path-key@2.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-git-repository@1.1.1|path-key@2.0.1"
+      "ref": "nachet-frontend@0.10.4|is-git-repository@1.1.1|path-key@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-glob@4.0.3",
+      "ref": "nachet-frontend@0.10.4|is-glob@4.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-extglob@2.1.1"
+        "nachet-frontend@0.10.4|is-extglob@2.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-map@2.0.3"
+      "ref": "nachet-frontend@0.10.4|is-map@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-negative-zero@2.0.3"
+      "ref": "nachet-frontend@0.10.4|is-negative-zero@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-number-object@1.1.1",
+      "ref": "nachet-frontend@0.10.4|is-number-object@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-number@7.0.0"
+      "ref": "nachet-frontend@0.10.4|is-number@7.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-plain-object@5.0.0"
+      "ref": "nachet-frontend@0.10.4|is-plain-object@5.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-port-reachable@4.0.0"
+      "ref": "nachet-frontend@0.10.4|is-port-reachable@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-potential-custom-element-name@1.0.1"
+      "ref": "nachet-frontend@0.10.4|is-potential-custom-element-name@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-promise@4.0.0"
+      "ref": "nachet-frontend@0.10.4|is-promise@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-regex@1.2.1",
+      "ref": "nachet-frontend@0.10.4|is-regex@1.2.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
-        "nachet-frontend@0.10.3|hasown@2.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
+        "nachet-frontend@0.10.4|hasown@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-set@2.0.3"
+      "ref": "nachet-frontend@0.10.4|is-set@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-shared-array-buffer@1.0.4",
+      "ref": "nachet-frontend@0.10.4|is-shared-array-buffer@1.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4"
+        "nachet-frontend@0.10.4|call-bound@1.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-stream@2.0.1"
+      "ref": "nachet-frontend@0.10.4|is-stream@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-string@1.1.1",
+      "ref": "nachet-frontend@0.10.4|is-string@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-symbol@1.1.1",
+      "ref": "nachet-frontend@0.10.4|is-symbol@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|safe-regex-test@1.1.0"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|safe-regex-test@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-typed-array@1.1.15",
+      "ref": "nachet-frontend@0.10.4|is-typed-array@1.1.15",
       "dependsOn": [
-        "nachet-frontend@0.10.3|which-typed-array@1.1.19"
+        "nachet-frontend@0.10.4|which-typed-array@1.1.19"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-weakmap@2.0.2"
+      "ref": "nachet-frontend@0.10.4|is-weakmap@2.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-weakref@1.1.1",
+      "ref": "nachet-frontend@0.10.4|is-weakref@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4"
+        "nachet-frontend@0.10.4|call-bound@1.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-weakset@2.0.4",
+      "ref": "nachet-frontend@0.10.4|is-weakset@2.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|is-wsl@2.2.0",
+      "ref": "nachet-frontend@0.10.4|is-wsl@2.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-docker@2.2.1"
+        "nachet-frontend@0.10.4|is-docker@2.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|isarray@1.0.0"
+      "ref": "nachet-frontend@0.10.4|isarray@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|isexe@2.0.0"
+      "ref": "nachet-frontend@0.10.4|isexe@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|istanbul-lib-coverage@3.2.2"
+      "ref": "nachet-frontend@0.10.4|istanbul-lib-coverage@3.2.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|istanbul-lib-report@3.0.1",
+      "ref": "nachet-frontend@0.10.4|istanbul-lib-report@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|istanbul-lib-coverage@3.2.2",
-        "nachet-frontend@0.10.3|make-dir@4.0.0",
-        "nachet-frontend@0.10.3|supports-color@7.2.0"
+        "nachet-frontend@0.10.4|istanbul-lib-coverage@3.2.2",
+        "nachet-frontend@0.10.4|make-dir@4.0.0",
+        "nachet-frontend@0.10.4|supports-color@7.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|istanbul-lib-source-maps@5.0.6",
+      "ref": "nachet-frontend@0.10.4|istanbul-lib-source-maps@5.0.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/trace-mapping@0.3.31",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|istanbul-lib-coverage@3.2.2"
+        "nachet-frontend@0.10.4|@jridgewell/trace-mapping@0.3.31",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|istanbul-lib-coverage@3.2.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|istanbul-reports@3.2.0",
+      "ref": "nachet-frontend@0.10.4|istanbul-reports@3.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|html-escaper@2.0.2",
-        "nachet-frontend@0.10.3|istanbul-lib-report@3.0.1"
+        "nachet-frontend@0.10.4|html-escaper@2.0.2",
+        "nachet-frontend@0.10.4|istanbul-lib-report@3.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|iterator.prototype@1.1.5",
+      "ref": "nachet-frontend@0.10.4|iterator.prototype@1.1.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|define-data-property@1.1.4",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|set-function-name@2.0.2"
+        "nachet-frontend@0.10.4|define-data-property@1.1.4",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|set-function-name@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jackspeak@3.4.3",
+      "ref": "nachet-frontend@0.10.4|jackspeak@3.4.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@isaacs/cliui@8.0.2",
-        "nachet-frontend@0.10.3|@pkgjs/parseargs@0.11.0"
+        "nachet-frontend@0.10.4|@isaacs/cliui@8.0.2",
+        "nachet-frontend@0.10.4|@pkgjs/parseargs@0.11.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-environment-jsdom@30.1.2",
+      "ref": "nachet-frontend@0.10.4|jest-environment-jsdom@30.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/environment-jsdom-abstract@30.1.2",
-        "nachet-frontend@0.10.3|@jest/environment@30.1.2",
-        "nachet-frontend@0.10.3|@types/jsdom@21.1.7",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|jsdom@26.1.0"
+        "nachet-frontend@0.10.4|@jest/environment-jsdom-abstract@30.1.2",
+        "nachet-frontend@0.10.4|@jest/environment@30.1.2",
+        "nachet-frontend@0.10.4|@types/jsdom@21.1.7",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|jsdom@26.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0",
+      "ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
-        "nachet-frontend@0.10.3|@jest/types@30.0.5",
-        "nachet-frontend@0.10.3|@types/stack-utils@2.0.3",
-        "nachet-frontend@0.10.3|chalk@4.1.2",
-        "nachet-frontend@0.10.3|graceful-fs@4.2.11",
-        "nachet-frontend@0.10.3|jest-message-util@30.1.0|pretty-format@30.0.5",
-        "nachet-frontend@0.10.3|micromatch@4.0.8",
-        "nachet-frontend@0.10.3|slash@3.0.0",
-        "nachet-frontend@0.10.3|stack-utils@2.0.6"
+        "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
+        "nachet-frontend@0.10.4|@jest/types@30.0.5",
+        "nachet-frontend@0.10.4|@types/stack-utils@2.0.3",
+        "nachet-frontend@0.10.4|chalk@4.1.2",
+        "nachet-frontend@0.10.4|graceful-fs@4.2.11",
+        "nachet-frontend@0.10.4|jest-message-util@30.1.0|pretty-format@30.0.5",
+        "nachet-frontend@0.10.4|micromatch@4.0.8",
+        "nachet-frontend@0.10.4|slash@3.0.0",
+        "nachet-frontend@0.10.4|stack-utils@2.0.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0|ansi-styles@5.2.0"
+      "ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0|ansi-styles@5.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0|pretty-format@30.0.5",
+      "ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0|pretty-format@30.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/schemas@30.0.5",
-        "nachet-frontend@0.10.3|jest-message-util@30.1.0|ansi-styles@5.2.0",
-        "nachet-frontend@0.10.3|jest-message-util@30.1.0|react-is@18.3.1"
+        "nachet-frontend@0.10.4|@jest/schemas@30.0.5",
+        "nachet-frontend@0.10.4|jest-message-util@30.1.0|ansi-styles@5.2.0",
+        "nachet-frontend@0.10.4|jest-message-util@30.1.0|react-is@18.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-message-util@30.1.0|react-is@18.3.1"
+      "ref": "nachet-frontend@0.10.4|jest-message-util@30.1.0|react-is@18.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-mock@30.0.5",
+      "ref": "nachet-frontend@0.10.4|jest-mock@30.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/types@30.0.5",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|jest-util@30.0.5"
+        "nachet-frontend@0.10.4|@jest/types@30.0.5",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|jest-util@30.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-regex-util@30.0.1"
+      "ref": "nachet-frontend@0.10.4|jest-regex-util@30.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|jest-util@30.0.5",
+      "ref": "nachet-frontend@0.10.4|jest-util@30.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jest/types@30.0.5",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|chalk@4.1.2",
-        "nachet-frontend@0.10.3|ci-info@4.3.0",
-        "nachet-frontend@0.10.3|graceful-fs@4.2.11",
-        "nachet-frontend@0.10.3|picomatch@4.0.3"
+        "nachet-frontend@0.10.4|@jest/types@30.0.5",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|chalk@4.1.2",
+        "nachet-frontend@0.10.4|ci-info@4.3.0",
+        "nachet-frontend@0.10.4|graceful-fs@4.2.11",
+        "nachet-frontend@0.10.4|picomatch@4.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|js-base64@3.7.8"
+      "ref": "nachet-frontend@0.10.4|js-base64@3.7.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|js-cookie@3.0.5"
+      "ref": "nachet-frontend@0.10.4|js-cookie@3.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|js-tokens@4.0.0"
+      "ref": "nachet-frontend@0.10.4|js-tokens@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|js-yaml@4.1.0",
+      "ref": "nachet-frontend@0.10.4|js-yaml@4.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|argparse@2.0.1"
+        "nachet-frontend@0.10.4|argparse@2.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jsdom@26.1.0",
+      "ref": "nachet-frontend@0.10.4|jsdom@26.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cssstyle@4.6.0",
-        "nachet-frontend@0.10.3|data-urls@5.0.0",
-        "nachet-frontend@0.10.3|decimal.js@10.6.0",
-        "nachet-frontend@0.10.3|html-encoding-sniffer@4.0.0",
-        "nachet-frontend@0.10.3|http-proxy-agent@7.0.2",
-        "nachet-frontend@0.10.3|https-proxy-agent@7.0.6",
-        "nachet-frontend@0.10.3|is-potential-custom-element-name@1.0.1",
-        "nachet-frontend@0.10.3|nwsapi@2.2.22",
-        "nachet-frontend@0.10.3|parse5@7.3.0",
-        "nachet-frontend@0.10.3|rrweb-cssom@0.8.0",
-        "nachet-frontend@0.10.3|saxes@6.0.0",
-        "nachet-frontend@0.10.3|symbol-tree@3.2.4",
-        "nachet-frontend@0.10.3|tough-cookie@5.1.2",
-        "nachet-frontend@0.10.3|w3c-xmlserializer@5.0.0",
-        "nachet-frontend@0.10.3|webidl-conversions@7.0.0",
-        "nachet-frontend@0.10.3|whatwg-encoding@3.1.1",
-        "nachet-frontend@0.10.3|whatwg-mimetype@4.0.0",
-        "nachet-frontend@0.10.3|whatwg-url@14.2.0",
-        "nachet-frontend@0.10.3|ws@8.18.3",
-        "nachet-frontend@0.10.3|xml-name-validator@5.0.0"
+        "nachet-frontend@0.10.4|cssstyle@4.6.0",
+        "nachet-frontend@0.10.4|data-urls@5.0.0",
+        "nachet-frontend@0.10.4|decimal.js@10.6.0",
+        "nachet-frontend@0.10.4|html-encoding-sniffer@4.0.0",
+        "nachet-frontend@0.10.4|http-proxy-agent@7.0.2",
+        "nachet-frontend@0.10.4|https-proxy-agent@7.0.6",
+        "nachet-frontend@0.10.4|is-potential-custom-element-name@1.0.1",
+        "nachet-frontend@0.10.4|nwsapi@2.2.22",
+        "nachet-frontend@0.10.4|parse5@7.3.0",
+        "nachet-frontend@0.10.4|rrweb-cssom@0.8.0",
+        "nachet-frontend@0.10.4|saxes@6.0.0",
+        "nachet-frontend@0.10.4|symbol-tree@3.2.4",
+        "nachet-frontend@0.10.4|tough-cookie@5.1.2",
+        "nachet-frontend@0.10.4|w3c-xmlserializer@5.0.0",
+        "nachet-frontend@0.10.4|webidl-conversions@7.0.0",
+        "nachet-frontend@0.10.4|whatwg-encoding@3.1.1",
+        "nachet-frontend@0.10.4|whatwg-mimetype@4.0.0",
+        "nachet-frontend@0.10.4|whatwg-url@14.2.0",
+        "nachet-frontend@0.10.4|ws@8.18.3",
+        "nachet-frontend@0.10.4|xml-name-validator@5.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jsesc@3.1.0"
+      "ref": "nachet-frontend@0.10.4|jsesc@3.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|json-buffer@3.0.1"
+      "ref": "nachet-frontend@0.10.4|json-buffer@3.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|json-parse-even-better-errors@2.3.1"
+      "ref": "nachet-frontend@0.10.4|json-parse-even-better-errors@2.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|json-schema-traverse@1.0.0"
+      "ref": "nachet-frontend@0.10.4|json-schema-traverse@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|json-stable-stringify-without-jsonify@1.0.1"
+      "ref": "nachet-frontend@0.10.4|json-stable-stringify-without-jsonify@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|json5@2.2.3"
+      "ref": "nachet-frontend@0.10.4|json5@2.2.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|jsx-ast-utils@3.3.5",
+      "ref": "nachet-frontend@0.10.4|jsx-ast-utils@3.3.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|array-includes@3.1.9",
-        "nachet-frontend@0.10.3|array.prototype.flat@1.3.3",
-        "nachet-frontend@0.10.3|object.assign@4.1.7",
-        "nachet-frontend@0.10.3|object.values@1.2.1"
+        "nachet-frontend@0.10.4|array-includes@3.1.9",
+        "nachet-frontend@0.10.4|array.prototype.flat@1.3.3",
+        "nachet-frontend@0.10.4|object.assign@4.1.7",
+        "nachet-frontend@0.10.4|object.values@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jszip@3.10.1",
+      "ref": "nachet-frontend@0.10.4|jszip@3.10.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|jszip@3.10.1|pako@1.0.11",
-        "nachet-frontend@0.10.3|lie@3.3.0",
-        "nachet-frontend@0.10.3|readable-stream@2.3.8",
-        "nachet-frontend@0.10.3|setimmediate@1.0.5"
+        "nachet-frontend@0.10.4|jszip@3.10.1|pako@1.0.11",
+        "nachet-frontend@0.10.4|lie@3.3.0",
+        "nachet-frontend@0.10.4|readable-stream@2.3.8",
+        "nachet-frontend@0.10.4|setimmediate@1.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|jszip@3.10.1|pako@1.0.11"
+      "ref": "nachet-frontend@0.10.4|jszip@3.10.1|pako@1.0.11"
     },
     {
-      "ref": "nachet-frontend@0.10.3|jwt-decode@4.0.0"
+      "ref": "nachet-frontend@0.10.4|jwt-decode@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|keyv@4.5.4",
+      "ref": "nachet-frontend@0.10.4|keyv@4.5.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|json-buffer@3.0.1"
+        "nachet-frontend@0.10.4|json-buffer@3.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|levn@0.4.1",
+      "ref": "nachet-frontend@0.10.4|levn@0.4.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|prelude-ls@1.2.1",
-        "nachet-frontend@0.10.3|type-check@0.4.0"
+        "nachet-frontend@0.10.4|prelude-ls@1.2.1",
+        "nachet-frontend@0.10.4|type-check@0.4.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|libxmljs2@0.37.0",
+      "ref": "nachet-frontend@0.10.4|libxmljs2@0.37.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|bindings@1.5.0",
-        "nachet-frontend@0.10.3|nan@2.22.2",
-        "nachet-frontend@0.10.3|node-gyp@11.4.2",
-        "nachet-frontend@0.10.3|prebuild-install@7.1.3"
+        "nachet-frontend@0.10.4|bindings@1.5.0",
+        "nachet-frontend@0.10.4|nan@2.22.2",
+        "nachet-frontend@0.10.4|node-gyp@11.4.2",
+        "nachet-frontend@0.10.4|prebuild-install@7.1.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|lie@3.3.0",
+      "ref": "nachet-frontend@0.10.4|lie@3.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|immediate@3.0.6"
+        "nachet-frontend@0.10.4|immediate@3.0.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|lines-and-columns@1.2.4"
+      "ref": "nachet-frontend@0.10.4|lines-and-columns@1.2.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|locate-path@6.0.0",
+      "ref": "nachet-frontend@0.10.4|locate-path@6.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|p-locate@5.0.0"
+        "nachet-frontend@0.10.4|p-locate@5.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|lodash.debounce@4.0.8"
+      "ref": "nachet-frontend@0.10.4|lodash.debounce@4.0.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|lodash.merge@4.6.2"
+      "ref": "nachet-frontend@0.10.4|lodash.merge@4.6.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|lodash@4.17.21"
+      "ref": "nachet-frontend@0.10.4|lodash@4.17.21"
     },
     {
-      "ref": "nachet-frontend@0.10.3|loose-envify@1.4.0",
+      "ref": "nachet-frontend@0.10.4|loose-envify@1.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|js-tokens@4.0.0"
+        "nachet-frontend@0.10.4|js-tokens@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|loupe@3.2.1"
+      "ref": "nachet-frontend@0.10.4|loupe@3.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|lru-cache@5.1.1",
+      "ref": "nachet-frontend@0.10.4|lru-cache@5.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|yallist@3.1.1"
+        "nachet-frontend@0.10.4|yallist@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|lz-string@1.5.0"
+      "ref": "nachet-frontend@0.10.4|lz-string@1.5.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|magic-string@0.30.19",
+      "ref": "nachet-frontend@0.10.4|magic-string@0.30.19",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@jridgewell/sourcemap-codec@1.5.5"
+        "nachet-frontend@0.10.4|@jridgewell/sourcemap-codec@1.5.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|magicast@0.3.5",
+      "ref": "nachet-frontend@0.10.4|magicast@0.3.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/parser@7.28.4",
-        "nachet-frontend@0.10.3|@babel/types@7.28.4",
-        "nachet-frontend@0.10.3|source-map-js@1.2.1"
+        "nachet-frontend@0.10.4|@babel/parser@7.28.4",
+        "nachet-frontend@0.10.4|@babel/types@7.28.4",
+        "nachet-frontend@0.10.4|source-map-js@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|make-dir@4.0.0",
+      "ref": "nachet-frontend@0.10.4|make-dir@4.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|make-dir@4.0.0|semver@7.7.2"
+        "nachet-frontend@0.10.4|make-dir@4.0.0|semver@7.7.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|make-dir@4.0.0|semver@7.7.2"
+      "ref": "nachet-frontend@0.10.4|make-dir@4.0.0|semver@7.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|make-fetch-happen@14.0.3",
+      "ref": "nachet-frontend@0.10.4|make-fetch-happen@14.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@npmcli/agent@3.0.0",
-        "nachet-frontend@0.10.3|cacache@19.0.1",
-        "nachet-frontend@0.10.3|http-cache-semantics@4.2.0",
-        "nachet-frontend@0.10.3|minipass-fetch@4.0.1",
-        "nachet-frontend@0.10.3|minipass-flush@1.0.5",
-        "nachet-frontend@0.10.3|minipass-pipeline@1.2.4",
-        "nachet-frontend@0.10.3|minipass@7.1.2",
-        "nachet-frontend@0.10.3|negotiator@1.0.0",
-        "nachet-frontend@0.10.3|proc-log@5.0.0",
-        "nachet-frontend@0.10.3|promise-retry@2.0.1",
-        "nachet-frontend@0.10.3|ssri@12.0.0"
+        "nachet-frontend@0.10.4|@npmcli/agent@3.0.0",
+        "nachet-frontend@0.10.4|cacache@19.0.1",
+        "nachet-frontend@0.10.4|http-cache-semantics@4.2.0",
+        "nachet-frontend@0.10.4|minipass-fetch@4.0.1",
+        "nachet-frontend@0.10.4|minipass-flush@1.0.5",
+        "nachet-frontend@0.10.4|minipass-pipeline@1.2.4",
+        "nachet-frontend@0.10.4|minipass@7.1.2",
+        "nachet-frontend@0.10.4|negotiator@1.0.0",
+        "nachet-frontend@0.10.4|proc-log@5.0.0",
+        "nachet-frontend@0.10.4|promise-retry@2.0.1",
+        "nachet-frontend@0.10.4|ssri@12.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|math-intrinsics@1.1.0"
+      "ref": "nachet-frontend@0.10.4|math-intrinsics@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|media-typer@1.1.0"
+      "ref": "nachet-frontend@0.10.4|media-typer@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|merge-descriptors@2.0.0"
+      "ref": "nachet-frontend@0.10.4|merge-descriptors@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|merge-stream@2.0.0"
+      "ref": "nachet-frontend@0.10.4|merge-stream@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|merge2@1.4.1"
+      "ref": "nachet-frontend@0.10.4|merge2@1.4.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|micromatch@4.0.8",
+      "ref": "nachet-frontend@0.10.4|micromatch@4.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|braces@3.0.3",
-        "nachet-frontend@0.10.3|micromatch@4.0.8|picomatch@2.3.1"
+        "nachet-frontend@0.10.4|braces@3.0.3",
+        "nachet-frontend@0.10.4|micromatch@4.0.8|picomatch@2.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|micromatch@4.0.8|picomatch@2.3.1"
+      "ref": "nachet-frontend@0.10.4|micromatch@4.0.8|picomatch@2.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|mime-db@1.54.0"
+      "ref": "nachet-frontend@0.10.4|mime-db@1.54.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|mime-types@3.0.1",
+      "ref": "nachet-frontend@0.10.4|mime-types@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|mime-db@1.54.0"
+        "nachet-frontend@0.10.4|mime-db@1.54.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|mimic-fn@2.1.0"
+      "ref": "nachet-frontend@0.10.4|mimic-fn@2.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|mimic-response@3.1.0"
+      "ref": "nachet-frontend@0.10.4|mimic-response@3.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|min-indent@1.0.1"
+      "ref": "nachet-frontend@0.10.4|min-indent@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|minimatch@3.1.2",
+      "ref": "nachet-frontend@0.10.4|minimatch@3.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|brace-expansion@1.1.12"
+        "nachet-frontend@0.10.4|brace-expansion@1.1.12"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minimist@1.2.8"
+      "ref": "nachet-frontend@0.10.4|minimist@1.2.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-collect@2.0.1",
+      "ref": "nachet-frontend@0.10.4|minipass-collect@2.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass@7.1.2"
+        "nachet-frontend@0.10.4|minipass@7.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-fetch@4.0.1",
+      "ref": "nachet-frontend@0.10.4|minipass-fetch@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|encoding@0.1.13",
-        "nachet-frontend@0.10.3|minipass-sized@1.0.3",
-        "nachet-frontend@0.10.3|minipass@7.1.2",
-        "nachet-frontend@0.10.3|minizlib@3.0.2"
+        "nachet-frontend@0.10.4|encoding@0.1.13",
+        "nachet-frontend@0.10.4|minipass-sized@1.0.3",
+        "nachet-frontend@0.10.4|minipass@7.1.2",
+        "nachet-frontend@0.10.4|minizlib@3.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-flush@1.0.5",
+      "ref": "nachet-frontend@0.10.4|minipass-flush@1.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass-flush@1.0.5|minipass@3.3.6"
+        "nachet-frontend@0.10.4|minipass-flush@1.0.5|minipass@3.3.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-flush@1.0.5|minipass@3.3.6",
+      "ref": "nachet-frontend@0.10.4|minipass-flush@1.0.5|minipass@3.3.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass-flush@1.0.5|yallist@4.0.0"
+        "nachet-frontend@0.10.4|minipass-flush@1.0.5|yallist@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-flush@1.0.5|yallist@4.0.0"
+      "ref": "nachet-frontend@0.10.4|minipass-flush@1.0.5|yallist@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-pipeline@1.2.4",
+      "ref": "nachet-frontend@0.10.4|minipass-pipeline@1.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass-pipeline@1.2.4|minipass@3.3.6"
+        "nachet-frontend@0.10.4|minipass-pipeline@1.2.4|minipass@3.3.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-pipeline@1.2.4|minipass@3.3.6",
+      "ref": "nachet-frontend@0.10.4|minipass-pipeline@1.2.4|minipass@3.3.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass-pipeline@1.2.4|yallist@4.0.0"
+        "nachet-frontend@0.10.4|minipass-pipeline@1.2.4|yallist@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-pipeline@1.2.4|yallist@4.0.0"
+      "ref": "nachet-frontend@0.10.4|minipass-pipeline@1.2.4|yallist@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-sized@1.0.3",
+      "ref": "nachet-frontend@0.10.4|minipass-sized@1.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass-sized@1.0.3|minipass@3.3.6"
+        "nachet-frontend@0.10.4|minipass-sized@1.0.3|minipass@3.3.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-sized@1.0.3|minipass@3.3.6",
+      "ref": "nachet-frontend@0.10.4|minipass-sized@1.0.3|minipass@3.3.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass-sized@1.0.3|yallist@4.0.0"
+        "nachet-frontend@0.10.4|minipass-sized@1.0.3|yallist@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass-sized@1.0.3|yallist@4.0.0"
+      "ref": "nachet-frontend@0.10.4|minipass-sized@1.0.3|yallist@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|minipass@7.1.2"
+      "ref": "nachet-frontend@0.10.4|minipass@7.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|minizlib@3.0.2",
+      "ref": "nachet-frontend@0.10.4|minizlib@3.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass@7.1.2"
+        "nachet-frontend@0.10.4|minipass@7.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|mkdirp-classic@0.5.3"
+      "ref": "nachet-frontend@0.10.4|mkdirp-classic@0.5.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|mkdirp@3.0.1"
+      "ref": "nachet-frontend@0.10.4|mkdirp@3.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|moo@0.5.2"
+      "ref": "nachet-frontend@0.10.4|moo@0.5.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ms@2.1.3"
+      "ref": "nachet-frontend@0.10.4|ms@2.1.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|nan@2.22.2"
+      "ref": "nachet-frontend@0.10.4|nan@2.22.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|nanoid@3.3.11"
+      "ref": "nachet-frontend@0.10.4|nanoid@3.3.11"
     },
     {
-      "ref": "nachet-frontend@0.10.3|napi-build-utils@2.0.0"
+      "ref": "nachet-frontend@0.10.4|napi-build-utils@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|natural-compare@1.4.0"
+      "ref": "nachet-frontend@0.10.4|natural-compare@1.4.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|nearley@2.20.1",
+      "ref": "nachet-frontend@0.10.4|nearley@2.20.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|moo@0.5.2",
-        "nachet-frontend@0.10.3|nearley@2.20.1|commander@2.20.3",
-        "nachet-frontend@0.10.3|railroad-diagrams@1.0.0",
-        "nachet-frontend@0.10.3|randexp@0.4.6"
+        "nachet-frontend@0.10.4|moo@0.5.2",
+        "nachet-frontend@0.10.4|nearley@2.20.1|commander@2.20.3",
+        "nachet-frontend@0.10.4|railroad-diagrams@1.0.0",
+        "nachet-frontend@0.10.4|randexp@0.4.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|nearley@2.20.1|commander@2.20.3"
+      "ref": "nachet-frontend@0.10.4|nearley@2.20.1|commander@2.20.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|negotiator@1.0.0"
+      "ref": "nachet-frontend@0.10.4|negotiator@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-abi@3.77.0",
+      "ref": "nachet-frontend@0.10.4|node-abi@3.77.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|node-abi@3.77.0|semver@7.7.2"
+        "nachet-frontend@0.10.4|node-abi@3.77.0|semver@7.7.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-abi@3.77.0|semver@7.7.2"
+      "ref": "nachet-frontend@0.10.4|node-abi@3.77.0|semver@7.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-domexception@1.0.0"
+      "ref": "nachet-frontend@0.10.4|node-domexception@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-fetch@3.3.2",
+      "ref": "nachet-frontend@0.10.4|node-fetch@3.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|data-uri-to-buffer@4.0.1",
-        "nachet-frontend@0.10.3|fetch-blob@3.2.0",
-        "nachet-frontend@0.10.3|formdata-polyfill@4.0.10"
+        "nachet-frontend@0.10.4|data-uri-to-buffer@4.0.1",
+        "nachet-frontend@0.10.4|fetch-blob@3.2.0",
+        "nachet-frontend@0.10.4|formdata-polyfill@4.0.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-gyp@11.4.2",
+      "ref": "nachet-frontend@0.10.4|node-gyp@11.4.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|env-paths@2.2.1",
-        "nachet-frontend@0.10.3|exponential-backoff@3.1.2",
-        "nachet-frontend@0.10.3|graceful-fs@4.2.11",
-        "nachet-frontend@0.10.3|make-fetch-happen@14.0.3",
-        "nachet-frontend@0.10.3|node-gyp@11.4.2|semver@7.7.2",
-        "nachet-frontend@0.10.3|node-gyp@11.4.2|which@5.0.0",
-        "nachet-frontend@0.10.3|nopt@8.1.0",
-        "nachet-frontend@0.10.3|proc-log@5.0.0",
-        "nachet-frontend@0.10.3|tar@7.4.3",
-        "nachet-frontend@0.10.3|tinyglobby@0.2.15"
+        "nachet-frontend@0.10.4|env-paths@2.2.1",
+        "nachet-frontend@0.10.4|exponential-backoff@3.1.2",
+        "nachet-frontend@0.10.4|graceful-fs@4.2.11",
+        "nachet-frontend@0.10.4|make-fetch-happen@14.0.3",
+        "nachet-frontend@0.10.4|node-gyp@11.4.2|semver@7.7.2",
+        "nachet-frontend@0.10.4|node-gyp@11.4.2|which@5.0.0",
+        "nachet-frontend@0.10.4|nopt@8.1.0",
+        "nachet-frontend@0.10.4|proc-log@5.0.0",
+        "nachet-frontend@0.10.4|tar@7.4.3",
+        "nachet-frontend@0.10.4|tinyglobby@0.2.15"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-gyp@11.4.2|isexe@3.1.1"
+      "ref": "nachet-frontend@0.10.4|node-gyp@11.4.2|isexe@3.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-gyp@11.4.2|semver@7.7.2"
+      "ref": "nachet-frontend@0.10.4|node-gyp@11.4.2|semver@7.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-gyp@11.4.2|which@5.0.0",
+      "ref": "nachet-frontend@0.10.4|node-gyp@11.4.2|which@5.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|node-gyp@11.4.2|isexe@3.1.1"
+        "nachet-frontend@0.10.4|node-gyp@11.4.2|isexe@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|node-releases@2.0.21"
+      "ref": "nachet-frontend@0.10.4|node-releases@2.0.21"
     },
     {
-      "ref": "nachet-frontend@0.10.3|nopt@8.1.0",
+      "ref": "nachet-frontend@0.10.4|nopt@8.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|abbrev@3.0.1"
+        "nachet-frontend@0.10.4|abbrev@3.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|normalize-package-data@8.0.0",
+      "ref": "nachet-frontend@0.10.4|normalize-package-data@8.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|hosted-git-info@9.0.0",
-        "nachet-frontend@0.10.3|normalize-package-data@8.0.0|semver@7.7.2",
-        "nachet-frontend@0.10.3|validate-npm-package-license@3.0.4"
+        "nachet-frontend@0.10.4|hosted-git-info@9.0.0",
+        "nachet-frontend@0.10.4|normalize-package-data@8.0.0|semver@7.7.2",
+        "nachet-frontend@0.10.4|validate-npm-package-license@3.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|normalize-package-data@8.0.0|semver@7.7.2"
+      "ref": "nachet-frontend@0.10.4|normalize-package-data@8.0.0|semver@7.7.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|npm-run-path@4.0.1",
+      "ref": "nachet-frontend@0.10.4|npm-run-path@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|path-key@3.1.1"
+        "nachet-frontend@0.10.4|path-key@3.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|nwsapi@2.2.22"
+      "ref": "nachet-frontend@0.10.4|nwsapi@2.2.22"
     },
     {
-      "ref": "nachet-frontend@0.10.3|object-assign@4.1.1"
+      "ref": "nachet-frontend@0.10.4|object-assign@4.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|object-inspect@1.13.4"
+      "ref": "nachet-frontend@0.10.4|object-inspect@1.13.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|object-keys@1.1.1"
+      "ref": "nachet-frontend@0.10.4|object-keys@1.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|object.assign@4.1.7",
+      "ref": "nachet-frontend@0.10.4|object.assign@4.1.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|object-keys@1.1.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|object-keys@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|object.entries@1.1.9",
+      "ref": "nachet-frontend@0.10.4|object.entries@1.1.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|object.fromentries@2.0.8",
+      "ref": "nachet-frontend@0.10.4|object.fromentries@2.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|object.groupby@1.0.3",
+      "ref": "nachet-frontend@0.10.4|object.groupby@1.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|object.values@1.2.1",
+      "ref": "nachet-frontend@0.10.4|object.values@1.2.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|on-finished@2.4.1",
+      "ref": "nachet-frontend@0.10.4|on-finished@2.4.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ee-first@1.1.1"
+        "nachet-frontend@0.10.4|ee-first@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|on-headers@1.1.0"
+      "ref": "nachet-frontend@0.10.4|on-headers@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|once@1.4.0",
+      "ref": "nachet-frontend@0.10.4|once@1.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|wrappy@1.0.2"
+        "nachet-frontend@0.10.4|wrappy@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|onetime@5.1.2",
+      "ref": "nachet-frontend@0.10.4|onetime@5.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|mimic-fn@2.1.0"
+        "nachet-frontend@0.10.4|mimic-fn@2.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|optionator@0.9.4",
+      "ref": "nachet-frontend@0.10.4|optionator@0.9.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|deep-is@0.1.4",
-        "nachet-frontend@0.10.3|fast-levenshtein@2.0.6",
-        "nachet-frontend@0.10.3|levn@0.4.1",
-        "nachet-frontend@0.10.3|prelude-ls@1.2.1",
-        "nachet-frontend@0.10.3|type-check@0.4.0",
-        "nachet-frontend@0.10.3|word-wrap@1.2.5"
+        "nachet-frontend@0.10.4|deep-is@0.1.4",
+        "nachet-frontend@0.10.4|fast-levenshtein@2.0.6",
+        "nachet-frontend@0.10.4|levn@0.4.1",
+        "nachet-frontend@0.10.4|prelude-ls@1.2.1",
+        "nachet-frontend@0.10.4|type-check@0.4.0",
+        "nachet-frontend@0.10.4|word-wrap@1.2.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|own-keys@1.0.1",
+      "ref": "nachet-frontend@0.10.4|own-keys@1.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|object-keys@1.1.1",
-        "nachet-frontend@0.10.3|safe-push-apply@1.0.0"
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|object-keys@1.1.1",
+        "nachet-frontend@0.10.4|safe-push-apply@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|p-finally@1.0.0"
+      "ref": "nachet-frontend@0.10.4|p-finally@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|p-limit@3.1.0",
+      "ref": "nachet-frontend@0.10.4|p-limit@3.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|yocto-queue@0.1.0"
+        "nachet-frontend@0.10.4|yocto-queue@0.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|p-locate@5.0.0",
+      "ref": "nachet-frontend@0.10.4|p-locate@5.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|p-limit@3.1.0"
+        "nachet-frontend@0.10.4|p-limit@3.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|p-map@7.0.3"
+      "ref": "nachet-frontend@0.10.4|p-map@7.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|package-json-from-dist@1.0.1"
+      "ref": "nachet-frontend@0.10.4|package-json-from-dist@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|packageurl-js@2.0.1"
+      "ref": "nachet-frontend@0.10.4|packageurl-js@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|pako@2.1.0"
+      "ref": "nachet-frontend@0.10.4|pako@2.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|parent-module@1.0.1",
+      "ref": "nachet-frontend@0.10.4|parent-module@1.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|callsites@3.1.0"
+        "nachet-frontend@0.10.4|callsites@3.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|parse-json@5.2.0",
+      "ref": "nachet-frontend@0.10.4|parse-json@5.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/code-frame@7.27.1",
-        "nachet-frontend@0.10.3|error-ex@1.3.4",
-        "nachet-frontend@0.10.3|json-parse-even-better-errors@2.3.1",
-        "nachet-frontend@0.10.3|lines-and-columns@1.2.4"
+        "nachet-frontend@0.10.4|@babel/code-frame@7.27.1",
+        "nachet-frontend@0.10.4|error-ex@1.3.4",
+        "nachet-frontend@0.10.4|json-parse-even-better-errors@2.3.1",
+        "nachet-frontend@0.10.4|lines-and-columns@1.2.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|parse-srcset@1.0.2"
+      "ref": "nachet-frontend@0.10.4|parse-srcset@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|parse5@7.3.0",
+      "ref": "nachet-frontend@0.10.4|parse5@7.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|parse5@7.3.0|entities@6.0.1"
+        "nachet-frontend@0.10.4|parse5@7.3.0|entities@6.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|parse5@7.3.0|entities@6.0.1"
+      "ref": "nachet-frontend@0.10.4|parse5@7.3.0|entities@6.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|parseurl@1.3.3"
+      "ref": "nachet-frontend@0.10.4|parseurl@1.3.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-exists@4.0.0"
+      "ref": "nachet-frontend@0.10.4|path-exists@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-is-absolute@1.0.1"
+      "ref": "nachet-frontend@0.10.4|path-is-absolute@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-is-inside@1.0.2"
+      "ref": "nachet-frontend@0.10.4|path-is-inside@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-key@3.1.1"
+      "ref": "nachet-frontend@0.10.4|path-key@3.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-parse@1.0.7"
+      "ref": "nachet-frontend@0.10.4|path-parse@1.0.7"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-scurry@1.11.1",
+      "ref": "nachet-frontend@0.10.4|path-scurry@1.11.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass@7.1.2",
-        "nachet-frontend@0.10.3|path-scurry@1.11.1|lru-cache@10.4.3"
+        "nachet-frontend@0.10.4|minipass@7.1.2",
+        "nachet-frontend@0.10.4|path-scurry@1.11.1|lru-cache@10.4.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-scurry@1.11.1|lru-cache@10.4.3"
+      "ref": "nachet-frontend@0.10.4|path-scurry@1.11.1|lru-cache@10.4.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-to-regexp@8.3.0"
+      "ref": "nachet-frontend@0.10.4|path-to-regexp@8.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|path-type@4.0.0"
+      "ref": "nachet-frontend@0.10.4|path-type@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|pathe@2.0.3"
+      "ref": "nachet-frontend@0.10.4|pathe@2.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|pathval@2.0.1"
+      "ref": "nachet-frontend@0.10.4|pathval@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|picocolors@1.1.1"
+      "ref": "nachet-frontend@0.10.4|picocolors@1.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|picomatch@4.0.3"
+      "ref": "nachet-frontend@0.10.4|picomatch@4.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|playwright-core@1.55.0"
+      "ref": "nachet-frontend@0.10.4|playwright-core@1.55.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|playwright@1.55.0",
+      "ref": "nachet-frontend@0.10.4|playwright@1.55.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fsevents@2.3.2",
-        "nachet-frontend@0.10.3|playwright-core@1.55.0"
+        "nachet-frontend@0.10.4|fsevents@2.3.2",
+        "nachet-frontend@0.10.4|playwright-core@1.55.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|possible-typed-array-names@1.1.0"
+      "ref": "nachet-frontend@0.10.4|possible-typed-array-names@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|postcss-value-parser@4.2.0"
+      "ref": "nachet-frontend@0.10.4|postcss-value-parser@4.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|postcss@8.5.6",
+      "ref": "nachet-frontend@0.10.4|postcss@8.5.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|nanoid@3.3.11",
-        "nachet-frontend@0.10.3|picocolors@1.1.1",
-        "nachet-frontend@0.10.3|source-map-js@1.2.1"
+        "nachet-frontend@0.10.4|nanoid@3.3.11",
+        "nachet-frontend@0.10.4|picocolors@1.1.1",
+        "nachet-frontend@0.10.4|source-map-js@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|prebuild-install@7.1.3",
+      "ref": "nachet-frontend@0.10.4|prebuild-install@7.1.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|detect-libc@2.1.0",
-        "nachet-frontend@0.10.3|expand-template@2.0.3",
-        "nachet-frontend@0.10.3|github-from-package@0.0.0",
-        "nachet-frontend@0.10.3|minimist@1.2.8",
-        "nachet-frontend@0.10.3|mkdirp-classic@0.5.3",
-        "nachet-frontend@0.10.3|napi-build-utils@2.0.0",
-        "nachet-frontend@0.10.3|node-abi@3.77.0",
-        "nachet-frontend@0.10.3|pump@3.0.3",
-        "nachet-frontend@0.10.3|rc@1.2.8",
-        "nachet-frontend@0.10.3|simple-get@4.0.1",
-        "nachet-frontend@0.10.3|tar-fs@2.1.3",
-        "nachet-frontend@0.10.3|tunnel-agent@0.6.0"
+        "nachet-frontend@0.10.4|detect-libc@2.1.0",
+        "nachet-frontend@0.10.4|expand-template@2.0.3",
+        "nachet-frontend@0.10.4|github-from-package@0.0.0",
+        "nachet-frontend@0.10.4|minimist@1.2.8",
+        "nachet-frontend@0.10.4|mkdirp-classic@0.5.3",
+        "nachet-frontend@0.10.4|napi-build-utils@2.0.0",
+        "nachet-frontend@0.10.4|node-abi@3.77.0",
+        "nachet-frontend@0.10.4|pump@3.0.3",
+        "nachet-frontend@0.10.4|rc@1.2.8",
+        "nachet-frontend@0.10.4|simple-get@4.0.1",
+        "nachet-frontend@0.10.4|tar-fs@2.1.3",
+        "nachet-frontend@0.10.4|tunnel-agent@0.6.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|prelude-ls@1.2.1"
+      "ref": "nachet-frontend@0.10.4|prelude-ls@1.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|prettier-linter-helpers@1.0.0",
+      "ref": "nachet-frontend@0.10.4|prettier-linter-helpers@1.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fast-diff@1.3.0"
+        "nachet-frontend@0.10.4|fast-diff@1.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|prettier@3.6.2"
+      "ref": "nachet-frontend@0.10.4|prettier@3.6.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|pretty-format@27.5.1",
+      "ref": "nachet-frontend@0.10.4|pretty-format@27.5.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1",
-        "nachet-frontend@0.10.3|pretty-format@27.5.1|ansi-styles@5.2.0",
-        "nachet-frontend@0.10.3|pretty-format@27.5.1|react-is@17.0.2"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1",
+        "nachet-frontend@0.10.4|pretty-format@27.5.1|ansi-styles@5.2.0",
+        "nachet-frontend@0.10.4|pretty-format@27.5.1|react-is@17.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|pretty-format@27.5.1|ansi-styles@5.2.0"
+      "ref": "nachet-frontend@0.10.4|pretty-format@27.5.1|ansi-styles@5.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|pretty-format@27.5.1|react-is@17.0.2"
+      "ref": "nachet-frontend@0.10.4|pretty-format@27.5.1|react-is@17.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|proc-log@5.0.0"
+      "ref": "nachet-frontend@0.10.4|proc-log@5.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|process-nextick-args@2.0.1"
+      "ref": "nachet-frontend@0.10.4|process-nextick-args@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|promise-retry@2.0.1",
+      "ref": "nachet-frontend@0.10.4|promise-retry@2.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|err-code@2.0.3",
-        "nachet-frontend@0.10.3|retry@0.12.0"
+        "nachet-frontend@0.10.4|err-code@2.0.3",
+        "nachet-frontend@0.10.4|retry@0.12.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|prop-types@15.8.1",
+      "ref": "nachet-frontend@0.10.4|prop-types@15.8.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|loose-envify@1.4.0",
-        "nachet-frontend@0.10.3|object-assign@4.1.1",
-        "nachet-frontend@0.10.3|prop-types@15.8.1|react-is@16.13.1"
+        "nachet-frontend@0.10.4|loose-envify@1.4.0",
+        "nachet-frontend@0.10.4|object-assign@4.1.1",
+        "nachet-frontend@0.10.4|prop-types@15.8.1|react-is@16.13.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|prop-types@15.8.1|react-is@16.13.1"
+      "ref": "nachet-frontend@0.10.4|prop-types@15.8.1|react-is@16.13.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|proxy-addr@2.0.7",
+      "ref": "nachet-frontend@0.10.4|proxy-addr@2.0.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|forwarded@0.2.0",
-        "nachet-frontend@0.10.3|ipaddr.js@1.9.1"
+        "nachet-frontend@0.10.4|forwarded@0.2.0",
+        "nachet-frontend@0.10.4|ipaddr.js@1.9.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|proxy-from-env@1.1.0"
+      "ref": "nachet-frontend@0.10.4|proxy-from-env@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|pump@3.0.3",
+      "ref": "nachet-frontend@0.10.4|pump@3.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|end-of-stream@1.4.5",
-        "nachet-frontend@0.10.3|once@1.4.0"
+        "nachet-frontend@0.10.4|end-of-stream@1.4.5",
+        "nachet-frontend@0.10.4|once@1.4.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|punycode@2.3.1"
+      "ref": "nachet-frontend@0.10.4|punycode@2.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|qs@6.14.0",
+      "ref": "nachet-frontend@0.10.4|qs@6.14.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|side-channel@1.1.0"
+        "nachet-frontend@0.10.4|side-channel@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|queue-microtask@1.2.3"
+      "ref": "nachet-frontend@0.10.4|queue-microtask@1.2.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|railroad-diagrams@1.0.0"
+      "ref": "nachet-frontend@0.10.4|railroad-diagrams@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|randexp@0.4.6",
+      "ref": "nachet-frontend@0.10.4|randexp@0.4.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|discontinuous-range@1.0.0",
-        "nachet-frontend@0.10.3|ret@0.1.15"
+        "nachet-frontend@0.10.4|discontinuous-range@1.0.0",
+        "nachet-frontend@0.10.4|ret@0.1.15"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|range-parser@1.2.1"
+      "ref": "nachet-frontend@0.10.4|range-parser@1.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|raw-body@3.0.1",
+      "ref": "nachet-frontend@0.10.4|raw-body@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|bytes@3.1.2",
-        "nachet-frontend@0.10.3|http-errors@2.0.0",
-        "nachet-frontend@0.10.3|raw-body@3.0.1|iconv-lite@0.7.0",
-        "nachet-frontend@0.10.3|unpipe@1.0.0"
+        "nachet-frontend@0.10.4|bytes@3.1.2",
+        "nachet-frontend@0.10.4|http-errors@2.0.0",
+        "nachet-frontend@0.10.4|raw-body@3.0.1|iconv-lite@0.7.0",
+        "nachet-frontend@0.10.4|unpipe@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|raw-body@3.0.1|iconv-lite@0.7.0",
+      "ref": "nachet-frontend@0.10.4|raw-body@3.0.1|iconv-lite@0.7.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|safer-buffer@2.1.2"
+        "nachet-frontend@0.10.4|safer-buffer@2.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|rc@1.2.8",
+      "ref": "nachet-frontend@0.10.4|rc@1.2.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|deep-extend@0.6.0",
-        "nachet-frontend@0.10.3|ini@1.3.8",
-        "nachet-frontend@0.10.3|minimist@1.2.8",
-        "nachet-frontend@0.10.3|rc@1.2.8|strip-json-comments@2.0.1"
+        "nachet-frontend@0.10.4|deep-extend@0.6.0",
+        "nachet-frontend@0.10.4|ini@1.3.8",
+        "nachet-frontend@0.10.4|minimist@1.2.8",
+        "nachet-frontend@0.10.4|rc@1.2.8|strip-json-comments@2.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|rc@1.2.8|strip-json-comments@2.0.1"
+      "ref": "nachet-frontend@0.10.4|rc@1.2.8|strip-json-comments@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|re-resizable@6.11.2",
+      "ref": "nachet-frontend@0.10.4|re-resizable@6.11.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-dom@19.1.1",
+      "ref": "nachet-frontend@0.10.4|react-dom@19.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react@19.1.1",
-        "nachet-frontend@0.10.3|scheduler@0.26.0"
+        "nachet-frontend@0.10.4|react@19.1.1",
+        "nachet-frontend@0.10.4|scheduler@0.26.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-draggable@4.5.0",
+      "ref": "nachet-frontend@0.10.4|react-draggable@4.5.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|clsx@2.1.1",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|clsx@2.1.1",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-icons@5.5.0",
+      "ref": "nachet-frontend@0.10.4|react-icons@5.5.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-is@19.1.1"
+      "ref": "nachet-frontend@0.10.4|react-is@19.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-picture-annotation@1.2.0",
+      "ref": "nachet-frontend@0.10.4|react-picture-annotation@1.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-router-dom@7.9.1",
+      "ref": "nachet-frontend@0.10.4|react-router-dom@7.9.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react-router@7.9.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react-router@7.9.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-router@7.9.1",
+      "ref": "nachet-frontend@0.10.4|react-router@7.9.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react-router@7.9.1|cookie@1.0.2",
-        "nachet-frontend@0.10.3|react@19.1.1",
-        "nachet-frontend@0.10.3|set-cookie-parser@2.7.1"
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react-router@7.9.1|cookie@1.0.2",
+        "nachet-frontend@0.10.4|react@19.1.1",
+        "nachet-frontend@0.10.4|set-cookie-parser@2.7.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-router@7.9.1|cookie@1.0.2"
+      "ref": "nachet-frontend@0.10.4|react-router@7.9.1|cookie@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-transition-group@4.4.5",
+      "ref": "nachet-frontend@0.10.4|react-transition-group@4.4.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@babel/runtime@7.28.4",
-        "nachet-frontend@0.10.3|dom-helpers@5.2.1",
-        "nachet-frontend@0.10.3|loose-envify@1.4.0",
-        "nachet-frontend@0.10.3|prop-types@15.8.1",
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@babel/runtime@7.28.4",
+        "nachet-frontend@0.10.4|dom-helpers@5.2.1",
+        "nachet-frontend@0.10.4|loose-envify@1.4.0",
+        "nachet-frontend@0.10.4|prop-types@15.8.1",
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react-webcam@7.2.0",
+      "ref": "nachet-frontend@0.10.4|react-webcam@7.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|react@19.1.1"
+      "ref": "nachet-frontend@0.10.4|react@19.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|readable-stream@2.3.8",
+      "ref": "nachet-frontend@0.10.4|readable-stream@2.3.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|core-util-is@1.0.3",
-        "nachet-frontend@0.10.3|inherits@2.0.4",
-        "nachet-frontend@0.10.3|isarray@1.0.0",
-        "nachet-frontend@0.10.3|process-nextick-args@2.0.1",
-        "nachet-frontend@0.10.3|readable-stream@2.3.8|safe-buffer@5.1.2",
-        "nachet-frontend@0.10.3|string_decoder@1.1.1",
-        "nachet-frontend@0.10.3|util-deprecate@1.0.2"
+        "nachet-frontend@0.10.4|core-util-is@1.0.3",
+        "nachet-frontend@0.10.4|inherits@2.0.4",
+        "nachet-frontend@0.10.4|isarray@1.0.0",
+        "nachet-frontend@0.10.4|process-nextick-args@2.0.1",
+        "nachet-frontend@0.10.4|readable-stream@2.3.8|safe-buffer@5.1.2",
+        "nachet-frontend@0.10.4|string_decoder@1.1.1",
+        "nachet-frontend@0.10.4|util-deprecate@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|readable-stream@2.3.8|safe-buffer@5.1.2"
+      "ref": "nachet-frontend@0.10.4|readable-stream@2.3.8|safe-buffer@5.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|redent@3.0.0",
+      "ref": "nachet-frontend@0.10.4|redent@3.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|indent-string@4.0.0",
-        "nachet-frontend@0.10.3|strip-indent@3.0.0"
+        "nachet-frontend@0.10.4|indent-string@4.0.0",
+        "nachet-frontend@0.10.4|strip-indent@3.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|reflect.getprototypeof@1.0.10",
+      "ref": "nachet-frontend@0.10.4|reflect.getprototypeof@1.0.10",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|which-builtin-type@1.2.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|which-builtin-type@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|regenerate-unicode-properties@10.2.2",
+      "ref": "nachet-frontend@0.10.4|regenerate-unicode-properties@10.2.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|regenerate@1.4.2"
+        "nachet-frontend@0.10.4|regenerate@1.4.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|regenerate@1.4.2"
+      "ref": "nachet-frontend@0.10.4|regenerate@1.4.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|regexp.prototype.flags@1.5.4",
+      "ref": "nachet-frontend@0.10.4|regexp.prototype.flags@1.5.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|set-function-name@2.0.2"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|set-function-name@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|regexpu-core@6.3.1",
+      "ref": "nachet-frontend@0.10.4|regexpu-core@6.3.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|regenerate-unicode-properties@10.2.2",
-        "nachet-frontend@0.10.3|regenerate@1.4.2",
-        "nachet-frontend@0.10.3|regjsgen@0.8.0",
-        "nachet-frontend@0.10.3|regjsparser@0.12.0",
-        "nachet-frontend@0.10.3|unicode-match-property-ecmascript@2.0.0",
-        "nachet-frontend@0.10.3|unicode-match-property-value-ecmascript@2.2.1"
+        "nachet-frontend@0.10.4|regenerate-unicode-properties@10.2.2",
+        "nachet-frontend@0.10.4|regenerate@1.4.2",
+        "nachet-frontend@0.10.4|regjsgen@0.8.0",
+        "nachet-frontend@0.10.4|regjsparser@0.12.0",
+        "nachet-frontend@0.10.4|unicode-match-property-ecmascript@2.0.0",
+        "nachet-frontend@0.10.4|unicode-match-property-value-ecmascript@2.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|registry-auth-token@3.3.2",
+      "ref": "nachet-frontend@0.10.4|registry-auth-token@3.3.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|rc@1.2.8",
-        "nachet-frontend@0.10.3|safe-buffer@5.2.1"
+        "nachet-frontend@0.10.4|rc@1.2.8",
+        "nachet-frontend@0.10.4|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|registry-url@3.1.0",
+      "ref": "nachet-frontend@0.10.4|registry-url@3.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|rc@1.2.8"
+        "nachet-frontend@0.10.4|rc@1.2.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|regjsgen@0.8.0"
+      "ref": "nachet-frontend@0.10.4|regjsgen@0.8.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|regjsparser@0.12.0",
+      "ref": "nachet-frontend@0.10.4|regjsparser@0.12.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|regjsparser@0.12.0|jsesc@3.0.2"
+        "nachet-frontend@0.10.4|regjsparser@0.12.0|jsesc@3.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|regjsparser@0.12.0|jsesc@3.0.2"
+      "ref": "nachet-frontend@0.10.4|regjsparser@0.12.0|jsesc@3.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|require-directory@2.1.1"
+      "ref": "nachet-frontend@0.10.4|require-directory@2.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|require-from-string@2.0.2"
+      "ref": "nachet-frontend@0.10.4|require-from-string@2.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|resolve-from@4.0.0"
+      "ref": "nachet-frontend@0.10.4|resolve-from@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|resolve@1.22.10",
+      "ref": "nachet-frontend@0.10.4|resolve@1.22.10",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-core-module@2.16.1",
-        "nachet-frontend@0.10.3|path-parse@1.0.7",
-        "nachet-frontend@0.10.3|supports-preserve-symlinks-flag@1.0.0"
+        "nachet-frontend@0.10.4|is-core-module@2.16.1",
+        "nachet-frontend@0.10.4|path-parse@1.0.7",
+        "nachet-frontend@0.10.4|supports-preserve-symlinks-flag@1.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ret@0.1.15"
+      "ref": "nachet-frontend@0.10.4|ret@0.1.15"
     },
     {
-      "ref": "nachet-frontend@0.10.3|retry@0.12.0"
+      "ref": "nachet-frontend@0.10.4|retry@0.12.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|reusify@1.1.0"
+      "ref": "nachet-frontend@0.10.4|reusify@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|rollup@4.50.2",
+      "ref": "nachet-frontend@0.10.4|rollup@4.50.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@rollup/rollup-android-arm-eabi@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-android-arm64@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-darwin-arm64@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-darwin-x64@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-freebsd-arm64@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-freebsd-x64@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-arm-gnueabihf@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-arm-musleabihf@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-arm64-gnu@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-arm64-musl@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-loong64-gnu@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-ppc64-gnu@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-riscv64-gnu@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-riscv64-musl@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-s390x-gnu@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-x64-gnu@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-linux-x64-musl@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-openharmony-arm64@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-win32-arm64-msvc@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-win32-ia32-msvc@4.50.2",
-        "nachet-frontend@0.10.3|@rollup/rollup-win32-x64-msvc@4.50.2",
-        "nachet-frontend@0.10.3|@types/estree@1.0.8",
-        "nachet-frontend@0.10.3|fsevents@2.3.2"
+        "nachet-frontend@0.10.4|@rollup/rollup-android-arm-eabi@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-android-arm64@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-darwin-arm64@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-darwin-x64@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-freebsd-arm64@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-freebsd-x64@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-arm-gnueabihf@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-arm-musleabihf@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-arm64-gnu@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-arm64-musl@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-loong64-gnu@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-ppc64-gnu@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-riscv64-gnu@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-riscv64-musl@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-s390x-gnu@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-x64-gnu@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-linux-x64-musl@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-openharmony-arm64@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-win32-arm64-msvc@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-win32-ia32-msvc@4.50.2",
+        "nachet-frontend@0.10.4|@rollup/rollup-win32-x64-msvc@4.50.2",
+        "nachet-frontend@0.10.4|@types/estree@1.0.8",
+        "nachet-frontend@0.10.4|fsevents@2.3.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|router@2.2.0",
+      "ref": "nachet-frontend@0.10.4|router@2.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|depd@2.0.0",
-        "nachet-frontend@0.10.3|is-promise@4.0.0",
-        "nachet-frontend@0.10.3|parseurl@1.3.3",
-        "nachet-frontend@0.10.3|path-to-regexp@8.3.0"
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|depd@2.0.0",
+        "nachet-frontend@0.10.4|is-promise@4.0.0",
+        "nachet-frontend@0.10.4|parseurl@1.3.3",
+        "nachet-frontend@0.10.4|path-to-regexp@8.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|rrweb-cssom@0.8.0"
+      "ref": "nachet-frontend@0.10.4|rrweb-cssom@0.8.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|run-parallel@1.2.0",
+      "ref": "nachet-frontend@0.10.4|run-parallel@1.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|queue-microtask@1.2.3"
+        "nachet-frontend@0.10.4|queue-microtask@1.2.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|safe-array-concat@1.1.3",
+      "ref": "nachet-frontend@0.10.4|safe-array-concat@1.1.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|safe-array-concat@1.1.3|isarray@2.0.5"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|safe-array-concat@1.1.3|isarray@2.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|safe-array-concat@1.1.3|isarray@2.0.5"
+      "ref": "nachet-frontend@0.10.4|safe-array-concat@1.1.3|isarray@2.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|safe-buffer@5.2.1"
+      "ref": "nachet-frontend@0.10.4|safe-buffer@5.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|safe-push-apply@1.0.0",
+      "ref": "nachet-frontend@0.10.4|safe-push-apply@1.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|safe-push-apply@1.0.0|isarray@2.0.5"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|safe-push-apply@1.0.0|isarray@2.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|safe-push-apply@1.0.0|isarray@2.0.5"
+      "ref": "nachet-frontend@0.10.4|safe-push-apply@1.0.0|isarray@2.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|safe-regex-test@1.1.0",
+      "ref": "nachet-frontend@0.10.4|safe-regex-test@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|is-regex@1.2.1"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|is-regex@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|safer-buffer@2.1.2"
+      "ref": "nachet-frontend@0.10.4|safer-buffer@2.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|sanitize-html@2.17.0",
+      "ref": "nachet-frontend@0.10.4|sanitize-html@2.17.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|deepmerge@4.3.1",
-        "nachet-frontend@0.10.3|escape-string-regexp@4.0.0",
-        "nachet-frontend@0.10.3|htmlparser2@8.0.2",
-        "nachet-frontend@0.10.3|is-plain-object@5.0.0",
-        "nachet-frontend@0.10.3|parse-srcset@1.0.2",
-        "nachet-frontend@0.10.3|postcss@8.5.6"
+        "nachet-frontend@0.10.4|deepmerge@4.3.1",
+        "nachet-frontend@0.10.4|escape-string-regexp@4.0.0",
+        "nachet-frontend@0.10.4|htmlparser2@8.0.2",
+        "nachet-frontend@0.10.4|is-plain-object@5.0.0",
+        "nachet-frontend@0.10.4|parse-srcset@1.0.2",
+        "nachet-frontend@0.10.4|postcss@8.5.6"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|saxes@6.0.0",
+      "ref": "nachet-frontend@0.10.4|saxes@6.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|xmlchars@2.2.0"
+        "nachet-frontend@0.10.4|xmlchars@2.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|scheduler@0.26.0"
+      "ref": "nachet-frontend@0.10.4|scheduler@0.26.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|schemes@1.4.0",
+      "ref": "nachet-frontend@0.10.4|schemes@1.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|extend@3.0.2"
+        "nachet-frontend@0.10.4|extend@3.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|semver@6.3.1"
+      "ref": "nachet-frontend@0.10.4|semver@6.3.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|send@1.2.0",
+      "ref": "nachet-frontend@0.10.4|send@1.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|encodeurl@2.0.0",
-        "nachet-frontend@0.10.3|escape-html@1.0.3",
-        "nachet-frontend@0.10.3|etag@1.8.1",
-        "nachet-frontend@0.10.3|fresh@2.0.0",
-        "nachet-frontend@0.10.3|http-errors@2.0.0",
-        "nachet-frontend@0.10.3|mime-types@3.0.1",
-        "nachet-frontend@0.10.3|ms@2.1.3",
-        "nachet-frontend@0.10.3|on-finished@2.4.1",
-        "nachet-frontend@0.10.3|range-parser@1.2.1",
-        "nachet-frontend@0.10.3|statuses@2.0.2"
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|encodeurl@2.0.0",
+        "nachet-frontend@0.10.4|escape-html@1.0.3",
+        "nachet-frontend@0.10.4|etag@1.8.1",
+        "nachet-frontend@0.10.4|fresh@2.0.0",
+        "nachet-frontend@0.10.4|http-errors@2.0.0",
+        "nachet-frontend@0.10.4|mime-types@3.0.1",
+        "nachet-frontend@0.10.4|ms@2.1.3",
+        "nachet-frontend@0.10.4|on-finished@2.4.1",
+        "nachet-frontend@0.10.4|range-parser@1.2.1",
+        "nachet-frontend@0.10.4|statuses@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6",
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minimatch@3.1.2",
-        "nachet-frontend@0.10.3|path-is-inside@1.0.2",
-        "nachet-frontend@0.10.3|serve-handler@6.1.6|bytes@3.0.0",
-        "nachet-frontend@0.10.3|serve-handler@6.1.6|content-disposition@0.5.2",
-        "nachet-frontend@0.10.3|serve-handler@6.1.6|mime-types@2.1.18",
-        "nachet-frontend@0.10.3|serve-handler@6.1.6|path-to-regexp@3.3.0",
-        "nachet-frontend@0.10.3|serve-handler@6.1.6|range-parser@1.2.0"
+        "nachet-frontend@0.10.4|minimatch@3.1.2",
+        "nachet-frontend@0.10.4|path-is-inside@1.0.2",
+        "nachet-frontend@0.10.4|serve-handler@6.1.6|bytes@3.0.0",
+        "nachet-frontend@0.10.4|serve-handler@6.1.6|content-disposition@0.5.2",
+        "nachet-frontend@0.10.4|serve-handler@6.1.6|mime-types@2.1.18",
+        "nachet-frontend@0.10.4|serve-handler@6.1.6|path-to-regexp@3.3.0",
+        "nachet-frontend@0.10.4|serve-handler@6.1.6|range-parser@1.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|bytes@3.0.0"
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|bytes@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|content-disposition@0.5.2"
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|content-disposition@0.5.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|mime-db@1.33.0"
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|mime-db@1.33.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|mime-types@2.1.18",
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|mime-types@2.1.18",
       "dependsOn": [
-        "nachet-frontend@0.10.3|serve-handler@6.1.6|mime-db@1.33.0"
+        "nachet-frontend@0.10.4|serve-handler@6.1.6|mime-db@1.33.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|path-to-regexp@3.3.0"
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|path-to-regexp@3.3.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-handler@6.1.6|range-parser@1.2.0"
+      "ref": "nachet-frontend@0.10.4|serve-handler@6.1.6|range-parser@1.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve-static@2.2.0",
+      "ref": "nachet-frontend@0.10.4|serve-static@2.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|encodeurl@2.0.0",
-        "nachet-frontend@0.10.3|escape-html@1.0.3",
-        "nachet-frontend@0.10.3|parseurl@1.3.3",
-        "nachet-frontend@0.10.3|send@1.2.0"
+        "nachet-frontend@0.10.4|encodeurl@2.0.0",
+        "nachet-frontend@0.10.4|escape-html@1.0.3",
+        "nachet-frontend@0.10.4|parseurl@1.3.3",
+        "nachet-frontend@0.10.4|send@1.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve@14.2.5",
+      "ref": "nachet-frontend@0.10.4|serve@14.2.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@zeit/schemas@2.36.0",
-        "nachet-frontend@0.10.3|arg@5.0.2",
-        "nachet-frontend@0.10.3|boxen@7.0.0",
-        "nachet-frontend@0.10.3|chalk-template@0.4.0",
-        "nachet-frontend@0.10.3|clipboardy@3.0.0",
-        "nachet-frontend@0.10.3|compression@1.8.1",
-        "nachet-frontend@0.10.3|is-port-reachable@4.0.0",
-        "nachet-frontend@0.10.3|serve-handler@6.1.6",
-        "nachet-frontend@0.10.3|serve@14.2.5|ajv@8.12.0",
-        "nachet-frontend@0.10.3|serve@14.2.5|chalk@5.0.1",
-        "nachet-frontend@0.10.3|update-check@1.5.4"
+        "nachet-frontend@0.10.4|@zeit/schemas@2.36.0",
+        "nachet-frontend@0.10.4|arg@5.0.2",
+        "nachet-frontend@0.10.4|boxen@7.0.0",
+        "nachet-frontend@0.10.4|chalk-template@0.4.0",
+        "nachet-frontend@0.10.4|clipboardy@3.0.0",
+        "nachet-frontend@0.10.4|compression@1.8.1",
+        "nachet-frontend@0.10.4|is-port-reachable@4.0.0",
+        "nachet-frontend@0.10.4|serve-handler@6.1.6",
+        "nachet-frontend@0.10.4|serve@14.2.5|ajv@8.12.0",
+        "nachet-frontend@0.10.4|serve@14.2.5|chalk@5.0.1",
+        "nachet-frontend@0.10.4|update-check@1.5.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve@14.2.5|ajv@8.12.0",
+      "ref": "nachet-frontend@0.10.4|serve@14.2.5|ajv@8.12.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fast-deep-equal@3.1.3",
-        "nachet-frontend@0.10.3|json-schema-traverse@1.0.0",
-        "nachet-frontend@0.10.3|require-from-string@2.0.2",
-        "nachet-frontend@0.10.3|uri-js@4.4.1"
+        "nachet-frontend@0.10.4|fast-deep-equal@3.1.3",
+        "nachet-frontend@0.10.4|json-schema-traverse@1.0.0",
+        "nachet-frontend@0.10.4|require-from-string@2.0.2",
+        "nachet-frontend@0.10.4|uri-js@4.4.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|serve@14.2.5|chalk@5.0.1"
+      "ref": "nachet-frontend@0.10.4|serve@14.2.5|chalk@5.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|set-cookie-parser@2.7.1"
+      "ref": "nachet-frontend@0.10.4|set-cookie-parser@2.7.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|set-function-length@1.2.2",
+      "ref": "nachet-frontend@0.10.4|set-function-length@1.2.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|define-data-property@1.1.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|function-bind@1.1.2",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-property-descriptors@1.0.2"
+        "nachet-frontend@0.10.4|define-data-property@1.1.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|function-bind@1.1.2",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-property-descriptors@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|set-function-name@2.0.2",
+      "ref": "nachet-frontend@0.10.4|set-function-name@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|define-data-property@1.1.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|functions-have-names@1.2.3",
-        "nachet-frontend@0.10.3|has-property-descriptors@1.0.2"
+        "nachet-frontend@0.10.4|define-data-property@1.1.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|functions-have-names@1.2.3",
+        "nachet-frontend@0.10.4|has-property-descriptors@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|set-proto@1.0.0",
+      "ref": "nachet-frontend@0.10.4|set-proto@1.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|dunder-proto@1.0.1",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|dunder-proto@1.0.1",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|setimmediate@1.0.5"
+      "ref": "nachet-frontend@0.10.4|setimmediate@1.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|setprototypeof@1.2.0"
+      "ref": "nachet-frontend@0.10.4|setprototypeof@1.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|shallowequal@1.1.0"
+      "ref": "nachet-frontend@0.10.4|shallowequal@1.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|shebang-command@2.0.0",
+      "ref": "nachet-frontend@0.10.4|shebang-command@2.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|shebang-regex@3.0.0"
+        "nachet-frontend@0.10.4|shebang-regex@3.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|shebang-regex@3.0.0"
+      "ref": "nachet-frontend@0.10.4|shebang-regex@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|side-channel-list@1.0.0",
+      "ref": "nachet-frontend@0.10.4|side-channel-list@1.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|object-inspect@1.13.4"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|object-inspect@1.13.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|side-channel-map@1.0.1",
+      "ref": "nachet-frontend@0.10.4|side-channel-map@1.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|object-inspect@1.13.4"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|object-inspect@1.13.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|side-channel-weakmap@1.0.2",
+      "ref": "nachet-frontend@0.10.4|side-channel-weakmap@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|object-inspect@1.13.4",
-        "nachet-frontend@0.10.3|side-channel-map@1.0.1"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|object-inspect@1.13.4",
+        "nachet-frontend@0.10.4|side-channel-map@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|side-channel@1.1.0",
+      "ref": "nachet-frontend@0.10.4|side-channel@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|object-inspect@1.13.4",
-        "nachet-frontend@0.10.3|side-channel-list@1.0.0",
-        "nachet-frontend@0.10.3|side-channel-map@1.0.1",
-        "nachet-frontend@0.10.3|side-channel-weakmap@1.0.2"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|object-inspect@1.13.4",
+        "nachet-frontend@0.10.4|side-channel-list@1.0.0",
+        "nachet-frontend@0.10.4|side-channel-map@1.0.1",
+        "nachet-frontend@0.10.4|side-channel-weakmap@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|siginfo@2.0.0"
+      "ref": "nachet-frontend@0.10.4|siginfo@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|signal-exit@3.0.7"
+      "ref": "nachet-frontend@0.10.4|signal-exit@3.0.7"
     },
     {
-      "ref": "nachet-frontend@0.10.3|simple-concat@1.0.1"
+      "ref": "nachet-frontend@0.10.4|simple-concat@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|simple-get@4.0.1",
+      "ref": "nachet-frontend@0.10.4|simple-get@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|decompress-response@6.0.0",
-        "nachet-frontend@0.10.3|once@1.4.0",
-        "nachet-frontend@0.10.3|simple-concat@1.0.1"
+        "nachet-frontend@0.10.4|decompress-response@6.0.0",
+        "nachet-frontend@0.10.4|once@1.4.0",
+        "nachet-frontend@0.10.4|simple-concat@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|slash@3.0.0"
+      "ref": "nachet-frontend@0.10.4|slash@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|smart-buffer@4.2.0"
+      "ref": "nachet-frontend@0.10.4|smart-buffer@4.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|smtp-address-parser@1.1.0",
+      "ref": "nachet-frontend@0.10.4|smtp-address-parser@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|nearley@2.20.1"
+        "nachet-frontend@0.10.4|nearley@2.20.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|socks-proxy-agent@8.0.5",
+      "ref": "nachet-frontend@0.10.4|socks-proxy-agent@8.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|agent-base@7.1.4",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|socks@2.8.7"
+        "nachet-frontend@0.10.4|agent-base@7.1.4",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|socks@2.8.7"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|socks@2.8.7",
+      "ref": "nachet-frontend@0.10.4|socks@2.8.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ip-address@10.0.1",
-        "nachet-frontend@0.10.3|smart-buffer@4.2.0"
+        "nachet-frontend@0.10.4|ip-address@10.0.1",
+        "nachet-frontend@0.10.4|smart-buffer@4.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|source-map-js@1.2.1"
+      "ref": "nachet-frontend@0.10.4|source-map-js@1.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|source-map@0.5.7"
+      "ref": "nachet-frontend@0.10.4|source-map@0.5.7"
     },
     {
-      "ref": "nachet-frontend@0.10.3|spdx-correct@3.2.0",
+      "ref": "nachet-frontend@0.10.4|spdx-correct@3.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|spdx-correct@3.2.0|spdx-expression-parse@3.0.1",
-        "nachet-frontend@0.10.3|spdx-license-ids@3.0.22"
+        "nachet-frontend@0.10.4|spdx-correct@3.2.0|spdx-expression-parse@3.0.1",
+        "nachet-frontend@0.10.4|spdx-license-ids@3.0.22"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|spdx-correct@3.2.0|spdx-expression-parse@3.0.1",
+      "ref": "nachet-frontend@0.10.4|spdx-correct@3.2.0|spdx-expression-parse@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|spdx-exceptions@2.5.0",
-        "nachet-frontend@0.10.3|spdx-license-ids@3.0.22"
+        "nachet-frontend@0.10.4|spdx-exceptions@2.5.0",
+        "nachet-frontend@0.10.4|spdx-license-ids@3.0.22"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|spdx-exceptions@2.5.0"
+      "ref": "nachet-frontend@0.10.4|spdx-exceptions@2.5.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|spdx-expression-parse@4.0.0",
+      "ref": "nachet-frontend@0.10.4|spdx-expression-parse@4.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|spdx-exceptions@2.5.0",
-        "nachet-frontend@0.10.3|spdx-license-ids@3.0.22"
+        "nachet-frontend@0.10.4|spdx-exceptions@2.5.0",
+        "nachet-frontend@0.10.4|spdx-license-ids@3.0.22"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|spdx-license-ids@3.0.22"
+      "ref": "nachet-frontend@0.10.4|spdx-license-ids@3.0.22"
     },
     {
-      "ref": "nachet-frontend@0.10.3|sprintf-js@1.0.3"
+      "ref": "nachet-frontend@0.10.4|sprintf-js@1.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ssri@12.0.0",
+      "ref": "nachet-frontend@0.10.4|ssri@12.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minipass@7.1.2"
+        "nachet-frontend@0.10.4|minipass@7.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|stack-utils@2.0.6",
+      "ref": "nachet-frontend@0.10.4|stack-utils@2.0.6",
       "dependsOn": [
-        "nachet-frontend@0.10.3|stack-utils@2.0.6|escape-string-regexp@2.0.0"
+        "nachet-frontend@0.10.4|stack-utils@2.0.6|escape-string-regexp@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|stack-utils@2.0.6|escape-string-regexp@2.0.0"
+      "ref": "nachet-frontend@0.10.4|stack-utils@2.0.6|escape-string-regexp@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|stackback@0.0.2"
+      "ref": "nachet-frontend@0.10.4|stackback@0.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|statuses@2.0.2"
+      "ref": "nachet-frontend@0.10.4|statuses@2.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|std-env@3.9.0"
+      "ref": "nachet-frontend@0.10.4|std-env@3.9.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|stop-iteration-iterator@1.1.0",
+      "ref": "nachet-frontend@0.10.4|stop-iteration-iterator@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|internal-slot@1.1.0"
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|internal-slot@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string_decoder@1.1.1",
+      "ref": "nachet-frontend@0.10.4|string_decoder@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|string_decoder@1.1.1|safe-buffer@5.1.2"
+        "nachet-frontend@0.10.4|string_decoder@1.1.1|safe-buffer@5.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string_decoder@1.1.1|safe-buffer@5.1.2"
+      "ref": "nachet-frontend@0.10.4|string_decoder@1.1.1|safe-buffer@5.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|string-width@4.2.3",
+      "ref": "nachet-frontend@0.10.4|string-width@4.2.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0",
-        "nachet-frontend@0.10.3|string-width@4.2.3|emoji-regex@8.0.0",
-        "nachet-frontend@0.10.3|string-width@4.2.3|strip-ansi@6.0.1"
+        "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0",
+        "nachet-frontend@0.10.4|string-width@4.2.3|emoji-regex@8.0.0",
+        "nachet-frontend@0.10.4|string-width@4.2.3|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string-width@4.2.3|emoji-regex@8.0.0"
+      "ref": "nachet-frontend@0.10.4|string-width@4.2.3|emoji-regex@8.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|string-width@4.2.3|strip-ansi@6.0.1",
+      "ref": "nachet-frontend@0.10.4|string-width@4.2.3|strip-ansi@6.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string-width@5.1.2",
+      "ref": "nachet-frontend@0.10.4|string-width@5.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|eastasianwidth@0.2.0",
-        "nachet-frontend@0.10.3|emoji-regex@9.2.2",
-        "nachet-frontend@0.10.3|strip-ansi@7.1.2"
+        "nachet-frontend@0.10.4|eastasianwidth@0.2.0",
+        "nachet-frontend@0.10.4|emoji-regex@9.2.2",
+        "nachet-frontend@0.10.4|strip-ansi@7.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string.prototype.matchall@4.0.12",
+      "ref": "nachet-frontend@0.10.4|string.prototype.matchall@4.0.12",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|get-intrinsic@1.3.0",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|internal-slot@1.1.0",
-        "nachet-frontend@0.10.3|regexp.prototype.flags@1.5.4",
-        "nachet-frontend@0.10.3|set-function-name@2.0.2",
-        "nachet-frontend@0.10.3|side-channel@1.1.0"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|get-intrinsic@1.3.0",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|internal-slot@1.1.0",
+        "nachet-frontend@0.10.4|regexp.prototype.flags@1.5.4",
+        "nachet-frontend@0.10.4|set-function-name@2.0.2",
+        "nachet-frontend@0.10.4|side-channel@1.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string.prototype.repeat@1.0.0",
+      "ref": "nachet-frontend@0.10.4|string.prototype.repeat@1.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0"
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string.prototype.trim@1.2.10",
+      "ref": "nachet-frontend@0.10.4|string.prototype.trim@1.2.10",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-data-property@1.1.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-abstract@1.24.0",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1",
-        "nachet-frontend@0.10.3|has-property-descriptors@1.0.2"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-data-property@1.1.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-abstract@1.24.0",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1",
+        "nachet-frontend@0.10.4|has-property-descriptors@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string.prototype.trimend@1.0.9",
+      "ref": "nachet-frontend@0.10.4|string.prototype.trimend@1.0.9",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|string.prototype.trimstart@1.0.8",
+      "ref": "nachet-frontend@0.10.4|string.prototype.trimstart@1.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|define-properties@1.2.1",
-        "nachet-frontend@0.10.3|es-object-atoms@1.1.1"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|define-properties@1.2.1",
+        "nachet-frontend@0.10.4|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-ansi@6.0.1",
+      "ref": "nachet-frontend@0.10.4|strip-ansi@6.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-ansi@7.1.2",
+      "ref": "nachet-frontend@0.10.4|strip-ansi@7.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|strip-ansi@7.1.2|ansi-regex@6.2.2"
+        "nachet-frontend@0.10.4|strip-ansi@7.1.2|ansi-regex@6.2.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-ansi@7.1.2|ansi-regex@6.2.2"
+      "ref": "nachet-frontend@0.10.4|strip-ansi@7.1.2|ansi-regex@6.2.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-bom@3.0.0"
+      "ref": "nachet-frontend@0.10.4|strip-bom@3.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-eof@1.0.0"
+      "ref": "nachet-frontend@0.10.4|strip-eof@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-final-newline@2.0.0"
+      "ref": "nachet-frontend@0.10.4|strip-final-newline@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-indent@3.0.0",
+      "ref": "nachet-frontend@0.10.4|strip-indent@3.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|min-indent@1.0.1"
+        "nachet-frontend@0.10.4|min-indent@1.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-json-comments@3.1.1"
+      "ref": "nachet-frontend@0.10.4|strip-json-comments@3.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-literal@3.0.0",
+      "ref": "nachet-frontend@0.10.4|strip-literal@3.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|strip-literal@3.0.0|js-tokens@9.0.1"
+        "nachet-frontend@0.10.4|strip-literal@3.0.0|js-tokens@9.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|strip-literal@3.0.0|js-tokens@9.0.1"
+      "ref": "nachet-frontend@0.10.4|strip-literal@3.0.0|js-tokens@9.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|styled-components@6.1.19",
+      "ref": "nachet-frontend@0.10.4|styled-components@6.1.19",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/stylis@4.2.5",
-        "nachet-frontend@0.10.3|css-to-react-native@3.2.0",
-        "nachet-frontend@0.10.3|csstype@3.1.3",
-        "nachet-frontend@0.10.3|react-dom@19.1.1",
-        "nachet-frontend@0.10.3|react@19.1.1",
-        "nachet-frontend@0.10.3|shallowequal@1.1.0",
-        "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/is-prop-valid@1.2.2",
-        "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/unitless@0.8.1",
-        "nachet-frontend@0.10.3|styled-components@6.1.19|postcss@8.4.49",
-        "nachet-frontend@0.10.3|styled-components@6.1.19|stylis@4.3.2",
-        "nachet-frontend@0.10.3|tslib@2.6.2"
+        "nachet-frontend@0.10.4|@types/stylis@4.2.5",
+        "nachet-frontend@0.10.4|css-to-react-native@3.2.0",
+        "nachet-frontend@0.10.4|csstype@3.1.3",
+        "nachet-frontend@0.10.4|react-dom@19.1.1",
+        "nachet-frontend@0.10.4|react@19.1.1",
+        "nachet-frontend@0.10.4|shallowequal@1.1.0",
+        "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/is-prop-valid@1.2.2",
+        "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/unitless@0.8.1",
+        "nachet-frontend@0.10.4|styled-components@6.1.19|postcss@8.4.49",
+        "nachet-frontend@0.10.4|styled-components@6.1.19|stylis@4.3.2",
+        "nachet-frontend@0.10.4|tslib@2.6.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/is-prop-valid@1.2.2",
+      "ref": "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/is-prop-valid@1.2.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/memoize@0.8.1"
+        "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/memoize@0.8.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/memoize@0.8.1"
+      "ref": "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/memoize@0.8.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|styled-components@6.1.19|@emotion/unitless@0.8.1"
+      "ref": "nachet-frontend@0.10.4|styled-components@6.1.19|@emotion/unitless@0.8.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|styled-components@6.1.19|postcss@8.4.49",
+      "ref": "nachet-frontend@0.10.4|styled-components@6.1.19|postcss@8.4.49",
       "dependsOn": [
-        "nachet-frontend@0.10.3|nanoid@3.3.11",
-        "nachet-frontend@0.10.3|picocolors@1.1.1",
-        "nachet-frontend@0.10.3|source-map-js@1.2.1"
+        "nachet-frontend@0.10.4|nanoid@3.3.11",
+        "nachet-frontend@0.10.4|picocolors@1.1.1",
+        "nachet-frontend@0.10.4|source-map-js@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|styled-components@6.1.19|stylis@4.3.2"
+      "ref": "nachet-frontend@0.10.4|styled-components@6.1.19|stylis@4.3.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|stylis@4.2.0"
+      "ref": "nachet-frontend@0.10.4|stylis@4.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|supports-color@7.2.0",
+      "ref": "nachet-frontend@0.10.4|supports-color@7.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|has-flag@4.0.0"
+        "nachet-frontend@0.10.4|has-flag@4.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|supports-preserve-symlinks-flag@1.0.0"
+      "ref": "nachet-frontend@0.10.4|supports-preserve-symlinks-flag@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|symbol-tree@3.2.4"
+      "ref": "nachet-frontend@0.10.4|symbol-tree@3.2.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|synckit@0.11.11",
+      "ref": "nachet-frontend@0.10.4|synckit@0.11.11",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@pkgr/core@0.2.9"
+        "nachet-frontend@0.10.4|@pkgr/core@0.2.9"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tar-fs@2.1.3",
+      "ref": "nachet-frontend@0.10.4|tar-fs@2.1.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|mkdirp-classic@0.5.3",
-        "nachet-frontend@0.10.3|pump@3.0.3",
-        "nachet-frontend@0.10.3|tar-fs@2.1.3|chownr@1.1.4",
-        "nachet-frontend@0.10.3|tar-stream@2.2.0"
+        "nachet-frontend@0.10.4|mkdirp-classic@0.5.3",
+        "nachet-frontend@0.10.4|pump@3.0.3",
+        "nachet-frontend@0.10.4|tar-fs@2.1.3|chownr@1.1.4",
+        "nachet-frontend@0.10.4|tar-stream@2.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tar-fs@2.1.3|chownr@1.1.4"
+      "ref": "nachet-frontend@0.10.4|tar-fs@2.1.3|chownr@1.1.4"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tar-stream@2.2.0",
+      "ref": "nachet-frontend@0.10.4|tar-stream@2.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|bl@4.1.0",
-        "nachet-frontend@0.10.3|end-of-stream@1.4.5",
-        "nachet-frontend@0.10.3|fs-constants@1.0.0",
-        "nachet-frontend@0.10.3|inherits@2.0.4",
-        "nachet-frontend@0.10.3|tar-stream@2.2.0|readable-stream@3.6.2"
+        "nachet-frontend@0.10.4|bl@4.1.0",
+        "nachet-frontend@0.10.4|end-of-stream@1.4.5",
+        "nachet-frontend@0.10.4|fs-constants@1.0.0",
+        "nachet-frontend@0.10.4|inherits@2.0.4",
+        "nachet-frontend@0.10.4|tar-stream@2.2.0|readable-stream@3.6.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tar-stream@2.2.0|readable-stream@3.6.2",
+      "ref": "nachet-frontend@0.10.4|tar-stream@2.2.0|readable-stream@3.6.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|inherits@2.0.4",
-        "nachet-frontend@0.10.3|string_decoder@1.1.1",
-        "nachet-frontend@0.10.3|util-deprecate@1.0.2"
+        "nachet-frontend@0.10.4|inherits@2.0.4",
+        "nachet-frontend@0.10.4|string_decoder@1.1.1",
+        "nachet-frontend@0.10.4|util-deprecate@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tar@7.4.3",
+      "ref": "nachet-frontend@0.10.4|tar@7.4.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@isaacs/fs-minipass@4.0.1",
-        "nachet-frontend@0.10.3|chownr@3.0.0",
-        "nachet-frontend@0.10.3|minipass@7.1.2",
-        "nachet-frontend@0.10.3|minizlib@3.0.2",
-        "nachet-frontend@0.10.3|mkdirp@3.0.1",
-        "nachet-frontend@0.10.3|tar@7.4.3|yallist@5.0.0"
+        "nachet-frontend@0.10.4|@isaacs/fs-minipass@4.0.1",
+        "nachet-frontend@0.10.4|chownr@3.0.0",
+        "nachet-frontend@0.10.4|minipass@7.1.2",
+        "nachet-frontend@0.10.4|minizlib@3.0.2",
+        "nachet-frontend@0.10.4|mkdirp@3.0.1",
+        "nachet-frontend@0.10.4|tar@7.4.3|yallist@5.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tar@7.4.3|yallist@5.0.0"
+      "ref": "nachet-frontend@0.10.4|tar@7.4.3|yallist@5.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|test-exclude@7.0.1",
+      "ref": "nachet-frontend@0.10.4|test-exclude@7.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@istanbuljs/schema@0.1.3",
-        "nachet-frontend@0.10.3|glob@10.4.5",
-        "nachet-frontend@0.10.3|test-exclude@7.0.1|minimatch@9.0.5"
+        "nachet-frontend@0.10.4|@istanbuljs/schema@0.1.3",
+        "nachet-frontend@0.10.4|glob@10.4.5",
+        "nachet-frontend@0.10.4|test-exclude@7.0.1|minimatch@9.0.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|test-exclude@7.0.1|brace-expansion@2.0.2",
+      "ref": "nachet-frontend@0.10.4|test-exclude@7.0.1|brace-expansion@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|balanced-match@1.0.2"
+        "nachet-frontend@0.10.4|balanced-match@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|test-exclude@7.0.1|minimatch@9.0.5",
+      "ref": "nachet-frontend@0.10.4|test-exclude@7.0.1|minimatch@9.0.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|test-exclude@7.0.1|brace-expansion@2.0.2"
+        "nachet-frontend@0.10.4|test-exclude@7.0.1|brace-expansion@2.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tinybench@2.9.0"
+      "ref": "nachet-frontend@0.10.4|tinybench@2.9.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tinyexec@0.3.2"
+      "ref": "nachet-frontend@0.10.4|tinyexec@0.3.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tinyglobby@0.2.15",
+      "ref": "nachet-frontend@0.10.4|tinyglobby@0.2.15",
       "dependsOn": [
-        "nachet-frontend@0.10.3|fdir@6.5.0",
-        "nachet-frontend@0.10.3|picomatch@4.0.3"
+        "nachet-frontend@0.10.4|fdir@6.5.0",
+        "nachet-frontend@0.10.4|picomatch@4.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tinypool@1.1.1"
+      "ref": "nachet-frontend@0.10.4|tinypool@1.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tinyrainbow@2.0.0"
+      "ref": "nachet-frontend@0.10.4|tinyrainbow@2.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tinyspy@4.0.3"
+      "ref": "nachet-frontend@0.10.4|tinyspy@4.0.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tldts-core@6.1.86"
+      "ref": "nachet-frontend@0.10.4|tldts-core@6.1.86"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tldts@6.1.86",
+      "ref": "nachet-frontend@0.10.4|tldts@6.1.86",
       "dependsOn": [
-        "nachet-frontend@0.10.3|tldts-core@6.1.86"
+        "nachet-frontend@0.10.4|tldts-core@6.1.86"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|to-regex-range@5.0.1",
+      "ref": "nachet-frontend@0.10.4|to-regex-range@5.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-number@7.0.0"
+        "nachet-frontend@0.10.4|is-number@7.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|toidentifier@1.0.1"
+      "ref": "nachet-frontend@0.10.4|toidentifier@1.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tough-cookie@5.1.2",
+      "ref": "nachet-frontend@0.10.4|tough-cookie@5.1.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|tldts@6.1.86"
+        "nachet-frontend@0.10.4|tldts@6.1.86"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tr46@5.1.1",
+      "ref": "nachet-frontend@0.10.4|tr46@5.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|punycode@2.3.1"
+        "nachet-frontend@0.10.4|punycode@2.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|ts-api-utils@2.1.0",
+      "ref": "nachet-frontend@0.10.4|ts-api-utils@2.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|typescript@5.9.2"
+        "nachet-frontend@0.10.4|typescript@5.9.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tsconfig-paths@3.15.0",
+      "ref": "nachet-frontend@0.10.4|tsconfig-paths@3.15.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/json5@0.0.29",
-        "nachet-frontend@0.10.3|minimist@1.2.8",
-        "nachet-frontend@0.10.3|strip-bom@3.0.0",
-        "nachet-frontend@0.10.3|tsconfig-paths@3.15.0|json5@1.0.2"
+        "nachet-frontend@0.10.4|@types/json5@0.0.29",
+        "nachet-frontend@0.10.4|minimist@1.2.8",
+        "nachet-frontend@0.10.4|strip-bom@3.0.0",
+        "nachet-frontend@0.10.4|tsconfig-paths@3.15.0|json5@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tsconfig-paths@3.15.0|json5@1.0.2",
+      "ref": "nachet-frontend@0.10.4|tsconfig-paths@3.15.0|json5@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|minimist@1.2.8"
+        "nachet-frontend@0.10.4|minimist@1.2.8"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|tslib@2.6.2"
+      "ref": "nachet-frontend@0.10.4|tslib@2.6.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|tunnel-agent@0.6.0",
+      "ref": "nachet-frontend@0.10.4|tunnel-agent@0.6.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|safe-buffer@5.2.1"
+        "nachet-frontend@0.10.4|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|type-check@0.4.0",
+      "ref": "nachet-frontend@0.10.4|type-check@0.4.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|prelude-ls@1.2.1"
+        "nachet-frontend@0.10.4|prelude-ls@1.2.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|type-detect@4.0.8"
+      "ref": "nachet-frontend@0.10.4|type-detect@4.0.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|type-fest@2.19.0"
+      "ref": "nachet-frontend@0.10.4|type-fest@2.19.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|type-is@2.0.1",
+      "ref": "nachet-frontend@0.10.4|type-is@2.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|content-type@1.0.5",
-        "nachet-frontend@0.10.3|media-typer@1.1.0",
-        "nachet-frontend@0.10.3|mime-types@3.0.1"
+        "nachet-frontend@0.10.4|content-type@1.0.5",
+        "nachet-frontend@0.10.4|media-typer@1.1.0",
+        "nachet-frontend@0.10.4|mime-types@3.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|typed-array-buffer@1.0.3",
+      "ref": "nachet-frontend@0.10.4|typed-array-buffer@1.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|es-errors@1.3.0",
-        "nachet-frontend@0.10.3|is-typed-array@1.1.15"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|es-errors@1.3.0",
+        "nachet-frontend@0.10.4|is-typed-array@1.1.15"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|typed-array-byte-length@1.0.3",
+      "ref": "nachet-frontend@0.10.4|typed-array-byte-length@1.0.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|for-each@0.3.5",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-proto@1.2.0",
-        "nachet-frontend@0.10.3|is-typed-array@1.1.15"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|for-each@0.3.5",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-proto@1.2.0",
+        "nachet-frontend@0.10.4|is-typed-array@1.1.15"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|typed-array-byte-offset@1.0.4",
+      "ref": "nachet-frontend@0.10.4|typed-array-byte-offset@1.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|available-typed-arrays@1.0.7",
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|for-each@0.3.5",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-proto@1.2.0",
-        "nachet-frontend@0.10.3|is-typed-array@1.1.15",
-        "nachet-frontend@0.10.3|reflect.getprototypeof@1.0.10"
+        "nachet-frontend@0.10.4|available-typed-arrays@1.0.7",
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|for-each@0.3.5",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-proto@1.2.0",
+        "nachet-frontend@0.10.4|is-typed-array@1.1.15",
+        "nachet-frontend@0.10.4|reflect.getprototypeof@1.0.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|typed-array-length@1.0.7",
+      "ref": "nachet-frontend@0.10.4|typed-array-length@1.0.7",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|for-each@0.3.5",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|is-typed-array@1.1.15",
-        "nachet-frontend@0.10.3|possible-typed-array-names@1.1.0",
-        "nachet-frontend@0.10.3|reflect.getprototypeof@1.0.10"
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|for-each@0.3.5",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|is-typed-array@1.1.15",
+        "nachet-frontend@0.10.4|possible-typed-array-names@1.1.0",
+        "nachet-frontend@0.10.4|reflect.getprototypeof@1.0.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|typescript@5.9.2"
+      "ref": "nachet-frontend@0.10.4|typescript@5.9.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|unbox-primitive@1.1.0",
+      "ref": "nachet-frontend@0.10.4|unbox-primitive@1.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|has-bigints@1.1.0",
-        "nachet-frontend@0.10.3|has-symbols@1.1.0",
-        "nachet-frontend@0.10.3|which-boxed-primitive@1.1.1"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|has-bigints@1.1.0",
+        "nachet-frontend@0.10.4|has-symbols@1.1.0",
+        "nachet-frontend@0.10.4|which-boxed-primitive@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|undici-types@6.21.0"
+      "ref": "nachet-frontend@0.10.4|undici-types@6.21.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|unicode-canonical-property-names-ecmascript@2.0.1"
+      "ref": "nachet-frontend@0.10.4|unicode-canonical-property-names-ecmascript@2.0.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|unicode-match-property-ecmascript@2.0.0",
+      "ref": "nachet-frontend@0.10.4|unicode-match-property-ecmascript@2.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|unicode-canonical-property-names-ecmascript@2.0.1",
-        "nachet-frontend@0.10.3|unicode-property-aliases-ecmascript@2.2.0"
+        "nachet-frontend@0.10.4|unicode-canonical-property-names-ecmascript@2.0.1",
+        "nachet-frontend@0.10.4|unicode-property-aliases-ecmascript@2.2.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|unicode-match-property-value-ecmascript@2.2.1"
+      "ref": "nachet-frontend@0.10.4|unicode-match-property-value-ecmascript@2.2.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|unicode-property-aliases-ecmascript@2.2.0"
+      "ref": "nachet-frontend@0.10.4|unicode-property-aliases-ecmascript@2.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|unique-filename@4.0.0",
+      "ref": "nachet-frontend@0.10.4|unique-filename@4.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|unique-slug@5.0.0"
+        "nachet-frontend@0.10.4|unique-slug@5.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|unique-slug@5.0.0",
+      "ref": "nachet-frontend@0.10.4|unique-slug@5.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|imurmurhash@0.1.4"
+        "nachet-frontend@0.10.4|imurmurhash@0.1.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|unpipe@1.0.0"
+      "ref": "nachet-frontend@0.10.4|unpipe@1.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|update-browserslist-db@1.1.3",
+      "ref": "nachet-frontend@0.10.4|update-browserslist-db@1.1.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|browserslist@4.26.2",
-        "nachet-frontend@0.10.3|escalade@3.2.0",
-        "nachet-frontend@0.10.3|picocolors@1.1.1"
+        "nachet-frontend@0.10.4|browserslist@4.26.2",
+        "nachet-frontend@0.10.4|escalade@3.2.0",
+        "nachet-frontend@0.10.4|picocolors@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|update-check@1.5.4",
+      "ref": "nachet-frontend@0.10.4|update-check@1.5.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|registry-auth-token@3.3.2",
-        "nachet-frontend@0.10.3|registry-url@3.1.0"
+        "nachet-frontend@0.10.4|registry-auth-token@3.3.2",
+        "nachet-frontend@0.10.4|registry-url@3.1.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|uri-js@4.4.1",
+      "ref": "nachet-frontend@0.10.4|uri-js@4.4.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|punycode@2.3.1"
+        "nachet-frontend@0.10.4|punycode@2.3.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|utif@3.1.0",
+      "ref": "nachet-frontend@0.10.4|utif@3.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|utif@3.1.0|pako@1.0.11"
+        "nachet-frontend@0.10.4|utif@3.1.0|pako@1.0.11"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|utif@3.1.0|pako@1.0.11"
+      "ref": "nachet-frontend@0.10.4|utif@3.1.0|pako@1.0.11"
     },
     {
-      "ref": "nachet-frontend@0.10.3|util-deprecate@1.0.2"
+      "ref": "nachet-frontend@0.10.4|util-deprecate@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|uuid@11.1.0"
+      "ref": "nachet-frontend@0.10.4|uuid@11.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|uzip@0.20201231.0"
+      "ref": "nachet-frontend@0.10.4|uzip@0.20201231.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|validate-npm-package-license@3.0.4",
+      "ref": "nachet-frontend@0.10.4|validate-npm-package-license@3.0.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|spdx-correct@3.2.0",
-        "nachet-frontend@0.10.3|validate-npm-package-license@3.0.4|spdx-expression-parse@3.0.1"
+        "nachet-frontend@0.10.4|spdx-correct@3.2.0",
+        "nachet-frontend@0.10.4|validate-npm-package-license@3.0.4|spdx-expression-parse@3.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|validate-npm-package-license@3.0.4|spdx-expression-parse@3.0.1",
+      "ref": "nachet-frontend@0.10.4|validate-npm-package-license@3.0.4|spdx-expression-parse@3.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|spdx-exceptions@2.5.0",
-        "nachet-frontend@0.10.3|spdx-license-ids@3.0.22"
+        "nachet-frontend@0.10.4|spdx-exceptions@2.5.0",
+        "nachet-frontend@0.10.4|spdx-license-ids@3.0.22"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|vary@1.1.2"
+      "ref": "nachet-frontend@0.10.4|vary@1.1.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|vite-node@3.2.4",
+      "ref": "nachet-frontend@0.10.4|vite-node@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cac@6.7.14",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|es-module-lexer@1.7.0",
-        "nachet-frontend@0.10.3|pathe@2.0.3",
-        "nachet-frontend@0.10.3|vite@7.1.5"
+        "nachet-frontend@0.10.4|cac@6.7.14",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|es-module-lexer@1.7.0",
+        "nachet-frontend@0.10.4|pathe@2.0.3",
+        "nachet-frontend@0.10.4|vite@7.1.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|vite-plugin-environment@1.1.3",
+      "ref": "nachet-frontend@0.10.4|vite-plugin-environment@1.1.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|vite@7.1.5"
+        "nachet-frontend@0.10.4|vite@7.1.5"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|vite@7.1.5",
+      "ref": "nachet-frontend@0.10.4|vite@7.1.5",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|esbuild@0.25.9",
-        "nachet-frontend@0.10.3|fdir@6.5.0",
-        "nachet-frontend@0.10.3|picomatch@4.0.3",
-        "nachet-frontend@0.10.3|postcss@8.5.6",
-        "nachet-frontend@0.10.3|rollup@4.50.2",
-        "nachet-frontend@0.10.3|tinyglobby@0.2.15",
-        "nachet-frontend@0.10.3|vite@7.1.5|fsevents@2.3.3"
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|esbuild@0.25.9",
+        "nachet-frontend@0.10.4|fdir@6.5.0",
+        "nachet-frontend@0.10.4|picomatch@4.0.3",
+        "nachet-frontend@0.10.4|postcss@8.5.6",
+        "nachet-frontend@0.10.4|rollup@4.50.2",
+        "nachet-frontend@0.10.4|tinyglobby@0.2.15",
+        "nachet-frontend@0.10.4|vite@7.1.5|fsevents@2.3.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|vite@7.1.5|fsevents@2.3.3"
+      "ref": "nachet-frontend@0.10.4|vite@7.1.5|fsevents@2.3.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|vitest@3.2.4",
+      "ref": "nachet-frontend@0.10.4|vitest@3.2.4",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/chai@5.2.2",
-        "nachet-frontend@0.10.3|@types/node@22.18.4",
-        "nachet-frontend@0.10.3|@vitest/expect@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/mocker@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/pretty-format@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/runner@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/snapshot@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/spy@3.2.4",
-        "nachet-frontend@0.10.3|@vitest/utils@3.2.4",
-        "nachet-frontend@0.10.3|chai@5.3.3",
-        "nachet-frontend@0.10.3|debug@4.4.3",
-        "nachet-frontend@0.10.3|expect-type@1.2.2",
-        "nachet-frontend@0.10.3|jsdom@26.1.0",
-        "nachet-frontend@0.10.3|magic-string@0.30.19",
-        "nachet-frontend@0.10.3|pathe@2.0.3",
-        "nachet-frontend@0.10.3|picomatch@4.0.3",
-        "nachet-frontend@0.10.3|std-env@3.9.0",
-        "nachet-frontend@0.10.3|tinybench@2.9.0",
-        "nachet-frontend@0.10.3|tinyexec@0.3.2",
-        "nachet-frontend@0.10.3|tinyglobby@0.2.15",
-        "nachet-frontend@0.10.3|tinypool@1.1.1",
-        "nachet-frontend@0.10.3|tinyrainbow@2.0.0",
-        "nachet-frontend@0.10.3|vite-node@3.2.4",
-        "nachet-frontend@0.10.3|vite@7.1.5",
-        "nachet-frontend@0.10.3|why-is-node-running@2.3.0"
+        "nachet-frontend@0.10.4|@types/chai@5.2.2",
+        "nachet-frontend@0.10.4|@types/node@22.18.5",
+        "nachet-frontend@0.10.4|@vitest/expect@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/mocker@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/pretty-format@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/runner@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/snapshot@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/spy@3.2.4",
+        "nachet-frontend@0.10.4|@vitest/utils@3.2.4",
+        "nachet-frontend@0.10.4|chai@5.3.3",
+        "nachet-frontend@0.10.4|debug@4.4.3",
+        "nachet-frontend@0.10.4|expect-type@1.2.2",
+        "nachet-frontend@0.10.4|jsdom@26.1.0",
+        "nachet-frontend@0.10.4|magic-string@0.30.19",
+        "nachet-frontend@0.10.4|pathe@2.0.3",
+        "nachet-frontend@0.10.4|picomatch@4.0.3",
+        "nachet-frontend@0.10.4|std-env@3.9.0",
+        "nachet-frontend@0.10.4|tinybench@2.9.0",
+        "nachet-frontend@0.10.4|tinyexec@0.3.2",
+        "nachet-frontend@0.10.4|tinyglobby@0.2.15",
+        "nachet-frontend@0.10.4|tinypool@1.1.1",
+        "nachet-frontend@0.10.4|tinyrainbow@2.0.0",
+        "nachet-frontend@0.10.4|vite-node@3.2.4",
+        "nachet-frontend@0.10.4|vite@7.1.5",
+        "nachet-frontend@0.10.4|why-is-node-running@2.3.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|w3c-xmlserializer@5.0.0",
+      "ref": "nachet-frontend@0.10.4|w3c-xmlserializer@5.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|xml-name-validator@5.0.0"
+        "nachet-frontend@0.10.4|xml-name-validator@5.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|web-streams-polyfill@3.3.3"
+      "ref": "nachet-frontend@0.10.4|web-streams-polyfill@3.3.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|web-vitals@5.1.0"
+      "ref": "nachet-frontend@0.10.4|web-vitals@5.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|webidl-conversions@7.0.0"
+      "ref": "nachet-frontend@0.10.4|webidl-conversions@7.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|whatwg-encoding@3.1.1",
+      "ref": "nachet-frontend@0.10.4|whatwg-encoding@3.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|iconv-lite@0.6.3"
+        "nachet-frontend@0.10.4|iconv-lite@0.6.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|whatwg-mimetype@4.0.0"
+      "ref": "nachet-frontend@0.10.4|whatwg-mimetype@4.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|whatwg-url@14.2.0",
+      "ref": "nachet-frontend@0.10.4|whatwg-url@14.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|tr46@5.1.1",
-        "nachet-frontend@0.10.3|webidl-conversions@7.0.0"
+        "nachet-frontend@0.10.4|tr46@5.1.1",
+        "nachet-frontend@0.10.4|webidl-conversions@7.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|which-boxed-primitive@1.1.1",
+      "ref": "nachet-frontend@0.10.4|which-boxed-primitive@1.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-bigint@1.1.0",
-        "nachet-frontend@0.10.3|is-boolean-object@1.2.2",
-        "nachet-frontend@0.10.3|is-number-object@1.1.1",
-        "nachet-frontend@0.10.3|is-string@1.1.1",
-        "nachet-frontend@0.10.3|is-symbol@1.1.1"
+        "nachet-frontend@0.10.4|is-bigint@1.1.0",
+        "nachet-frontend@0.10.4|is-boolean-object@1.2.2",
+        "nachet-frontend@0.10.4|is-number-object@1.1.1",
+        "nachet-frontend@0.10.4|is-string@1.1.1",
+        "nachet-frontend@0.10.4|is-symbol@1.1.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|which-builtin-type@1.2.1",
+      "ref": "nachet-frontend@0.10.4|which-builtin-type@1.2.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|function.prototype.name@1.1.8",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2",
-        "nachet-frontend@0.10.3|is-async-function@2.1.1",
-        "nachet-frontend@0.10.3|is-date-object@1.1.0",
-        "nachet-frontend@0.10.3|is-finalizationregistry@1.1.1",
-        "nachet-frontend@0.10.3|is-generator-function@1.1.0",
-        "nachet-frontend@0.10.3|is-regex@1.2.1",
-        "nachet-frontend@0.10.3|is-weakref@1.1.1",
-        "nachet-frontend@0.10.3|which-boxed-primitive@1.1.1",
-        "nachet-frontend@0.10.3|which-builtin-type@1.2.1|isarray@2.0.5",
-        "nachet-frontend@0.10.3|which-collection@1.0.2",
-        "nachet-frontend@0.10.3|which-typed-array@1.1.19"
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|function.prototype.name@1.1.8",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2",
+        "nachet-frontend@0.10.4|is-async-function@2.1.1",
+        "nachet-frontend@0.10.4|is-date-object@1.1.0",
+        "nachet-frontend@0.10.4|is-finalizationregistry@1.1.1",
+        "nachet-frontend@0.10.4|is-generator-function@1.1.0",
+        "nachet-frontend@0.10.4|is-regex@1.2.1",
+        "nachet-frontend@0.10.4|is-weakref@1.1.1",
+        "nachet-frontend@0.10.4|which-boxed-primitive@1.1.1",
+        "nachet-frontend@0.10.4|which-builtin-type@1.2.1|isarray@2.0.5",
+        "nachet-frontend@0.10.4|which-collection@1.0.2",
+        "nachet-frontend@0.10.4|which-typed-array@1.1.19"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|which-builtin-type@1.2.1|isarray@2.0.5"
+      "ref": "nachet-frontend@0.10.4|which-builtin-type@1.2.1|isarray@2.0.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|which-collection@1.0.2",
+      "ref": "nachet-frontend@0.10.4|which-collection@1.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-map@2.0.3",
-        "nachet-frontend@0.10.3|is-set@2.0.3",
-        "nachet-frontend@0.10.3|is-weakmap@2.0.2",
-        "nachet-frontend@0.10.3|is-weakset@2.0.4"
+        "nachet-frontend@0.10.4|is-map@2.0.3",
+        "nachet-frontend@0.10.4|is-set@2.0.3",
+        "nachet-frontend@0.10.4|is-weakmap@2.0.2",
+        "nachet-frontend@0.10.4|is-weakset@2.0.4"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|which-typed-array@1.1.19",
+      "ref": "nachet-frontend@0.10.4|which-typed-array@1.1.19",
       "dependsOn": [
-        "nachet-frontend@0.10.3|available-typed-arrays@1.0.7",
-        "nachet-frontend@0.10.3|call-bind@1.0.8",
-        "nachet-frontend@0.10.3|call-bound@1.0.4",
-        "nachet-frontend@0.10.3|for-each@0.3.5",
-        "nachet-frontend@0.10.3|get-proto@1.0.1",
-        "nachet-frontend@0.10.3|gopd@1.2.0",
-        "nachet-frontend@0.10.3|has-tostringtag@1.0.2"
+        "nachet-frontend@0.10.4|available-typed-arrays@1.0.7",
+        "nachet-frontend@0.10.4|call-bind@1.0.8",
+        "nachet-frontend@0.10.4|call-bound@1.0.4",
+        "nachet-frontend@0.10.4|for-each@0.3.5",
+        "nachet-frontend@0.10.4|get-proto@1.0.1",
+        "nachet-frontend@0.10.4|gopd@1.2.0",
+        "nachet-frontend@0.10.4|has-tostringtag@1.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|which@2.0.2",
+      "ref": "nachet-frontend@0.10.4|which@2.0.2",
       "dependsOn": [
-        "nachet-frontend@0.10.3|isexe@2.0.0"
+        "nachet-frontend@0.10.4|isexe@2.0.0"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|why-is-node-running@2.3.0",
+      "ref": "nachet-frontend@0.10.4|why-is-node-running@2.3.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|siginfo@2.0.0",
-        "nachet-frontend@0.10.3|stackback@0.0.2"
+        "nachet-frontend@0.10.4|siginfo@2.0.0",
+        "nachet-frontend@0.10.4|stackback@0.0.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|widest-line@4.0.1",
+      "ref": "nachet-frontend@0.10.4|widest-line@4.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|string-width@5.1.2"
+        "nachet-frontend@0.10.4|string-width@5.1.2"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|word-wrap@1.2.5"
+      "ref": "nachet-frontend@0.10.4|word-wrap@1.2.5"
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0",
+      "ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-styles@4.3.0",
-        "nachet-frontend@0.10.3|wrap-ansi@7.0.0|string-width@4.2.3",
-        "nachet-frontend@0.10.3|wrap-ansi@7.0.0|strip-ansi@6.0.1"
+        "nachet-frontend@0.10.4|ansi-styles@4.3.0",
+        "nachet-frontend@0.10.4|wrap-ansi@7.0.0|string-width@4.2.3",
+        "nachet-frontend@0.10.4|wrap-ansi@7.0.0|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0|emoji-regex@8.0.0"
+      "ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0|emoji-regex@8.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0|string-width@4.2.3",
+      "ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0|string-width@4.2.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0",
-        "nachet-frontend@0.10.3|wrap-ansi@7.0.0|emoji-regex@8.0.0",
-        "nachet-frontend@0.10.3|wrap-ansi@7.0.0|strip-ansi@6.0.1"
+        "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0",
+        "nachet-frontend@0.10.4|wrap-ansi@7.0.0|emoji-regex@8.0.0",
+        "nachet-frontend@0.10.4|wrap-ansi@7.0.0|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrap-ansi@7.0.0|strip-ansi@6.0.1",
+      "ref": "nachet-frontend@0.10.4|wrap-ansi@7.0.0|strip-ansi@6.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrap-ansi@8.1.0",
+      "ref": "nachet-frontend@0.10.4|wrap-ansi@8.1.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|string-width@5.1.2",
-        "nachet-frontend@0.10.3|strip-ansi@7.1.2",
-        "nachet-frontend@0.10.3|wrap-ansi@8.1.0|ansi-styles@6.2.3"
+        "nachet-frontend@0.10.4|string-width@5.1.2",
+        "nachet-frontend@0.10.4|strip-ansi@7.1.2",
+        "nachet-frontend@0.10.4|wrap-ansi@8.1.0|ansi-styles@6.2.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrap-ansi@8.1.0|ansi-styles@6.2.3"
+      "ref": "nachet-frontend@0.10.4|wrap-ansi@8.1.0|ansi-styles@6.2.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|wrappy@1.0.2"
+      "ref": "nachet-frontend@0.10.4|wrappy@1.0.2"
     },
     {
-      "ref": "nachet-frontend@0.10.3|ws@8.18.3"
+      "ref": "nachet-frontend@0.10.4|ws@8.18.3"
     },
     {
-      "ref": "nachet-frontend@0.10.3|xml-name-validator@5.0.0"
+      "ref": "nachet-frontend@0.10.4|xml-name-validator@5.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|xmlbuilder2@3.1.1",
+      "ref": "nachet-frontend@0.10.4|xmlbuilder2@3.1.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@oozcitak/dom@1.15.10",
-        "nachet-frontend@0.10.3|@oozcitak/infra@1.0.8",
-        "nachet-frontend@0.10.3|@oozcitak/util@8.3.8",
-        "nachet-frontend@0.10.3|xmlbuilder2@3.1.1|js-yaml@3.14.1"
+        "nachet-frontend@0.10.4|@oozcitak/dom@1.15.10",
+        "nachet-frontend@0.10.4|@oozcitak/infra@1.0.8",
+        "nachet-frontend@0.10.4|@oozcitak/util@8.3.8",
+        "nachet-frontend@0.10.4|xmlbuilder2@3.1.1|js-yaml@3.14.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|xmlbuilder2@3.1.1|argparse@1.0.10",
+      "ref": "nachet-frontend@0.10.4|xmlbuilder2@3.1.1|argparse@1.0.10",
       "dependsOn": [
-        "nachet-frontend@0.10.3|sprintf-js@1.0.3"
+        "nachet-frontend@0.10.4|sprintf-js@1.0.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|xmlbuilder2@3.1.1|js-yaml@3.14.1",
+      "ref": "nachet-frontend@0.10.4|xmlbuilder2@3.1.1|js-yaml@3.14.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|esprima@4.0.1",
-        "nachet-frontend@0.10.3|xmlbuilder2@3.1.1|argparse@1.0.10"
+        "nachet-frontend@0.10.4|esprima@4.0.1",
+        "nachet-frontend@0.10.4|xmlbuilder2@3.1.1|argparse@1.0.10"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|xmlchars@2.2.0"
+      "ref": "nachet-frontend@0.10.4|xmlchars@2.2.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|y18n@5.0.8"
+      "ref": "nachet-frontend@0.10.4|y18n@5.0.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|yallist@3.1.1"
+      "ref": "nachet-frontend@0.10.4|yallist@3.1.1"
     },
     {
-      "ref": "nachet-frontend@0.10.3|yargs-parser@20.2.9"
+      "ref": "nachet-frontend@0.10.4|yargs-parser@20.2.9"
     },
     {
-      "ref": "nachet-frontend@0.10.3|yargs@16.2.0",
+      "ref": "nachet-frontend@0.10.4|yargs@16.2.0",
       "dependsOn": [
-        "nachet-frontend@0.10.3|cliui@7.0.4",
-        "nachet-frontend@0.10.3|escalade@3.2.0",
-        "nachet-frontend@0.10.3|get-caller-file@2.0.5",
-        "nachet-frontend@0.10.3|require-directory@2.1.1",
-        "nachet-frontend@0.10.3|y18n@5.0.8",
-        "nachet-frontend@0.10.3|yargs-parser@20.2.9",
-        "nachet-frontend@0.10.3|yargs@16.2.0|string-width@4.2.3"
+        "nachet-frontend@0.10.4|cliui@7.0.4",
+        "nachet-frontend@0.10.4|escalade@3.2.0",
+        "nachet-frontend@0.10.4|get-caller-file@2.0.5",
+        "nachet-frontend@0.10.4|require-directory@2.1.1",
+        "nachet-frontend@0.10.4|y18n@5.0.8",
+        "nachet-frontend@0.10.4|yargs-parser@20.2.9",
+        "nachet-frontend@0.10.4|yargs@16.2.0|string-width@4.2.3"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|yargs@16.2.0|emoji-regex@8.0.0"
+      "ref": "nachet-frontend@0.10.4|yargs@16.2.0|emoji-regex@8.0.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|yargs@16.2.0|string-width@4.2.3",
+      "ref": "nachet-frontend@0.10.4|yargs@16.2.0|string-width@4.2.3",
       "dependsOn": [
-        "nachet-frontend@0.10.3|is-fullwidth-code-point@3.0.0",
-        "nachet-frontend@0.10.3|yargs@16.2.0|emoji-regex@8.0.0",
-        "nachet-frontend@0.10.3|yargs@16.2.0|strip-ansi@6.0.1"
+        "nachet-frontend@0.10.4|is-fullwidth-code-point@3.0.0",
+        "nachet-frontend@0.10.4|yargs@16.2.0|emoji-regex@8.0.0",
+        "nachet-frontend@0.10.4|yargs@16.2.0|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|yargs@16.2.0|strip-ansi@6.0.1",
+      "ref": "nachet-frontend@0.10.4|yargs@16.2.0|strip-ansi@6.0.1",
       "dependsOn": [
-        "nachet-frontend@0.10.3|ansi-regex@5.0.1"
+        "nachet-frontend@0.10.4|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "nachet-frontend@0.10.3|yocto-queue@0.1.0"
+      "ref": "nachet-frontend@0.10.4|yocto-queue@0.1.0"
     },
     {
-      "ref": "nachet-frontend@0.10.3|zod@4.1.8"
+      "ref": "nachet-frontend@0.10.4|zod@4.1.8"
     },
     {
-      "ref": "nachet-frontend@0.10.3|zustand@5.0.8",
+      "ref": "nachet-frontend@0.10.4|zustand@5.0.8",
       "dependsOn": [
-        "nachet-frontend@0.10.3|@types/react@19.1.13",
-        "nachet-frontend@0.10.3|react@19.1.1"
+        "nachet-frontend@0.10.4|@types/react@19.1.13",
+        "nachet-frontend@0.10.4|react@19.1.1"
       ]
     }
   ]


### PR DESCRIPTION
closes #322

This pull request primarily updates dependencies and GitHub Actions used in CI/CD workflows to their latest versions. These changes help ensure better security, compatibility, and access to the latest features and bug fixes.

**Dependency updates (Frontend):**
- Bumped the `nachet-frontend` package version from `0.10.3` to `0.10.4` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)
- Updated several frontend devDependencies to their latest patch versions, including `@babel/preset-env`, `@types/node`, `@types/react`, and `@types/react-dom` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L75-R75) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L86-R89) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL49-R49) [[4]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL60-R63) [[5]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3937-R3941)

**CI/CD workflow action updates:**
- Updated the `anchore/scan-action` version in `.github/workflows/frontend-lint.yml` for improved SBOM security scanning.
- Updated the `EndBug/add-and-commit` and `ncipollo/release-action` versions in `.github/workflows/frontend-release.yml` for more reliable release automation. [[1]](diffhunk://#diff-b0d8cc02829769a10fb635778193800dceaf2af4c2fdc1afd6bf28f5ce9cb8f5L116-R116) [[2]](diffhunk://#diff-b0d8cc02829769a10fb635778193800dceaf2af4c2fdc1afd6bf28f5ce9cb8f5L205-R205)
- Updated the `sigstore/cosign-installer` and `softprops/action-gh-release` versions in `.github/workflows/prod-build-sign-deploy.yml` to ensure secure artifact signing and release creation. [[1]](diffhunk://#diff-d57c035fc9d863ff57693650de09c6a6e36b39d12a421dcae103ebfe21a040eaL53-R53) [[2]](diffhunk://#diff-d57c035fc9d863ff57693650de09c6a6e36b39d12a421dcae103ebfe21a040eaL120-R120) [[3]](diffhunk://#diff-d57c035fc9d863ff57693650de09c6a6e36b39d12a421dcae103ebfe21a040eaL155-R155)
- Updated the `trufflesecurity/trufflehog` action version in `.github/workflows/trufflehog.yml` for improved secret scanning.