### PR TITLE
344 renovate monorepo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,24 @@
     {
       "matchDepTypes": ["*"],
       "matchUpdateTypes": ["major"],
+      "groupName": "frontend workflows major dependencies",
+      "groupSlug": "frontend-workflows-major",
+      "matchPackageNames": ["*"],
+      "matchFileNames": [".github/workflows/frontend-*"]
+    },
+
+    {
+      "matchDepTypes": ["*"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "backend workflows major dependencies",
+      "groupSlug": "backend-workflows-major",
+      "matchPackageNames": ["*"],
+      "matchFileNames": [".github/workflows/backend-*"]
+    },
+
+    {
+      "matchDepTypes": ["*"],
+      "matchUpdateTypes": ["major"],
       "groupName": "frontend major dependencies",
       "groupSlug": "frontend-major",
       "matchPackageNames": ["*"],
@@ -38,6 +56,16 @@
       "groupSlug": "backend-major",
       "matchPackageNames": ["*"],
       "matchFileNames": ["backend/**"]
+    },
+
+    {
+      "matchDepTypes": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "other minor dependencies",
+      "groupSlug": "other-minor",
+      "matchConfidence": ["low", "neutral"],
+      "matchPackageNames": ["*"],
+      "matchFileNames": ["*"]
     }
   ]
 }


### PR DESCRIPTION
closes #344 

This pull request updates the `renovate.json` configuration to provide more granular control over how dependency updates are grouped and managed. The changes introduce separate rules for frontend, backend, and workflow dependencies, distinguishing between major and non-major updates and setting confidence levels for grouping.

Dependency grouping and configuration improvements:

* Added separate grouping rules for frontend and backend dependencies, splitting minor/patch and major updates, and applying these groups based on file paths (`frontend/**`, `backend/**`).
* Introduced grouping for major dependency updates in workflow files, with distinct groups for frontend and backend workflows (`.github/workflows/frontend-*`, `.github/workflows/backend-*`).
* Implemented confidence-based grouping for non-major updates, so only high-confidence updates are grouped for frontend/backend, while low/neutral confidence updates fall into an "other minor dependencies" group.