### PR TITLE
585 Add automatic version incrementation for renovate PRs

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -69,12 +69,12 @@ jobs:
           uv version --bump patch
 
       - name: Commit & push changes
-        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5
+        uses: EndBug/add-and-commit@62806537b45381f4b1475ec463d5e2106d9d3110
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: "chore: bump backend version"
-          branch: ${{ github.head_ref || github.ref_name }}
-          rebase: true
+          message: "chore: bump backend version for Renovate PRs"
+          add: "."
+          author_name: "github-actions"
+          author_email: "actions@github.com"
 
   backend-lint:
     name: backend-lint-test-python

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -67,12 +67,12 @@ jobs:
           echo "new version: $(jq -r '.version' package.json)"
 
       - name: Commit & push changes
-        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5
+        uses: EndBug/add-and-commit@62806537b45381f4b1475ec463d5e2106d9d3110
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: "chore: bump frontend version"
-          branch: ${{ github.head_ref || github.ref_name }}
-          rebase: true
+          message: "chore: bump frontend version for Renovate PRs"
+          add: "."
+          author_name: "github-actions"
+          author_email: "actions@github.com"
 
 
   check-package-lock:


### PR DESCRIPTION
When a PR is opened, as part of the linting process, the commit author is checked to be renovate[bot] and the need for a bump is verified. If both return true, the necessary version is bumped with the according process (uv/npm) before being commited.