### PR TITLE
Issue #808: Sign backend and frontend build images

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/backend-build.yml"
+      - ".github/workflows/reusable-sign-container-images.yml"
     types:
       - opened
       - closed
@@ -98,58 +99,13 @@ jobs:
 
   sign-images:
     needs: [get-version, build-and-push-gcr]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
-
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@115e4ce455e573aa6e9ba51e8d040ddd5c1378af
-        with:
-          cosign-release: "v2.2.3"
-
-      - name: Log in to the github container registry (GCR)
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sign backend images
-        working-directory: .
-        env:
-          IMAGE: ghcr.io/ai-cfia/${{ github.event.repository.name }}-backend
-          RELEASE_VERSION: ${{ needs.get-version.outputs.app-version }}
-        run: |
-          set -euo pipefail
-
-          tags=(
-            "${IMAGE}:${{ github.sha }}"
-            "${IMAGE}:${RELEASE_VERSION}"
-          )
-
-          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
-            tags+=("${IMAGE}:${{ github.event.pull_request.base.ref }}")
-          else
-            branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-            clean_branch_name="$(echo "$branch_name" | sed 's/[\/\\]/-/g')"
-            tags+=(
-              "${IMAGE}:${{ github.event.number }}"
-              "${IMAGE}:${clean_branch_name}"
-            )
-          fi
-
-          for tag in "${tags[@]}"; do
-            echo "Signing backend image: $tag"
-            cosign sign --yes "$tag"
-          done
-
-          for tag in "${tags[@]}"; do
-            echo "Verifying backend image signature: $tag"
-            cosign verify \
-              --certificate-identity-regexp='^https://github.com/ai-cfia/.*$' \
-              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-              "$tag"
-          done
+    uses: ./.github/workflows/reusable-sign-container-images.yml
+    with:
+      image-name: ghcr.io/ai-cfia/${{ github.event.repository.name }}-backend
+      image-label: backend
+      release-version: ${{ needs.get-version.outputs.app-version }}
+    secrets: inherit

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -94,3 +95,60 @@ jobs:
       release-version: ${{ needs.get-version.outputs.app-version }}
       registry: ghcr.io/ai-cfia
     secrets: inherit
+
+  sign-images:
+    needs: [get-version, build-and-push-gcr]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@115e4ce455e573aa6e9ba51e8d040ddd5c1378af
+        with:
+          cosign-release: "v2.2.3"
+
+      - name: Log in to the github container registry (GCR)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign backend images
+        env:
+          IMAGE: ghcr.io/ai-cfia/${{ github.event.repository.name }}-backend
+          RELEASE_VERSION: ${{ needs.get-version.outputs.app-version }}
+        run: |
+          set -euo pipefail
+
+          tags=(
+            "${IMAGE}:${{ github.sha }}"
+            "${IMAGE}:${RELEASE_VERSION}"
+          )
+
+          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            tags+=("${IMAGE}:${{ github.event.pull_request.base.ref }}")
+          else
+            branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+            clean_branch_name="$(echo "$branch_name" | sed 's/[\/\\]/-/g')"
+            tags+=(
+              "${IMAGE}:${{ github.event.number }}"
+              "${IMAGE}:${clean_branch_name}"
+            )
+          fi
+
+          for tag in "${tags[@]}"; do
+            echo "Signing backend image: $tag"
+            cosign sign --yes "$tag"
+          done
+
+          for tag in "${tags[@]}"; do
+            echo "Verifying backend image signature: $tag"
+            cosign verify \
+              --certificate-identity-regexp='^https://github.com/ai-cfia/.*$' \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              "$tag"
+          done

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -118,6 +118,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign backend images
+        working-directory: .
         env:
           IMAGE: ghcr.io/ai-cfia/${{ github.event.repository.name }}-backend
           RELEASE_VERSION: ${{ needs.get-version.outputs.app-version }}

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -47,3 +48,60 @@ jobs:
       release-version: ${{ needs.get-version.outputs.app-version }}
       registry: ghcr.io/ai-cfia
     secrets: inherit
+
+  sign-images:
+    needs: [get-version, build-and-push-gcr]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@115e4ce455e573aa6e9ba51e8d040ddd5c1378af
+        with:
+          cosign-release: "v2.2.3"
+
+      - name: Log in to the github container registry (GCR)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign frontend images
+        env:
+          IMAGE: ghcr.io/ai-cfia/${{ github.event.repository.name }}-frontend
+          RELEASE_VERSION: ${{ needs.get-version.outputs.app-version }}
+        run: |
+          set -euo pipefail
+
+          tags=(
+            "${IMAGE}:${{ github.sha }}"
+            "${IMAGE}:${RELEASE_VERSION}"
+          )
+
+          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            tags+=("${IMAGE}:${{ github.event.pull_request.base.ref }}")
+          else
+            branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+            clean_branch_name="$(echo "$branch_name" | sed 's/[\/\\]/-/g')"
+            tags+=(
+              "${IMAGE}:${{ github.event.number }}"
+              "${IMAGE}:${clean_branch_name}"
+            )
+          fi
+
+          for tag in "${tags[@]}"; do
+            echo "Signing frontend image: $tag"
+            cosign sign --yes "$tag"
+          done
+
+          for tag in "${tags[@]}"; do
+            echo "Verifying frontend image signature: $tag"
+            cosign verify \
+              --certificate-identity-regexp='^https://github.com/ai-cfia/.*$' \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              "$tag"
+          done

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-build.yml"
+      - ".github/workflows/reusable-sign-container-images.yml"
     types:
       - opened
       - closed
@@ -51,58 +52,13 @@ jobs:
 
   sign-images:
     needs: [get-version, build-and-push-gcr]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
