### PR TITLE
Issue #795: Increase Nachet Mini image size limit

### DIFF
--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/nachet-mini/src/_versions.ts
+++ b/nachet-mini/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
   gitTag?: string;
 }
 export const versions: TsAppVersion = {
-  version: "0.10.5",
+  version: "0.10.6",
   name: "nachet-mini",
-  versionDate: "2026-05-12T14:47:43.526Z",
+  versionDate: "2026-05-28T15:07:58.000Z",
 };
 export default versions;

--- a/nachet-mini/src/common/imageutils.ts
+++ b/nachet-mini/src/common/imageutils.ts
@@ -46,8 +46,11 @@ interface ImageValidationResult {
   };
 }
 
+const MAX_IMAGE_WIDTH = 8000;
+const MAX_IMAGE_HEIGHT = 8000;
+
 /**
- * Validates an image file for MIME type (PNG or JPEG), file size (max 10MB), and dimensions (max 4608x2592)
+ * Validates an image file for MIME type (PNG or JPEG), file size (max 10MB), and dimensions (max 8000x8000)
  */
 export const validateImageFile = async (
   file: File,
@@ -67,7 +70,10 @@ export const validateImageFile = async (
   try {
     const dimensions = await getImageDimensions(file);
 
-    if (dimensions.width > 4608 || dimensions.height > 2592) {
+    if (
+      dimensions.width > MAX_IMAGE_WIDTH ||
+      dimensions.height > MAX_IMAGE_HEIGHT
+    ) {
       errorKeys.push("dimensionsTooLarge");
     }
 

--- a/nachet-mini/src/common/tests/imageutils.test.ts
+++ b/nachet-mini/src/common/tests/imageutils.test.ts
@@ -260,13 +260,13 @@ describe("validateImageFile", () => {
     expect(result.errorKeys).toEqual([]);
   });
 
-  it("accepts a file with exactly the maximum dimensions (4608x2592)", async () => {
-    mockNaturalWidth = 4608;
-    mockNaturalHeight = 2592;
+  it("accepts a file with exactly the maximum dimensions (8000x8000)", async () => {
+    mockNaturalWidth = 8000;
+    mockNaturalHeight = 8000;
     const result = await validateImageFile(makePng());
     expect(result.isValid).toBe(true);
     expect(result.errorKeys).toEqual([]);
-    expect(result.dimensions).toEqual({ width: 4608, height: 2592 });
+    expect(result.dimensions).toEqual({ width: 8000, height: 8000 });
   });
 
   it("accepts a file with exactly the maximum size (10 MB)", async () => {
@@ -291,17 +291,17 @@ describe("validateImageFile", () => {
     expect(result.errorKeys).toContain("fileTooLarge");
   });
 
-  it("rejects an image with width > 4608", async () => {
-    mockNaturalWidth = 4609;
+  it("rejects an image with width > 8000", async () => {
+    mockNaturalWidth = 8001;
     mockNaturalHeight = 1080;
     const result = await validateImageFile(makePng());
     expect(result.isValid).toBe(false);
     expect(result.errorKeys).toContain("dimensionsTooLarge");
   });
 
-  it("rejects an image with height > 2592", async () => {
+  it("rejects an image with height > 8000", async () => {
     mockNaturalWidth = 1920;
-    mockNaturalHeight = 2593;
+    mockNaturalHeight = 8001;
     const result = await validateImageFile(makePng());
     expect(result.isValid).toBe(false);
     expect(result.errorKeys).toContain("dimensionsTooLarge");
@@ -317,7 +317,7 @@ describe("validateImageFile", () => {
   });
 
   it("accumulates all three errors (wrong type + too large + dimensions too large)", async () => {
-    mockNaturalWidth = 5000; // Trigger dimensionsTooLarge
+    mockNaturalWidth = 8001; // Trigger dimensionsTooLarge
     const trifectaFile = new File([""], "bad.gif", { type: "image/gif" });
     Object.defineProperty(trifectaFile, "size", { value: 11 * 1024 * 1024 });
 

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -106,7 +106,7 @@ const main = {
   validation: {
     invalidType: "File must be a PNG or JPEG image",
     fileTooLarge: "File size must be less than 10MB",
-    dimensionsTooLarge: "Image dimensions must not exceed 4608x2592 pixels",
+    dimensionsTooLarge: "Image dimensions must not exceed 8000x8000 pixels",
     unreadableDimensions: "Unable to read image dimensions",
     loadFailed: "Failed to load image",
   },

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -110,7 +110,7 @@ const main = {
     invalidType: "Le fichier doit \u00eatre une image PNG ou JPEG",
     fileTooLarge: "La taille du fichier ne doit pas d\u00e9passer 10\u00a0Mo",
     dimensionsTooLarge:
-      "Les dimensions de l\u2019image ne doivent pas d\u00e9passer 4608\u00d72592 pixels",
+      "Les dimensions de l\u2019image ne doivent pas d\u00e9passer 8000\u00d78000 pixels",
     unreadableDimensions: "Impossible de lire les dimensions de l\u2019image",
     loadFailed: "Impossible de charger l\u2019image",
   },


### PR DESCRIPTION
Closes #795

## Summary

- Increase Nachet Mini upload image dimension limit to `8000x8000`
- Update image validation boundary tests for the new limit
- Update English and French validation messages

## Validation

- `npm run test -- src/common/tests/imageutils.test.ts --run`
- `npm run lint`
- `npm run build`

## Notes

- Existing 10 MB file size limit is unchanged