### PR TITLE
Issue #793: Add select all images control

### DIFF
--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.5",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.5",
+      "version": "0.10.7",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.5",
+  "version": "0.10.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/nachet-mini/src/_versions.ts
+++ b/nachet-mini/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
   gitTag?: string;
 }
 export const versions: TsAppVersion = {
-  version: "0.10.5",
+  version: "0.10.7",
   name: "nachet-mini",
-  versionDate: "2026-05-12T14:47:43.526Z",
+  versionDate: "2026-05-28T15:18:37.000Z",
 };
 export default versions;

--- a/nachet-mini/src/components/ImageGallery.tsx
+++ b/nachet-mini/src/components/ImageGallery.tsx
@@ -66,6 +66,17 @@ const ImageGallery = ({
   const setCheckedResults = onCheckedResultsChange;
 
   const hasChecked = checkedImages.size > 0 || checkedResults.size > 0;
+  const imageIndices = images.map((image) => image.index);
+  const selectedImageCount = imageIndices.filter((index) =>
+    checkedImages.has(index),
+  ).length;
+  const allImagesSelected =
+    imageIndices.length > 0 && selectedImageCount === imageIndices.length;
+  const someImagesSelected = selectedImageCount > 0 && !allImagesSelected;
+
+  const handleSelectAllImages = (checked: boolean) => {
+    setCheckedImages(checked ? new Set(imageIndices) : new Set());
+  };
 
   const handleImageClick = (index: number) => {
     onSelectImage(index);
@@ -105,35 +116,55 @@ const ImageGallery = ({
         }}
         sx={{ padding: "0.8vh 1vh 0.8vh 0.8vh", flexShrink: 0 }}
         action={
-          <IconButton
-            sx={{ padding: 0, marginTop: "0.27vh", marginRight: "0.4vh" }}
-            onClick={() => {
-              if (hasChecked) {
-                checkedResults.forEach((key) => onRemoveResult(key));
-                checkedImages.forEach((index) => onRemoveImage(index));
-                setCheckedResults(new Set());
-                setCheckedImages(new Set());
-              } else {
-                onClear();
-              }
-            }}
-            aria-label={
-              hasChecked
-                ? t("imageGallery.removeResult")
-                : t("imageGallery.clearAllImages")
-            }
-            disabled={images.length === 0}
-          >
-            <DeleteIcon
-              style={{
-                color: hasChecked ? "#d32f2f" : "#1565c0",
-                fontSize: "2vh",
-                marginTop: "0.1vh",
-                marginBottom: "0.1vh",
-                marginRight: "0.1vh",
+          <Box sx={{ display: "flex", alignItems: "center", gap: "0.5vh" }}>
+            <Checkbox
+              size="small"
+              checked={allImagesSelected}
+              indeterminate={someImagesSelected}
+              onChange={(e) => handleSelectAllImages(e.target.checked)}
+              disabled={images.length === 0}
+              sx={{
+                padding: 0,
+                "& .MuiSvgIcon-root": { fontSize: "2vh" },
+              }}
+              slotProps={{
+                input: {
+                  "aria-label": allImagesSelected
+                    ? t("imageGallery.deselectAllImages")
+                    : t("imageGallery.selectAllImages"),
+                },
               }}
             />
-          </IconButton>
+            <IconButton
+              sx={{ padding: 0, marginTop: "0.27vh", marginRight: "0.4vh" }}
+              onClick={() => {
+                if (hasChecked) {
+                  checkedResults.forEach((key) => onRemoveResult(key));
+                  checkedImages.forEach((index) => onRemoveImage(index));
+                  setCheckedResults(new Set());
+                  setCheckedImages(new Set());
+                } else {
+                  onClear();
+                }
+              }}
+              aria-label={
+                hasChecked
+                  ? t("imageGallery.removeResult")
+                  : t("imageGallery.clearAllImages")
+              }
+              disabled={images.length === 0}
+            >
+              <DeleteIcon
+                style={{
+                  color: hasChecked ? "#d32f2f" : "#1565c0",
+                  fontSize: "2vh",
+                  marginTop: "0.1vh",
+                  marginBottom: "0.1vh",
+                  marginRight: "0.1vh",
+                }}
+              />
+            </IconButton>
+          </Box>
         }
       />
 

--- a/nachet-mini/src/components/ImageGallery.tsx
+++ b/nachet-mini/src/components/ImageGallery.tsx
@@ -106,17 +106,8 @@ const ImageGallery = ({
       data-testid="image-gallery-component"
     >
       <CardHeader
-        title={t("imageGallery.title")}
-        titleTypographyProps={{
-          variant: "h6",
-          align: "left",
-          fontWeight: 600,
-          fontSize: "1.3vh",
-          color: "text.primary",
-        }}
-        sx={{ padding: "0.8vh 1vh 0.8vh 0.8vh", flexShrink: 0 }}
-        action={
-          <Box sx={{ display: "flex", alignItems: "center", gap: "0.5vh" }}>
+        title={
+          <Box sx={{ display: "flex", alignItems: "center", gap: "0.6vh" }}>
             <Checkbox
               size="small"
               checked={allImagesSelected}
@@ -125,7 +116,7 @@ const ImageGallery = ({
               disabled={images.length === 0}
               sx={{
                 padding: 0,
-                "& .MuiSvgIcon-root": { fontSize: "2vh" },
+                "& .MuiSvgIcon-root": { fontSize: "2.4vh" },
               }}
               slotProps={{
                 input: {
@@ -135,36 +126,49 @@ const ImageGallery = ({
                 },
               }}
             />
-            <IconButton
-              sx={{ padding: 0, marginTop: "0.27vh", marginRight: "0.4vh" }}
-              onClick={() => {
-                if (hasChecked) {
-                  checkedResults.forEach((key) => onRemoveResult(key));
-                  checkedImages.forEach((index) => onRemoveImage(index));
-                  setCheckedResults(new Set());
-                  setCheckedImages(new Set());
-                } else {
-                  onClear();
-                }
+            <Box
+              component="span"
+              sx={{
+                fontWeight: 600,
+                fontSize: "1.3vh",
+                color: "text.primary",
               }}
-              aria-label={
-                hasChecked
-                  ? t("imageGallery.removeResult")
-                  : t("imageGallery.clearAllImages")
-              }
-              disabled={images.length === 0}
             >
-              <DeleteIcon
-                style={{
-                  color: hasChecked ? "#d32f2f" : "#1565c0",
-                  fontSize: "2vh",
-                  marginTop: "0.1vh",
-                  marginBottom: "0.1vh",
-                  marginRight: "0.1vh",
-                }}
-              />
-            </IconButton>
+              {t("imageGallery.title")}
+            </Box>
           </Box>
+        }
+        sx={{ padding: "0.8vh 1vh 0.8vh 0.8vh", flexShrink: 0 }}
+        action={
+          <IconButton
+            sx={{ padding: 0, marginTop: "0.27vh", marginRight: "0.4vh" }}
+            onClick={() => {
+              if (hasChecked) {
+                checkedResults.forEach((key) => onRemoveResult(key));
+                checkedImages.forEach((index) => onRemoveImage(index));
+                setCheckedResults(new Set());
+                setCheckedImages(new Set());
+              } else {
+                onClear();
+              }
+            }}
+            aria-label={
+              hasChecked
+                ? t("imageGallery.removeResult")
+                : t("imageGallery.clearAllImages")
+            }
+            disabled={images.length === 0}
+          >
+            <DeleteIcon
+              style={{
+                color: hasChecked ? "#d32f2f" : "#1565c0",
+                fontSize: "2vh",
+                marginTop: "0.1vh",
+                marginBottom: "0.1vh",
+                marginRight: "0.1vh",
+              }}
+            />
+          </IconButton>
         }
       />
 

--- a/nachet-mini/src/components/tests/ImageGallery.test.tsx
+++ b/nachet-mini/src/components/tests/ImageGallery.test.tsx
@@ -144,6 +144,17 @@ describe("ImageGallery", () => {
         )
         .not.toBeDisabled();
     });
+
+    it("disables the select-all checkbox when there are no images", async () => {
+      renderGallery();
+      await expect
+        .element(
+          page.getByRole("checkbox", {
+            name: enMain.imageGallery.selectAllImages,
+          }),
+        )
+        .toBeDisabled();
+    });
   });
 
   describe("image list", () => {
@@ -372,7 +383,9 @@ describe("ImageGallery", () => {
   describe("image checkboxes", () => {
     it("renders a checkbox for each image", async () => {
       renderGallery({ images: [makeImage(0), makeImage(1)] });
-      expect(await page.getByRole("checkbox").all()).toHaveLength(2);
+      expect(
+        await page.getByRole("checkbox", { name: /^Select image \d+$/ }).all(),
+      ).toHaveLength(2);
     });
 
     it("image checkbox is unchecked when not in checkedImages", async () => {
@@ -453,6 +466,46 @@ describe("ImageGallery", () => {
         .click();
       expect(onSelectImage).not.toHaveBeenCalled();
     });
+
+    it("selects all image checkboxes from the header checkbox", async () => {
+      const onCheckedImagesChange = vi.fn();
+      renderGallery({
+        images: [makeImage(0), makeImage(1)],
+        checkedImages: new Set<number>(),
+        onCheckedImagesChange,
+      });
+      await page
+        .getByRole("checkbox", { name: enMain.imageGallery.selectAllImages })
+        .click();
+      expect(onCheckedImagesChange).toHaveBeenCalledWith(new Set([0, 1]));
+    });
+
+    it("clears image checkbox selection from the header checkbox when all images are selected", async () => {
+      const onCheckedImagesChange = vi.fn();
+      renderGallery({
+        images: [makeImage(0), makeImage(1)],
+        checkedImages: new Set([0, 1]),
+        onCheckedImagesChange,
+      });
+      await page
+        .getByRole("checkbox", { name: enMain.imageGallery.deselectAllImages })
+        .click();
+      expect(onCheckedImagesChange).toHaveBeenCalledWith(new Set());
+    });
+
+    it("shows the header checkbox as indeterminate when some images are selected", async () => {
+      renderGallery({
+        images: [makeImage(0), makeImage(1)],
+        checkedImages: new Set([0]),
+      });
+      await expect
+        .element(
+          page.getByRole("checkbox", {
+            name: enMain.imageGallery.selectAllImages,
+          }),
+        )
+        .toHaveAttribute("data-indeterminate", "true");
+    });
   });
 
   describe("result checkboxes", () => {
@@ -461,7 +514,11 @@ describe("ImageGallery", () => {
     it("renders a checkbox for each result entry", async () => {
       const getResultsForImage = vi.fn().mockReturnValue([resultEntry]);
       renderGallery({ images: [makeImage(0)], getResultsForImage });
-      expect(await page.getByRole("checkbox").all()).toHaveLength(2);
+      expect(
+        await page
+          .getByRole("checkbox", { name: /Select result model-a/ })
+          .all(),
+      ).toHaveLength(1);
     });
 
     it("result checkbox is unchecked when not in checkedResults", async () => {

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -70,6 +70,8 @@ const main = {
     image: "Image {{number}}",
     clearAllImages: "Clear all images",
     editMetadataImage: "Edit metadata image {{number}}",
+    selectAllImages: "Select all images",
+    deselectAllImages: "Deselect all images",
     selectImage: "Select image {{number}}",
     selectResult: "Select result {{modelId}}",
     resultsAvailable: "Results available",

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -71,6 +71,8 @@ const main = {
     image: "Image {{number}}",
     clearAllImages: "Effacer toutes les images",
     editMetadataImage: "Modifier les métadonnées de l’image {{number}}",
+    selectAllImages: "Sélectionner toutes les images",
+    deselectAllImages: "Désélectionner toutes les images",
     selectImage: "Sélectionner l’image {{number}}",
     selectResult: "Sélectionner le résultat {{modelId}}",
     resultsAvailable: "R\u00e9sultats disponibles",


### PR DESCRIPTION
Closes #793

## Summary

- Add a select-all checkbox to the Nachet Mini image browser
- Support checked, unchecked, and indeterminate selection states
- Keep image selection separate from result selection
- Add English and French labels for select/deselect all images
- Bump Nachet Mini version to `0.10.7`

## Validation

- `npm run test:browser -- src/components/tests/ImageGallery.test.tsx`
- `npm run lint`
- `npm run build`