-
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@115e4ce455e573aa6e9ba51e8d040ddd5c1378af
-        with:
-          cosign-release: "v2.2.3"
-
-      - name: Log in to the github container registry (GCR)
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sign frontend images
-        working-directory: .
-        env:
-          IMAGE: ghcr.io/ai-cfia/${{ github.event.repository.name }}-frontend
-          RELEASE_VERSION: ${{ needs.get-version.outputs.app-version }}
-        run: |
-          set -euo pipefail
-
-          tags=(
-            "${IMAGE}:${{ github.sha }}"
-            "${IMAGE}:${RELEASE_VERSION}"
-          )
-
-          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
-            tags+=("${IMAGE}:${{ github.event.pull_request.base.ref }}")
-          else
-            branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-            clean_branch_name="$(echo "$branch_name" | sed 's/[\/\\]/-/g')"
-            tags+=(
-              "${IMAGE}:${{ github.event.number }}"
-              "${IMAGE}:${clean_branch_name}"
-            )
-          fi
-
-          for tag in "${tags[@]}"; do
-            echo "Signing frontend image: $tag"
-            cosign sign --yes "$tag"
-          done
-
-          for tag in "${tags[@]}"; do
-            echo "Verifying frontend image signature: $tag"
-            cosign verify \
-              --certificate-identity-regexp='^https://github.com/ai-cfia/.*$' \
-              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-              "$tag"
-          done
+    uses: ./.github/workflows/reusable-sign-container-images.yml
+    with:
+      image-name: ghcr.io/ai-cfia/${{ github.event.repository.name }}-frontend
+      image-label: frontend
+      release-version: ${{ needs.get-version.outputs.app-version }}
+    secrets: inherit

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -71,6 +71,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign frontend images
+        working-directory: .
         env:
           IMAGE: ghcr.io/ai-cfia/${{ github.event.repository.name }}-frontend
           RELEASE_VERSION: ${{ needs.get-version.outputs.app-version }}

--- a/.github/workflows/prod-build-sign-deploy.yml
+++ b/.github/workflows/prod-build-sign-deploy.yml
@@ -72,7 +72,7 @@ jobs:
           echo "${{ steps.meta-backend.outputs.tags }}" | while read -r tag; do
             echo "Verifying backend image: $tag"
             cosign verify \
-              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/prod-build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
               --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
               "$tag"
           done
@@ -139,7 +139,7 @@ jobs:
           echo "${{ steps.meta-frontend.outputs.tags }}" | while read -r tag; do
             echo "Verifying frontend image: $tag"
             cosign verify \
-              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/prod-build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
               --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
               "$tag"
           done
@@ -173,13 +173,13 @@ jobs:
 
             # Verify frontend signature
             cosign verify \
-              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/prod-build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
               --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
               ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-frontend:${{ github.ref_name }}
 
             # Verify backend signature
             cosign verify \
-              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
+              --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/prod-build-sign-deploy.yml@refs/tags/${{ github.ref_name }} \
               --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
               ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/nachet-backend:${{ github.ref_name }}
             ```

--- a/.github/workflows/reusable-sign-container-images.yml
+++ b/.github/workflows/reusable-sign-container-images.yml
@@ -1,0 +1,76 @@
+name: Sign Container Images
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Fully qualified image name without tag"
+        required: true
+        type: string
+      image-label:
+        description: "Human-readable image label for logs"
+        required: true
+        type: string
+      release-version:
+        description: "Application version tag to sign"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  sign-images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@115e4ce455e573aa6e9ba51e8d040ddd5c1378af
+        with:
+          cosign-release: "v2.2.3"
+
+      - name: Log in to the github container registry (GCR)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign and verify images
+        env:
+          IMAGE: ${{ inputs.image-name }}
+          IMAGE_LABEL: ${{ inputs.image-label }}
+          RELEASE_VERSION: ${{ inputs.release-version }}
+        run: |
+          set -euo pipefail
+
+          tags=(
+            "${IMAGE}:${{ github.sha }}"
+            "${IMAGE}:${RELEASE_VERSION}"
+          )
+
+          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            tags+=("${IMAGE}:${{ github.event.pull_request.base.ref }}")
+          else
+            branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+            clean_branch_name="$(echo "$branch_name" | sed 's/[\/\\]/-/g')"
+            tags+=(
+              "${IMAGE}:${{ github.event.number }}"
+              "${IMAGE}:${clean_branch_name}"
+            )
+          fi
+
+          for tag in "${tags[@]}"; do
+            echo "Signing ${IMAGE_LABEL} image: $tag"
+            cosign sign --yes "$tag"
+          done
+
+          for tag in "${tags[@]}"; do
+            echo "Verifying ${IMAGE_LABEL} image signature: $tag"
+            cosign verify \
+              --certificate-identity-regexp='^https://github.com/ai-cfia/.*$' \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              "$tag"
+          done

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "2.9.12"
+version = "2.9.13"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "2.9.12"
+version = "2.9.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "2.9.12",
+      "version": "2.9.13",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "2.9.12",
+  "version": "2.9.13",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },


### PR DESCRIPTION
## Summary

- Add Cosign keyless signing to the backend and frontend GHCR build workflows.
- Verify each image signature after signing.
- Fix the production signing workflow's verification identity to use the current workflow file name.

## Context

Relates to #808.

Staging is currently blocked in Argo CD because `ghcr.io/ai-cfia/nachet-backend:2.4.0` is rejected by the cluster Sigstore policy with `no signatures found`.

## Checks

- Confirmed `nachet-backend:2.4.0` resolves to the digest shown in Argo CD.
- Confirmed `cosign verify` returns `no signatures found` for the current image.
- Checked the updated workflow YAML syntax locally.

## Follow-up

After this merges, we still need to build or deploy a signed backend image and confirm Argo CD syncs successfully.