### PR TITLE
Issue 326 renovate group pull requests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,11 @@
   "packageRules": [
     {
       "matchDepTypes": ["*"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
closes #326

This pull request updates the dependency management configuration in `renovate.json` to improve how Renovate handles updates. The main change is grouping all minor and patch updates for any dependency into a single pull request, making dependency updates easier to review and manage.

**Dependency update configuration:**

* Updated the package rule to group all minor and patch updates for any dependency into a pull request with the group name "all non-major dependencies" and group slug "all-minor-patch".