### PR TITLE
Issue #794: Add custom export filename and save picker

### DIFF
--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.7",
+  "version": "0.10.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/nachet-mini/src/_versions.ts
+++ b/nachet-mini/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
   gitTag?: string;
 }
 export const versions: TsAppVersion = {
-  version: "0.10.7",
+  version: "0.10.8",
   name: "nachet-mini",
-  versionDate: "2026-05-28T15:18:37.000Z",
+  versionDate: "2026-05-28T15:31:10.000Z",
 };
 export default versions;

--- a/nachet-mini/src/common/exportSave.ts
+++ b/nachet-mini/src/common/exportSave.ts
@@ -1,0 +1,82 @@
+import { saveAs } from "file-saver";
+
+export class ExportCancelledError extends Error {
+  constructor() {
+    super("Export cancelled");
+    this.name = "ExportCancelledError";
+  }
+}
+
+type SaveFilePickerOptions = {
+  suggestedName?: string;
+  types?: Array<{
+    description: string;
+    accept: Record<string, string[]>;
+  }>;
+};
+
+type FileSystemWritableFileStream = {
+  write: (data: Blob) => Promise<void>;
+  close: () => Promise<void>;
+};
+
+type FileSystemFileHandle = {
+  createWritable: () => Promise<FileSystemWritableFileStream>;
+};
+
+type WindowWithSaveFilePicker = Window & {
+  showSaveFilePicker?: (
+    options?: SaveFilePickerOptions,
+  ) => Promise<FileSystemFileHandle>;
+};
+
+export const getDefaultExportFileName = (date = new Date()): string => {
+  const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  return `nachet-mini-export-${dateStr}.zip`;
+};
+
+const replaceControlCharacters = (value: string): string =>
+  Array.from(value)
+    .map((char) => (char.charCodeAt(0) < 32 ? "-" : char))
+    .join("");
+
+export const normalizeExportFileName = (fileName: string): string => {
+  const trimmed = fileName.trim();
+  const hasZipExtension = trimmed.toLowerCase().endsWith(".zip");
+  const nameWithoutExtension = hasZipExtension ? trimmed.slice(0, -4) : trimmed;
+  const normalized = replaceControlCharacters(nameWithoutExtension.trim())
+    .replace(/[<>:"/\\|?*]/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^[.\s-]+|[.\s-]+$/g, "");
+
+  const safeName = normalized || getDefaultExportFileName();
+  return safeName.toLowerCase().endsWith(".zip") ? safeName : `${safeName}.zip`;
+};
+
+export const saveExportBlob = async (content: Blob, fileName: string) => {
+  const picker = (window as WindowWithSaveFilePicker).showSaveFilePicker;
+  if (picker) {
+    try {
+      const handle = await picker({
+        suggestedName: fileName,
+        types: [
+          {
+            description: "ZIP archive",
+            accept: { "application/zip": [".zip"] },
+          },
+        ],
+      });
+      const writable = await handle.createWritable();
+      await writable.write(content);
+      await writable.close();
+      return;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw new ExportCancelledError();
+      }
+      throw error;
+    }
+  }
+
+  saveAs(content, fileName);
+};

--- a/nachet-mini/src/common/exportUtils.ts
+++ b/nachet-mini/src/common/exportUtils.ts
@@ -1,5 +1,4 @@
 import JSZip from "jszip";
-import { saveAs } from "file-saver";
 import type { Images, InferenceResult } from "@common/types";
 import type {
   ExportManifest,
@@ -7,6 +6,11 @@ import type {
   ExportInferenceEntry,
   ExportBoxEntry,
 } from "@common/exportTypes";
+import {
+  getDefaultExportFileName,
+  normalizeExportFileName,
+  saveExportBlob,
+} from "@common/exportSave";
 
 interface ResultEntry {
   modelConfigId: string;
@@ -290,6 +294,7 @@ export const generateExportZip = async (
     includeCsv?: boolean;
     humanReadable?: boolean;
     includeAnnotatedImages?: boolean;
+    fileName?: string;
   },
 ): Promise<void> => {
   const zip = new JSZip();
@@ -390,8 +395,9 @@ export const generateExportZip = async (
     zip.file("results.csv", csv);
   }
 
-  const d = new Date();
-  const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
   const content = await zip.generateAsync({ type: "blob" });
-  saveAs(content, `nachet-mini-export-${dateStr}.zip`);
+  await saveExportBlob(
+    content,
+    normalizeExportFileName(options?.fileName ?? getDefaultExportFileName()),
+  );
 };

--- a/nachet-mini/src/common/tests/exportSave.test.ts
+++ b/nachet-mini/src/common/tests/exportSave.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { saveAs } from "file-saver";
+import {
+  ExportCancelledError,
+  getDefaultExportFileName,
+  normalizeExportFileName,
+  saveExportBlob,
+} from "../exportSave";
+
+vi.mock("file-saver", () => ({ saveAs: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getDefaultExportFileName", () => {
+  it("builds a dated zip filename", () => {
+    expect(getDefaultExportFileName(new Date("2026-05-28T12:00:00Z"))).toBe(
+      "nachet-mini-export-2026-05-28.zip",
+    );
+  });
+});
+
+describe("normalizeExportFileName", () => {
+  it("keeps zip filenames unchanged", () => {
+    expect(normalizeExportFileName("custom-export.zip")).toBe(
+      "custom-export.zip",
+    );
+  });
+
+  it("adds a zip extension when missing", () => {
+    expect(normalizeExportFileName("custom-export")).toBe("custom-export.zip");
+  });
+
+  it("removes path separators and reserved filename characters", () => {
+    expect(normalizeExportFileName("../bad:name?.zip")).toBe("bad-name.zip");
+  });
+});
+
+describe("saveExportBlob", () => {
+  const content = new Blob(["zip"]);
+
+  it("falls back to file-saver when the browser save picker is unavailable", async () => {
+    await saveExportBlob(content, "custom-export.zip");
+
+    expect(saveAs).toHaveBeenCalledWith(content, "custom-export.zip");
+  });
+
+  it("uses the browser save picker when available", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const createWritable = vi.fn().mockResolvedValue({ write, close });
+    const showSaveFilePicker = vi.fn().mockResolvedValue({ createWritable });
+    vi.stubGlobal("showSaveFilePicker", showSaveFilePicker);
+
+    await saveExportBlob(content, "custom-export.zip");
+
+    expect(showSaveFilePicker).toHaveBeenCalledWith(
+      expect.objectContaining({ suggestedName: "custom-export.zip" }),
+    );
+    expect(write).toHaveBeenCalledWith(content);
+    expect(close).toHaveBeenCalledOnce();
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it("throws ExportCancelledError when the browser save picker is cancelled", async () => {
+    vi.stubGlobal(
+      "showSaveFilePicker",
+      vi.fn().mockRejectedValue(new DOMException("cancelled", "AbortError")),
+    );
+
+    await expect(
+      saveExportBlob(content, "custom-export.zip"),
+    ).rejects.toBeInstanceOf(ExportCancelledError);
+  });
+});

--- a/nachet-mini/src/common/tests/exportUtils.test.ts
+++ b/nachet-mini/src/common/tests/exportUtils.test.ts
@@ -8,7 +8,6 @@ import {
 } from "../exportUtils";
 import type { Images, InferenceResult, InferenceBox } from "../types";
 import type { ExportManifest, ExportBoxEntry } from "../exportTypes";
-import { saveAs } from "file-saver";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock state — must be available before vi.mock factories run
@@ -34,6 +33,12 @@ const zipMock = vi.hoisted(() => {
   };
 });
 
+const exportSaveMock = vi.hoisted(() => ({
+  getDefaultExportFileName: vi.fn(),
+  normalizeExportFileName: vi.fn(),
+  saveExportBlob: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
@@ -45,7 +50,7 @@ vi.mock("jszip", () => {
   return { default: MockJSZip };
 });
 
-vi.mock("file-saver", () => ({ saveAs: vi.fn() }));
+vi.mock("@common/exportSave", () => exportSaveMock);
 
 // ---------------------------------------------------------------------------
 // MockImage — triggers onload or onerror asynchronously
@@ -160,6 +165,13 @@ beforeEach(() => {
     // Fall through to real implementation for other elements
     return document.createElement.call(document, tag as "div");
   });
+  exportSaveMock.getDefaultExportFileName.mockReturnValue(
+    "nachet-mini-export-test.zip",
+  );
+  exportSaveMock.normalizeExportFileName.mockImplementation(
+    (fileName: string) => `normalized-${fileName}`,
+  );
+  exportSaveMock.saveExportBlob.mockResolvedValue(undefined);
   vi.clearAllMocks();
 });
 
@@ -580,11 +592,30 @@ describe("generateExportZip", () => {
     });
   });
 
-  it("calls saveAs with a correctly date-stamped filename", async () => {
+  it("saves with the default export filename", async () => {
     await generateExportZip(makeManifest(), images);
-    expect(saveAs).toHaveBeenCalled();
-    const filename = vi.mocked(saveAs).mock.calls[0][1] as string;
-    expect(filename).toMatch(/^nachet-mini-export-\d{4}-\d{2}-\d{2}\.zip$/);
+    expect(exportSaveMock.getDefaultExportFileName).toHaveBeenCalledOnce();
+    expect(exportSaveMock.normalizeExportFileName).toHaveBeenCalledWith(
+      "nachet-mini-export-test.zip",
+    );
+    expect(exportSaveMock.saveExportBlob).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "normalized-nachet-mini-export-test.zip",
+    );
+  });
+
+  it("saves with a custom filename", async () => {
+    await generateExportZip(makeManifest(), images, {
+      fileName: "custom-export.zip",
+    });
+    expect(exportSaveMock.getDefaultExportFileName).not.toHaveBeenCalled();
+    expect(exportSaveMock.normalizeExportFileName).toHaveBeenCalledWith(
+      "custom-export.zip",
+    );
+    expect(exportSaveMock.saveExportBlob).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "normalized-custom-export.zip",
+    );
   });
 
   it("does not add manifest.json when includeResults=false", async () => {

--- a/nachet-mini/src/components/ExportDialog.tsx
+++ b/nachet-mini/src/components/ExportDialog.tsx
@@ -8,12 +8,17 @@ import {
   DialogContent,
   FormControlLabel,
   IconButton,
+  TextField,
   Typography,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { useImageStore } from "@stores/useImageStore";
 import { useInferenceStore } from "@stores/useInferenceStore";
 import { buildExportManifest, generateExportZip } from "@common/exportUtils";
+import {
+  ExportCancelledError,
+  getDefaultExportFileName,
+} from "@common/exportSave";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -44,6 +49,7 @@ const ExportDialog = ({
   const [includeAnnotatedImages, setIncludeAnnotatedImages] = useState(false);
   const [humanReadable, setHumanReadable] = useState(false);
   const [exportError, setExportError] = useState("");
+  const [fileName, setFileName] = useState(() => getDefaultExportFileName());
 
   // Count what will be exported
   const imageIndices = new Set<number>(checkedImages);
@@ -67,8 +73,14 @@ const ExportDialog = ({
   }
 
   const nothingSelected = imageIndices.size === 0;
+  const fileNameRequired = fileName.trim().length === 0;
 
   const handleExport = async () => {
+    if (fileNameRequired) {
+      setExportError(t("exportDialog.fileNameRequired"));
+      return;
+    }
+
     setExporting(true);
     setExportError("");
     try {
@@ -85,6 +97,7 @@ const ExportDialog = ({
         includeCsv,
         includeAnnotatedImages,
         humanReadable,
+        fileName,
       });
       onExportComplete();
       onClose();
@@ -93,6 +106,8 @@ const ExportDialog = ({
       if (message.startsWith("DUPLICATE_NAME:")) {
         const name = message.slice("DUPLICATE_NAME:".length);
         setExportError(t("exportDialog.duplicateNameError", { name }));
+      } else if (error instanceof ExportCancelledError) {
+        setExportError("");
       } else {
         console.error("Export error:", message);
       }
@@ -151,6 +166,28 @@ const ExportDialog = ({
           </Typography>
 
           <Box sx={{ display: "flex", flexDirection: "column", mb: "1vh" }}>
+            <TextField
+              label={t("exportDialog.fileName")}
+              value={fileName}
+              onChange={(e) => {
+                setFileName(e.target.value);
+                setExportError("");
+              }}
+              error={fileNameRequired && exportError.length > 0}
+              helperText={
+                fileNameRequired && exportError
+                  ? t("exportDialog.fileNameRequired")
+                  : undefined
+              }
+              size="small"
+              fullWidth
+              sx={{
+                mb: "1vh",
+                "& .MuiInputBase-input": { fontSize: "1.3vh" },
+                "& .MuiInputLabel-root": { fontSize: "1.3vh" },
+                "& .MuiFormHelperText-root": { fontSize: "1.1vh" },
+              }}
+            />
             <FormControlLabel
               control={
                 <Checkbox
@@ -247,6 +284,7 @@ const ExportDialog = ({
               disabled={
                 nothingSelected ||
                 exporting ||
+                fileNameRequired ||
                 (!includeImages &&
                   !includeResults &&
                   !includeCsv &&

--- a/nachet-mini/src/components/tests/ExportDialog.test.tsx
+++ b/nachet-mini/src/components/tests/ExportDialog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { page } from "vitest/browser";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../../i18n";
@@ -19,6 +20,11 @@ const { mockBuildExportManifest, mockGenerateExportZip } = vi.hoisted(() => ({
 vi.mock("@common/exportUtils", () => ({
   buildExportManifest: mockBuildExportManifest,
   generateExportZip: mockGenerateExportZip,
+}));
+
+vi.mock("@common/exportSave", () => ({
+  ExportCancelledError: class ExportCancelledError extends Error {},
+  getDefaultExportFileName: () => "nachet-mini-export-test.zip",
 }));
 
 vi.mock("@stores/useImageStore", () => ({ useImageStore: vi.fn() }));
@@ -138,6 +144,15 @@ describe("ExportDialog", () => {
       await expect
         .element(page.getByRole("button", { name: enMain.exportDialog.title }))
         .toBeVisible();
+    });
+
+    it("renders the export filename field with the default filename", async () => {
+      renderDialog();
+      await expect
+        .element(
+          page.getByRole("textbox", { name: enMain.exportDialog.fileName }),
+        )
+        .toHaveValue("nachet-mini-export-test.zip");
     });
 
     it("shows nothingSelected text when no images or results are checked", async () => {
@@ -391,9 +406,49 @@ describe("ExportDialog", () => {
             includeCsv: true,
             includeAnnotatedImages: false,
             humanReadable: false,
+            fileName: "nachet-mini-export-test.zip",
           }),
         ),
       );
+    });
+
+    it("passes a custom filename to generateExportZip", async () => {
+      const user = userEvent.setup();
+      renderDialog({ checkedImages: new Set([0]) });
+
+      const filenameInput = page
+        .getByRole("textbox", { name: enMain.exportDialog.fileName })
+        .element() as HTMLElement;
+      await user.clear(filenameInput);
+      await user.type(filenameInput, "custom-export.zip");
+
+      await page
+        .getByRole("button", { name: enMain.exportDialog.title })
+        .click();
+
+      await vi.waitFor(() =>
+        expect(mockGenerateExportZip).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({
+            fileName: "custom-export.zip",
+          }),
+        ),
+      );
+    });
+
+    it("disables export when the filename is empty", async () => {
+      const user = userEvent.setup();
+      renderDialog({ checkedImages: new Set([0]) });
+
+      const filenameInput = page
+        .getByRole("textbox", { name: enMain.exportDialog.fileName })
+        .element() as HTMLElement;
+      await user.clear(filenameInput);
+
+      await expect
+        .element(page.getByRole("button", { name: enMain.exportDialog.title }))
+        .toBeDisabled();
     });
 
     it("passes updated options when checkboxes are changed", async () => {

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -57,6 +57,8 @@ const main = {
     includeCsv: "Include CSV",
     includeAnnotatedImages: "Include annotated images",
     humanReadable: "Human readable filenames",
+    fileName: "Export filename",
+    fileNameRequired: "Export filename is required",
     duplicateNameError:
       "Duplicate image name: {{name}}. Rename before exporting.",
   },

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -58,6 +58,8 @@ const main = {
     includeCsv: "Inclure le CSV",
     includeAnnotatedImages: "Inclure les images annotées",
     humanReadable: "Noms de fichiers lisibles",
+    fileName: "Nom du fichier d’exportation",
+    fileNameRequired: "Le nom du fichier d’exportation est obligatoire",
     duplicateNameError:
       "Nom d'image en double : {{name}}. Renommez avant d'exporter.",
   },


### PR DESCRIPTION
Closes #794

## Summary

- Add a custom export filename field to the Nachet Mini export dialog
- Use the browser Save As picker for export location/name selection when available
- Keep existing download behavior as a fallback
- Normalize export filenames and append `.zip` when needed
- Handle cancelled Save As dialogs without treating them as export errors
- Bump Nachet Mini version to `0.10.8`

## Validation

- `npm run test -- src/common/tests/exportUtils.test.ts --run`
- `npm run test -- src/common/tests/exportSave.test.ts --run`
- `npm run test:browser -- src/components/tests/ExportDialog.test.tsx`
- `npm run lint`
- `npm run build`