### PR TITLE
Issue #664: Nachet Mini Inference Queue

### DIFF
--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.9",
+      "version": "0.10.10",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.9",
+  "version": "0.10.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/nachet-mini/src/components/ImageGallery.tsx
+++ b/nachet-mini/src/components/ImageGallery.tsx
@@ -12,6 +12,7 @@ import {
   CircularProgress,
   Chip
 } from "@mui/material";
+import CancelIcon from "@mui/icons-material/Cancel";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import ImageIcon from "@mui/icons-material/Image";
@@ -95,6 +96,8 @@ const ImageGallery = ({
       return next;
     });
   };
+
+  const cancel = useInferenceQueueStore((s) => s.cancel);
 
   return (
     <Box
@@ -303,6 +306,21 @@ const ImageGallery = ({
                           />
                         )}
                       </Box>
+
+                      {queueEntry && (
+                        <IconButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            cancel(queueEntry.id);
+                          }}
+                          sx={{ padding: 0, pr: "5px" }}
+                          aria-label={t("imageGallery.cancelInference", { number: item.index + 1 })}
+                          title={t("imageGallery.cancelInference", { number: item.index + 1 })}
+                          size="small"
+                        >
+                          <CancelIcon style={{ color: "#d32f2f", fontSize: "2.4vh" }} />
+                        </IconButton>
+                      )}
 
                       <IconButton
                         onClick={(e) => {

--- a/nachet-mini/src/components/ImageGallery.tsx
+++ b/nachet-mini/src/components/ImageGallery.tsx
@@ -10,7 +10,7 @@ import {
   Collapse,
   Checkbox,
   CircularProgress,
-  Chip
+  Chip,
 } from "@mui/material";
 import CancelIcon from "@mui/icons-material/Cancel";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -22,11 +22,9 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import type { Images, InferenceResult } from "@common/types";
 import { resultKey } from "@stores/useInferenceStore";
-import {
-  useInferenceQueueStore,
-} from "@stores/useInferenceQueueStore";
+import { useInferenceQueueStore } from "@stores/useInferenceQueueStore";
 import { useTranslation } from "react-i18next";
-import { useState } from "react";
+import { useState, useCallback, useMemo } from "react";
 interface Props {
   images: Images[];
   currentIndex: number;
@@ -63,7 +61,14 @@ const ImageGallery = ({
   getResultsForImage,
 }: Props) => {
   const { t } = useTranslation("main");
-  const queue = useInferenceQueueStore((s) => s.queue);
+  const queueSnapshot = useInferenceQueueStore((s) =>
+    s.queue.map((i) => `${i.id}:${i.imageIndex}:${i.status}`).join(","),
+  );
+  const queue = useMemo(
+    () => useInferenceQueueStore.getState().queue,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [queueSnapshot],
+  );
   const [collapsedIndices, setCollapsedIndices] = useState<Set<number>>(
     new Set(),
   );
@@ -97,7 +102,10 @@ const ImageGallery = ({
     });
   };
 
-  const cancel = useInferenceQueueStore((s) => s.cancel);
+  const cancel = useCallback(
+    (id: string) => useInferenceQueueStore.getState().cancel(id),
+    [],
+  );
 
   return (
     <Box
@@ -199,11 +207,17 @@ const ImageGallery = ({
               const imageResults = getResultsForImage(item.index);
               const hasResults = imageResults.length > 0;
               const isExpanded = !collapsedIndices.has(item.index);
-              const queueEntry = queue.find((i) => i.imageIndex === item.index && (i.status === "pending" || i.status === "processing"));
+              const queueEntry = queue.find(
+                (i) =>
+                  i.imageIndex === item.index &&
+                  (i.status === "pending" || i.status === "processing"),
+              );
               const pendingItems = queue.filter((i) => i.status === "pending");
-              const queuePosition = queueEntry?.status === "pending"
-                ? pendingItems.indexOf(queueEntry) + 1
-                : null;
+              const queuePosition =
+                queueEntry?.status === "pending"
+                  ? pendingItems.indexOf(queueEntry) + 1
+                  : null;
+              const isPending = queueEntry?.status === "pending";
               const isProcessing = queueEntry?.status === "processing";
 
               return (
@@ -282,43 +296,73 @@ const ImageGallery = ({
                           />
                         )}
                         {isProcessing && (
-                          <CircularProgress
-                            size="1.8vh"
-                            thickness={5}
-                            sx={{ color: "#1565c0", flexShrink: 0 }}
-                            aria-label={t("imageGallery.inferring")}
-                          />
-                        )}
-                        {!isProcessing && queuePosition !== null && queuePosition > 0 && (
-                          <Chip
-                            label={queuePosition}
-                            size="small"
+                          <Box
                             sx={{
-                              height: "2vh",
-                              fontSize: "1.1vh",
-                              bgcolor: "#E3F2FD",
-                              color: "#1565c0",
-                              fontWeight: 600,
-                              flexShrink: 0,
-                              "& .MuiChip-label": { px: "0.6vh" },
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "0.4vh",
                             }}
-                            aria-label={t("imageGallery.queuePosition", { position: queuePosition })}
-                          />
+                          >
+                            <CircularProgress
+                              size="1.8vh"
+                              thickness={5}
+                              sx={{ color: "#1565c0", flexShrink: 0 }}
+                            />
+                            <Chip
+                              label={t("imageGallery.inferring_")}
+                              size="small"
+                              sx={{
+                                height: "2vh",
+                                fontSize: "1.1vh",
+                                bgcolor: "#E8F5E9",
+                                color: "#2e7d32",
+                                fontWeight: 600,
+                                flexShrink: 0,
+                                "& .MuiChip-label": { px: "0.6vh" },
+                              }}
+                            />
+                          </Box>
                         )}
+                        {!isProcessing &&
+                          queuePosition !== null &&
+                          queuePosition > 0 && (
+                            <Chip
+                              label={queuePosition}
+                              size="small"
+                              sx={{
+                                height: "2vh",
+                                fontSize: "1.1vh",
+                                bgcolor: "#E3F2FD",
+                                color: "#1565c0",
+                                fontWeight: 600,
+                                flexShrink: 0,
+                                "& .MuiChip-label": { px: "0.6vh" },
+                              }}
+                              aria-label={t("imageGallery.queuePosition", {
+                                position: queuePosition,
+                              })}
+                            />
+                          )}
                       </Box>
 
-                      {queueEntry && (
+                      {isPending && (
                         <IconButton
                           onClick={(e) => {
                             e.stopPropagation();
                             cancel(queueEntry.id);
                           }}
                           sx={{ padding: 0, pr: "5px" }}
-                          aria-label={t("imageGallery.cancelInference", { number: item.index + 1 })}
-                          title={t("imageGallery.cancelInference", { number: item.index + 1 })}
+                          aria-label={t("imageGallery.cancelInference", {
+                            number: item.index + 1,
+                          })}
+                          title={t("imageGallery.cancelInference", {
+                            number: item.index + 1,
+                          })}
                           size="small"
                         >
-                          <CancelIcon style={{ color: "#d32f2f", fontSize: "2.4vh" }} />
+                          <CancelIcon
+                            style={{ color: "#d32f2f", fontSize: "2.4vh" }}
+                          />
                         </IconButton>
                       )}
 

--- a/nachet-mini/src/components/ImageGallery.tsx
+++ b/nachet-mini/src/components/ImageGallery.tsx
@@ -9,6 +9,8 @@ import {
   CardHeader,
   Collapse,
   Checkbox,
+  CircularProgress,
+  Chip
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
@@ -19,9 +21,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import type { Images, InferenceResult } from "@common/types";
 import { resultKey } from "@stores/useInferenceStore";
+import {
+  useInferenceQueueStore,
+} from "@stores/useInferenceQueueStore";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-
 interface Props {
   images: Images[];
   currentIndex: number;
@@ -58,6 +62,7 @@ const ImageGallery = ({
   getResultsForImage,
 }: Props) => {
   const { t } = useTranslation("main");
+  const queue = useInferenceQueueStore((s) => s.queue);
   const [collapsedIndices, setCollapsedIndices] = useState<Set<number>>(
     new Set(),
   );
@@ -191,6 +196,12 @@ const ImageGallery = ({
               const imageResults = getResultsForImage(item.index);
               const hasResults = imageResults.length > 0;
               const isExpanded = !collapsedIndices.has(item.index);
+              const queueEntry = queue.find((i) => i.imageIndex === item.index && (i.status === "pending" || i.status === "processing"));
+              const pendingItems = queue.filter((i) => i.status === "pending");
+              const queuePosition = queueEntry?.status === "pending"
+                ? pendingItems.indexOf(queueEntry) + 1
+                : null;
+              const isProcessing = queueEntry?.status === "processing";
 
               return (
                 <TableRow key={item.index} sx={{ display: "table-row" }}>
@@ -265,6 +276,30 @@ const ImageGallery = ({
                           <CheckCircleIcon
                             sx={{ color: "#4caf50", fontSize: "2.4vh" }}
                             titleAccess={t("imageGallery.resultsAvailable")}
+                          />
+                        )}
+                        {isProcessing && (
+                          <CircularProgress
+                            size="1.8vh"
+                            thickness={5}
+                            sx={{ color: "#1565c0", flexShrink: 0 }}
+                            aria-label={t("imageGallery.inferring")}
+                          />
+                        )}
+                        {!isProcessing && queuePosition !== null && queuePosition > 0 && (
+                          <Chip
+                            label={queuePosition}
+                            size="small"
+                            sx={{
+                              height: "2vh",
+                              fontSize: "1.1vh",
+                              bgcolor: "#E3F2FD",
+                              color: "#1565c0",
+                              fontWeight: 600,
+                              flexShrink: 0,
+                              "& .MuiChip-label": { px: "0.6vh" },
+                            }}
+                            aria-label={t("imageGallery.queuePosition", { position: queuePosition })}
                           />
                         )}
                       </Box>

--- a/nachet-mini/src/components/ModelLoader.tsx
+++ b/nachet-mini/src/components/ModelLoader.tsx
@@ -5,7 +5,6 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  Skeleton,
 } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import type { SelectChangeEvent } from "@mui/material";
@@ -49,30 +48,9 @@ const ModelLoader = ({
     maxWidth: { xs: "fit-content", md: "8vw" },
   };
 
-  if (isLoading) {
-    return (
-      <Box
-        role="status"
-        aria-label={t("modelLoader.loading")}
-        sx={{ display: "flex", alignItems: "center", gap: "0.4vh" }}
-      >
-        <Skeleton
-          data-testid="model-loader-skeleton"
-          variant="rounded"
-          sx={{ ...dropdownSx, height: "4vh", minWidth: "8vw" }}
-        />
-        <Skeleton
-          data-testid="model-loader-skeleton"
-          variant="rounded"
-          sx={{ ...dropdownSx, height: "4vh", minWidth: "8vw" }}
-        />
-      </Box>
-    );
-  }
-
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: "0.4vh" }}>
-      <FormControl size="small" sx={dropdownSx}>
+      <FormControl size="small" sx={dropdownSx} disabled={isLoading}>
         <InputLabel id="detector-model-label" sx={{ fontSize: "1.2vh" }}>
           {detectorLabel}
         </InputLabel>
@@ -107,7 +85,7 @@ const ModelLoader = ({
         </IconButton>
       )}
 
-      <FormControl size="small" sx={dropdownSx}>
+      <FormControl size="small" sx={dropdownSx} disabled={isLoading}>
         <InputLabel id="classifier-model-label" sx={{ fontSize: "1.2vh" }}>
           {classifierLabel}
         </InputLabel>

--- a/nachet-mini/src/components/NachetMiniContainer.tsx
+++ b/nachet-mini/src/components/NachetMiniContainer.tsx
@@ -11,6 +11,10 @@ import { useInferenceStore, resultKey } from "@stores/useInferenceStore";
 import { useInference } from "@inference/useInference";
 import { useBoxEditStore } from "@stores/useBoxEditStore";
 import {
+  useInferenceQueueStore,
+  selectNextPending,
+} from "@stores/useInferenceQueueStore";
+import {
   DETECTOR_MODELS,
   CLASSIFIER_MODELS,
   DEFAULT_DETECTOR,
@@ -76,15 +80,16 @@ const NachetMiniContainer = () => {
   const hasAcknowledgedModelLoadWarning = useModelLoadConsentStore(
     (s) => s.hasAcknowledgedModelLoadWarning,
   );
-  const pendingInferenceRequest = useModelLoadConsentStore(
-    (s) => s.pendingInferenceRequest,
-  );
   const acknowledgeModelLoadWarning = useModelLoadConsentStore(
     (s) => s.acknowledgeModelLoadWarning,
   );
-  const setPendingInferenceRequest = useModelLoadConsentStore(
-    (s) => s.setPendingInferenceRequest,
-  );
+
+  // Inference queue store
+  const enqueue = useInferenceQueueStore((s) => s.enqueue);
+  const markProcessing = useInferenceQueueStore((s) => s.markProcessing);
+  const markDone = useInferenceQueueStore((s) => s.markDone);
+  const cancel = useInferenceQueueStore((s) => s.cancel);
+  const nextPending = useInferenceQueueStore(selectNextPending);
 
   // ADD local dialog state
   const [modelLoadDialogOpen, setModelLoadDialogOpen] = useState(false);
@@ -184,49 +189,64 @@ const NachetMiniContainer = () => {
     }
   }, [selectedDetectorId, selectedClassifierId, modelLoaded]);
 
+  const isInferring = status === "detecting" || status === "classifying";
   const handleRunInference = () => {
     if (!currentImage) return;
 
-    if (modelLoaded) {
-      runInference(currentImage.src, currentImage.index);
-      return;
-    }
-
-    setPendingInferenceRequest({
-      imageSrc: currentImage.src,
-      imageIndex: currentImage.index,
-    });
+    enqueue({ imageSrc: currentImage.src, imageIndex: currentImage.index });
 
     if (!hasAcknowledgedModelLoadWarning) {
       setModelLoadDialogOpen(true);
       return;
     }
 
-    handleLoadModel();
+    if (!modelLoaded) {
+      handleLoadModel();
+    }
   };
 
-  // When model finishes loading, run the pending inference request (if any).
-  const pendingRef = useRef(pendingInferenceRequest);
+  const startTimeRef = useRef<number | null>(null);
 
+  // Fire the next pending item when conditions are met
   useEffect(() => {
-    pendingRef.current = pendingInferenceRequest;
-  }, [pendingInferenceRequest]);
+    if (!modelLoaded || isInferring || !nextPending) return;
 
-  useEffect(() => {
-    if (!modelLoaded) return;
-    const pending = pendingRef.current;
-    if (!pending) return;
-
-    const stillExists = images.some((img) => img.index === pending.imageIndex);
-    if (stillExists) {
-      runInference(pending.imageSrc, pending.imageIndex);
+    const item = nextPending;
+    const stillExists = images.some((img) => img.index === item.imageIndex);
+    if (!stillExists) {
+      cancel(item.id);
+      return;
     }
-    setPendingInferenceRequest(null);
-  }, [modelLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    markProcessing(item.id);
+    startTimeRef.current = Date.now();
+    runInference(item.imageSrc, item.imageIndex);
+  }, [modelLoaded, isInferring, nextPending]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When inference completes, mark the processing item as done
+  useEffect(() => {
+    if (isInferring) {
+      startTimeRef.current ??= Date.now();
+      return;
+    }
+
+    if (status === "complete") {
+      const processingItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.status === "processing");
+      if (!processingItem) return;
+
+      const duration = startTimeRef.current
+        ? Date.now() - startTimeRef.current
+        : 0;
+      markDone(processingItem.id, duration);
+      startTimeRef.current = null;
+    }
+  }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleModelLoadDialogCancel = () => {
     setModelLoadDialogOpen(false);
-    setPendingInferenceRequest(null);
+    if (nextPending) cancel(nextPending.id);
   };
 
   const handleModelLoadDialogContinue = () => {
@@ -350,7 +370,6 @@ const NachetMiniContainer = () => {
     setCheckedResults(new Set());
   }, []);
 
-  const isInferring = status === "detecting" || status === "classifying";
   const isLoading = status === "loading-model";
   const canRunInference =
     !isWebcamActive && !!currentImage && !isInferring && !isEditing;

--- a/nachet-mini/src/components/NachetMiniContainer.tsx
+++ b/nachet-mini/src/components/NachetMiniContainer.tsx
@@ -89,7 +89,12 @@ const NachetMiniContainer = () => {
   const markProcessing = useInferenceQueueStore((s) => s.markProcessing);
   const markDone = useInferenceQueueStore((s) => s.markDone);
   const cancel = useInferenceQueueStore((s) => s.cancel);
-  const nextPending = useInferenceQueueStore(selectNextPending);
+  const nextPendingId = useInferenceQueueStore(
+    (s) => s.queue.find((i) => i.status === "pending")?.id ?? null,
+  );
+  const nextPending = nextPendingId
+    ? useInferenceQueueStore.getState().queue.find((i) => i.id === nextPendingId) ?? null
+    : null;
 
   // ADD local dialog state
   const [modelLoadDialogOpen, setModelLoadDialogOpen] = useState(false);
@@ -200,7 +205,7 @@ const NachetMiniContainer = () => {
       return;
     }
 
-    if (!modelLoaded) {
+    if (!modelLoaded && !isLoading) {
       handleLoadModel();
     }
   };
@@ -372,7 +377,7 @@ const NachetMiniContainer = () => {
 
   const isLoading = status === "loading-model";
   const canRunInference =
-    !isWebcamActive && !!currentImage && !isInferring && !isEditing;
+    !isWebcamActive && !!currentImage && !isEditing;
   const canEditBoxes =
     !isWebcamActive && !!currentResult && !isInferring && !isEditing;
   const canClassifyEdited =

--- a/nachet-mini/src/components/NachetMiniContainer.tsx
+++ b/nachet-mini/src/components/NachetMiniContainer.tsx
@@ -10,10 +10,7 @@ import { useImageStore } from "@stores/useImageStore";
 import { useInferenceStore, resultKey } from "@stores/useInferenceStore";
 import { useInference } from "@inference/useInference";
 import { useBoxEditStore } from "@stores/useBoxEditStore";
-import {
-  useInferenceQueueStore,
-  selectNextPending,
-} from "@stores/useInferenceQueueStore";
+import { useInferenceQueueStore } from "@stores/useInferenceQueueStore";
 import {
   DETECTOR_MODELS,
   CLASSIFIER_MODELS,
@@ -75,8 +72,10 @@ const NachetMiniContainer = () => {
   const clearResults = useInferenceStore((s) => s.clearResults);
   const setError = useInferenceStore((s) => s.setError);
 
-  const { loadModels, runInference, runClassifyOnly } = useInference();
+  const { loadModels, runInference, runClassifyOnly } =
+    useInference(currentIndex);
 
+  // Model load consent store
   const hasAcknowledgedModelLoadWarning = useModelLoadConsentStore(
     (s) => s.hasAcknowledgedModelLoadWarning,
   );
@@ -92,10 +91,8 @@ const NachetMiniContainer = () => {
   const nextPendingId = useInferenceQueueStore(
     (s) => s.queue.find((i) => i.status === "pending")?.id ?? null,
   );
-  const nextPending = nextPendingId
-    ? useInferenceQueueStore.getState().queue.find((i) => i.id === nextPendingId) ?? null
-    : null;
-
+  const [drainTick, setDrainTick] = useState(0);
+  const clearCompleted = useInferenceQueueStore((s) => s.clearCompleted);
   // ADD local dialog state
   const [modelLoadDialogOpen, setModelLoadDialogOpen] = useState(false);
 
@@ -198,6 +195,16 @@ const NachetMiniContainer = () => {
   const handleRunInference = () => {
     if (!currentImage) return;
 
+    const alreadyQueued = useInferenceQueueStore
+      .getState()
+      .queue.some(
+        (i) =>
+          i.imageIndex === currentImage.index &&
+          (i.status === "pending" || i.status === "processing"),
+      );
+
+    if (alreadyQueued) return;
+
     enqueue({ imageSrc: currentImage.src, imageIndex: currentImage.index });
 
     if (!hasAcknowledgedModelLoadWarning) {
@@ -211,22 +218,34 @@ const NachetMiniContainer = () => {
   };
 
   const startTimeRef = useRef<number | null>(null);
+  const isFiringRef = useRef(false);
 
   // Fire the next pending item when conditions are met
   useEffect(() => {
-    if (!modelLoaded || isInferring || !nextPending) return;
+    console.log("drain fired", {
+      modelLoaded,
+      isInferring,
+      nextPendingId,
+      isFiring: isFiringRef.current,
+    });
+    if (!modelLoaded || isInferring || !nextPendingId) return;
+    if (isFiringRef.current) return;
 
-    const item = nextPending;
+    const state = useInferenceQueueStore.getState();
+    const item = state.queue.find((i) => i.id === nextPendingId);
+    if (!item || item.status !== "pending") return;
+
     const stillExists = images.some((img) => img.index === item.imageIndex);
     if (!stillExists) {
       cancel(item.id);
       return;
     }
 
+    isFiringRef.current = true;
     markProcessing(item.id);
     startTimeRef.current = Date.now();
     runInference(item.imageSrc, item.imageIndex);
-  }, [modelLoaded, isInferring, nextPending]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [modelLoaded, isInferring, nextPendingId, drainTick]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // When inference completes, mark the processing item as done
   useEffect(() => {
@@ -236,22 +255,37 @@ const NachetMiniContainer = () => {
     }
 
     if (status === "complete") {
-      const processingItem = useInferenceQueueStore
-        .getState()
-        .queue.find((i) => i.status === "processing");
-      if (!processingItem) return;
-
       const duration = startTimeRef.current
         ? Date.now() - startTimeRef.current
         : 0;
-      markDone(processingItem.id, duration);
+
+      const processingItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.status === "processing");
+
+      console.log("finalization", {
+        duration,
+        processingItem,
+        queue: useInferenceQueueStore
+          .getState()
+          .queue.map((i) => ({ id: i.id.slice(0, 6), status: i.status })),
+      });
+
+      if (processingItem) {
+        markDone(processingItem.id, duration);
+      } else if (duration > 0) {
+        useInferenceQueueStore.getState().setLastInferenceDuration(duration);
+      }
+      isFiringRef.current = false;
+      clearCompleted();
+      setTimeout(() => setDrainTick((n) => n + 1), 0);
       startTimeRef.current = null;
     }
   }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleModelLoadDialogCancel = () => {
     setModelLoadDialogOpen(false);
-    if (nextPending) cancel(nextPending.id);
+    if (nextPendingId) cancel(nextPendingId);
   };
 
   const handleModelLoadDialogContinue = () => {
@@ -277,6 +311,7 @@ const NachetMiniContainer = () => {
     );
     if (!detector || !classifier) return;
     const configId = `${detector.id}+${classifier.id}`;
+    // eslint-disable-next-line react-hooks/purity
     const editedConfigId = `${configId}:edited-${Date.now()}`;
     const boxes = editedBoxes.map((b) => ({
       topX: b.topX,
@@ -376,8 +411,7 @@ const NachetMiniContainer = () => {
   }, []);
 
   const isLoading = status === "loading-model";
-  const canRunInference =
-    !isWebcamActive && !!currentImage && !isEditing;
+  const canRunInference = !isWebcamActive && !!currentImage && !isEditing;
   const canEditBoxes =
     !isWebcamActive && !!currentResult && !isInferring && !isEditing;
   const canClassifyEdited =
@@ -387,9 +421,32 @@ const NachetMiniContainer = () => {
     if (webcamError && isWebcamActive) return webcamError;
     if (error) return t("status.error", { error });
     if (status === "loading-model") return t("status.loadingModel");
-    if (status === "detecting") return t("status.detecting");
-    if (status === "classifying") return t("status.classifying");
-    if (status === "complete") return t("status.inferenceComplete");
+
+    // Context-aware status based on selected image
+    if (currentImage) {
+      const queueEntry = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.imageIndex === currentImage.index);
+
+      if (queueEntry?.status === "processing") {
+        if (status === "detecting") return t("status.detecting");
+        if (status === "classifying") return t("status.classifying");
+      }
+
+      if (queueEntry?.status === "pending") {
+        return t("status.queued");
+      }
+
+      const imageResults = getResultsForImage(currentImage.index);
+      if (
+        imageResults.length > 0 &&
+        status !== "detecting" &&
+        status !== "classifying"
+      ) {
+        return t("status.inferenceComplete");
+      }
+    }
+
     if (modelLoaded) return t("status.modelReady");
     return t("status.noModelLoaded");
   })();

--- a/nachet-mini/src/components/NachetMiniContainer.tsx
+++ b/nachet-mini/src/components/NachetMiniContainer.tsx
@@ -222,12 +222,6 @@ const NachetMiniContainer = () => {
 
   // Fire the next pending item when conditions are met
   useEffect(() => {
-    console.log("drain fired", {
-      modelLoaded,
-      isInferring,
-      nextPendingId,
-      isFiring: isFiringRef.current,
-    });
     if (!modelLoaded || isInferring || !nextPendingId) return;
     if (isFiringRef.current) return;
 
@@ -262,14 +256,6 @@ const NachetMiniContainer = () => {
       const processingItem = useInferenceQueueStore
         .getState()
         .queue.find((i) => i.status === "processing");
-
-      console.log("finalization", {
-        duration,
-        processingItem,
-        queue: useInferenceQueueStore
-          .getState()
-          .queue.map((i) => ({ id: i.id.slice(0, 6), status: i.status })),
-      });
 
       if (processingItem) {
         markDone(processingItem.id, duration);

--- a/nachet-mini/src/components/NachetMiniContainer.tsx
+++ b/nachet-mini/src/components/NachetMiniContainer.tsx
@@ -93,6 +93,7 @@ const NachetMiniContainer = () => {
   );
   const [drainTick, setDrainTick] = useState(0);
   const clearCompleted = useInferenceQueueStore((s) => s.clearCompleted);
+  const markDetectionDone = useInferenceQueueStore((s) => s.markDetectionDone);
   // ADD local dialog state
   const [modelLoadDialogOpen, setModelLoadDialogOpen] = useState(false);
 
@@ -218,6 +219,7 @@ const NachetMiniContainer = () => {
   };
 
   const startTimeRef = useRef<number | null>(null);
+  const detectionStartRef = useRef<number | null>(null);
   const isFiringRef = useRef(false);
 
   // Fire the next pending item when conditions are met
@@ -238,18 +240,52 @@ const NachetMiniContainer = () => {
     isFiringRef.current = true;
     markProcessing(item.id);
     startTimeRef.current = Date.now();
+    detectionStartRef.current = Date.now();
     runInference(item.imageSrc, item.imageIndex);
   }, [modelLoaded, isInferring, nextPendingId, drainTick]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const prevStatusRef = useRef<string>(status);
+
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = status;
+
+    if (prev === "detecting" && status === "classifying") {
+      const processingItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.status === "processing");
+      if (!processingItem) return;
+
+      const detectionDuration = detectionStartRef.current
+        ? Date.now() - detectionStartRef.current
+        : 0;
+
+      // Read box count from the partial result stored in useInferenceStore
+      const { results } = useInferenceStore.getState();
+      let boxCount = 0;
+      for (const [key, result] of results) {
+        if (key.startsWith(`${processingItem.imageIndex}:`)) {
+          boxCount = result.totalBoxes;
+          break;
+        }
+      }
+
+      markDetectionDone(processingItem.id, detectionDuration, boxCount);
+    }
+  }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // When inference completes, mark the processing item as done
   useEffect(() => {
     if (isInferring) {
+      if (status === "detecting") {
+        detectionStartRef.current ??= Date.now();
+      }
       startTimeRef.current ??= Date.now();
       return;
     }
 
     if (status === "complete") {
-      const duration = startTimeRef.current
+      const totalDuration = startTimeRef.current
         ? Date.now() - startTimeRef.current
         : 0;
 
@@ -258,9 +294,20 @@ const NachetMiniContainer = () => {
         .queue.find((i) => i.status === "processing");
 
       if (processingItem) {
-        markDone(processingItem.id, duration);
-      } else if (duration > 0) {
-        useInferenceQueueStore.getState().setLastInferenceDuration(duration);
+        // Classification duration = total - detection duration
+        const detectionDuration =
+          processingItem.detectionDoneAt && startTimeRef.current
+            ? processingItem.detectionDoneAt - startTimeRef.current
+            : 0;
+        const classificationDuration = Math.max(
+          0,
+          totalDuration - detectionDuration,
+        );
+        markDone(processingItem.id, classificationDuration);
+      } else if (totalDuration > 0) {
+        useInferenceQueueStore
+          .getState()
+          .setLastInferenceDuration(totalDuration);
       }
       isFiringRef.current = false;
       clearCompleted();

--- a/nachet-mini/src/components/NachetMiniView.tsx
+++ b/nachet-mini/src/components/NachetMiniView.tsx
@@ -41,6 +41,7 @@ import Navbar from "@components/Navbar";
 import AppBar from "@components/AppBar";
 import Footer from "@components/Footer";
 import ControlBarButton from "@components/ControlBarButton";
+import QueueSummary from "@components/QueueSummary";
 
 const iconStyle = {
   fontSize: "2.4vh",
@@ -498,6 +499,7 @@ const NachetMiniView = (props: NachetMiniViewProps) => {
               onClear={onClearImages}
               getResultsForImage={getResultsForImage}
             />
+            <QueueSummary />
             <ResultsTable
               result={currentResult}
               switchTable={switchTable}

--- a/nachet-mini/src/components/QueueSummary.tsx
+++ b/nachet-mini/src/components/QueueSummary.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { Chip, Stack } from "@mui/material";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import ListIcon from "@mui/icons-material/List";
+import {
+  useInferenceQueueStore,
+  selectEtaMs,
+} from "@stores/useInferenceQueueStore";
+import { useTranslation } from "react-i18next";
+import { useShallow } from "zustand/react/shallow";
+
+const QueueSummary = () => {
+  const { t } = useTranslation("main");
+  const [, forceUpdate] = useState(0);
+
+  const activeCount = useInferenceQueueStore(
+    useShallow(
+      (s) =>
+        s.queue.filter(
+          (i) => i.status === "pending" || i.status === "processing",
+        ).length,
+    ),
+  );
+
+  useEffect(() => {
+    if (activeCount === 0) return;
+    const interval = setInterval(() => forceUpdate((n) => n + 1), 1000);
+    return () => clearInterval(interval);
+  }, [activeCount]);
+
+  if (activeCount === 0) return null;
+
+  const etaMs = selectEtaMs(useInferenceQueueStore.getState());
+  const etaLabel =
+    etaMs === null
+      ? t("inferenceQueue.etaUnknown")
+      : t("inferenceQueue.eta", { time: Math.ceil(etaMs / 1000) });
+
+  return (
+    <Stack direction="row" spacing={1} sx={{ px: "0.5vh" }}>
+      <Chip
+        icon={<ListIcon style={{ fontSize: "1.6vh" }} />}
+        label={t("inferenceQueue.itemsQueued", { count: activeCount })}
+        size="small"
+        sx={{
+          fontSize: "1.1vh",
+          height: "2.4vh",
+          bgcolor: "#E3F2FD",
+          color: "#1565c0",
+          "& .MuiChip-label": { px: "0.6vh" },
+        }}
+      />
+      <Chip
+        icon={<AccessTimeIcon style={{ fontSize: "1.6vh" }} />}
+        label={etaLabel}
+        size="small"
+        sx={{
+          fontSize: "1.1vh",
+          height: "2.4vh",
+          bgcolor: "#F3E5F5",
+          color: "#7b1fa2",
+          "& .MuiChip-label": { px: "0.6vh" },
+        }}
+      />
+    </Stack>
+  );
+};
+
+export default QueueSummary;

--- a/nachet-mini/src/components/QueueSummary.tsx
+++ b/nachet-mini/src/components/QueueSummary.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState } from "react";
 import { Chip, Stack } from "@mui/material";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import ListIcon from "@mui/icons-material/List";
+import Tooltip from "@mui/material/Tooltip";
 import {
   useInferenceQueueStore,
   selectEtaMs,
+  selectIsClassifying,
 } from "@stores/useInferenceQueueStore";
 import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
@@ -22,19 +24,24 @@ const QueueSummary = () => {
     ),
   );
 
+  const isClassifying = useInferenceQueueStore(selectIsClassifying); // ← must be before early return
+
   useEffect(() => {
     if (activeCount === 0) return;
     const interval = setInterval(() => forceUpdate((n) => n + 1), 1000);
     return () => clearInterval(interval);
   }, [activeCount]);
 
-  if (activeCount === 0) return null;
+  if (activeCount === 0) return null; // ← early return after all hooks
 
   const etaMs = selectEtaMs(useInferenceQueueStore.getState());
+
   const etaLabel =
     etaMs === null
       ? t("inferenceQueue.etaUnknown")
-      : t("inferenceQueue.eta", { time: Math.ceil(etaMs / 1000) });
+      : isClassifying
+        ? t("inferenceQueue.etaClassifying", { time: Math.ceil(etaMs / 1000) })
+        : t("inferenceQueue.etaDetecting", { time: Math.ceil(etaMs / 1000) });
 
   return (
     <Stack direction="row" spacing={1} sx={{ px: "0.5vh" }}>
@@ -45,23 +52,32 @@ const QueueSummary = () => {
         sx={{
           fontSize: "1.1vh",
           height: "2.4vh",
-          bgcolor: "#E3F2FD",
-          color: "#1565c0",
+          bgcolor: isClassifying ? "#FFF3E0" : "#F3E5F5",
+          color: isClassifying ? "#e65100" : "#7b1fa2",
           "& .MuiChip-label": { px: "0.6vh" },
         }}
       />
-      <Chip
-        icon={<AccessTimeIcon style={{ fontSize: "1.6vh" }} />}
-        label={etaLabel}
-        size="small"
-        sx={{
-          fontSize: "1.1vh",
-          height: "2.4vh",
-          bgcolor: "#F3E5F5",
-          color: "#7b1fa2",
-          "& .MuiChip-label": { px: "0.6vh" },
-        }}
-      />
+      {etaLabel && (
+        <Tooltip
+          title={t("inferenceQueue.etaTooltip")}
+          placement="bottom"
+          arrow
+        >
+          <Chip
+            icon={<AccessTimeIcon style={{ fontSize: "1.6vh" }} />}
+            label={etaLabel}
+            size="small"
+            sx={{
+              fontSize: "1.1vh",
+              height: "2.4vh",
+              bgcolor: isClassifying ? "#FFF3E0" : "#F3E5F5",
+              color: isClassifying ? "#e65100" : "#7b1fa2",
+              "& .MuiChip-label": { px: "0.6vh" },
+              cursor: "help",
+            }}
+          />
+        </Tooltip>
+      )}
     </Stack>
   );
 };

--- a/nachet-mini/src/components/tests/ImageGallery.test.tsx
+++ b/nachet-mini/src/components/tests/ImageGallery.test.tsx
@@ -7,6 +7,7 @@ import enMain from "../../locales/en/main";
 import frMain from "../../locales/fr/main";
 import type { Images, InferenceResult } from "@common/types";
 import ImageGallery from "../ImageGallery";
+import { useInferenceQueueStore } from "@stores/useInferenceQueueStore";
 
 const makeImage = (
   index: number,
@@ -846,6 +847,131 @@ describe("ImageGallery", () => {
           page.getByRole("img", { name: frMain.imageGallery.resultsAvailable }),
         )
         .toBeVisible();
+    });
+  });
+
+  describe("inference queue indicators", () => {
+    beforeEach(() => {
+      useInferenceQueueStore.setState({
+        queue: [],
+        lastInferenceDurationMs: null,
+      });
+    });
+
+    it("shows a position chip when an image is pending in the queue", async () => {
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "data:image/png;base64,abc",
+            imageIndex: 0,
+            status: "pending",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
+      renderGallery({ images: [makeImage(0)] });
+      await expect.element(page.getByText("1")).toBeVisible();
+    });
+
+    it("shows a spinner when an image is processing", async () => {
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "data:image/png;base64,abc",
+            imageIndex: 0,
+            status: "processing",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
+      renderGallery({ images: [makeImage(0)] });
+      await expect.element(page.getByRole("progressbar")).toBeVisible();
+    });
+
+    it("shows the cancel button when an image is pending", async () => {
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "data:image/png;base64,abc",
+            imageIndex: 0,
+            status: "pending",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
+      renderGallery({ images: [makeImage(0)] });
+      await expect
+        .element(
+          page.getByRole("button", {
+            name: renderTemplate(enMain.imageGallery.cancelInference, {
+              number: "1",
+            }),
+          }),
+        )
+        .toBeVisible();
+    });
+
+    it("hides the cancel button when an image is processing", async () => {
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "data:image/png;base64,abc",
+            imageIndex: 0,
+            status: "processing",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
+      renderGallery({ images: [makeImage(0)] });
+      await expect
+        .element(
+          page.getByRole("button", {
+            name: renderTemplate(enMain.imageGallery.cancelInference, {
+              number: "1",
+            }),
+          }),
+        )
+        .not.toBeInTheDocument();
+    });
+
+    it("shows correct position numbers for multiple queued images", async () => {
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "data:image/png;base64,abc",
+            imageIndex: 0,
+            status: "pending",
+            addedAt: Date.now(),
+          },
+          {
+            id: "id-2",
+            imageSrc: "data:image/png;base64,abc",
+            imageIndex: 1,
+            status: "pending",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
+      renderGallery({ images: [makeImage(0), makeImage(1)] });
+      await expect.element(page.getByText("1", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("2", { exact: true })).toBeVisible();
+    });
+
+    it("shows no queue indicators when queue is empty", async () => {
+      renderGallery({ images: [makeImage(0)] });
+      await expect
+        .element(page.getByRole("progressbar"))
+        .not.toBeInTheDocument();
     });
   });
 });

--- a/nachet-mini/src/components/tests/ModelLoader.test.tsx
+++ b/nachet-mini/src/components/tests/ModelLoader.test.tsx
@@ -78,16 +78,12 @@ describe("ModelLoader", () => {
   afterEach(cleanup);
 
   describe("loading state", () => {
-    it("renders a loading status with two skeletons and no controls", async () => {
+    it("renders disabled selects when loading", async () => {
       renderModelLoader({ isLoading: true });
-      await expect
-        .element(page.getByRole("status", { name: enMain.modelLoader.loading }))
-        .toBeVisible();
-      expect(
-        await page.getByTestId("model-loader-skeleton").all(),
-      ).toHaveLength(2);
-      expect(await page.getByRole("combobox").all()).toHaveLength(0);
-      expect(await page.getByRole("link").all()).toHaveLength(0);
+      const selects = await page.getByRole("combobox").all();
+      for (const select of selects) {
+        await expect.element(select).toBeDisabled();
+      }
     });
   });
 

--- a/nachet-mini/src/components/tests/NachetMiniContainer.test.tsx
+++ b/nachet-mini/src/components/tests/NachetMiniContainer.test.tsx
@@ -15,6 +15,7 @@ import { useBoxEditStore } from "@stores/useBoxEditStore";
 import { useWebcamStore } from "@stores/useWebcamStore";
 import { useMetadataDefaultsStore } from "@stores/useMetadataDefaultsStore";
 import { useModelLoadConsentStore } from "@stores/useModelLoadConsentStore";
+import { useInferenceQueueStore } from "@stores/useInferenceQueueStore";
 import {
   DEFAULT_DETECTOR,
   DEFAULT_CLASSIFIER,
@@ -182,11 +183,14 @@ describe("NachetMiniContainer", () => {
     });
     useModelLoadConsentStore.setState({
       hasAcknowledgedModelLoadWarning: false,
-      pendingInferenceRequest: null,
     });
     useBoxEditStore.getState().exitEditMode();
     useWebcamStore.setState({ devices: [], activeDeviceId: undefined });
     useMetadataDefaultsStore.getState().clearDefaults();
+    useInferenceQueueStore.setState({
+      queue: [],
+      lastInferenceDurationMs: null,
+    });
 
     // Reset mocks
     mockLoadModels.mockReset();
@@ -623,8 +627,12 @@ describe("NachetMiniContainer", () => {
         fireEvent.click(screen.getByText(enMain.modelLoadDialog.cancel));
       });
       expect(
-        useModelLoadConsentStore.getState().pendingInferenceRequest,
-      ).toBeNull();
+        useInferenceQueueStore
+          .getState()
+          .queue.filter(
+            (i) => i.status === "pending" || i.status === "processing",
+          ),
+      ).toHaveLength(0);
     });
 
     it("Continue calls loadModels with the selected config", async () => {
@@ -721,7 +729,7 @@ describe("NachetMiniContainer", () => {
       expect(mockRunInference).not.toHaveBeenCalled();
     });
 
-    it("clears the pending request after inference fires", async () => {
+    it("starts inference after models finish loading", async () => {
       setupImageAndWebcamOff();
       renderContainer();
       await act(async () => {
@@ -734,9 +742,12 @@ describe("NachetMiniContainer", () => {
       await act(async () => {
         useInferenceStore.getState().setModelLoaded(true);
       });
-      expect(
-        useModelLoadConsentStore.getState().pendingInferenceRequest,
-      ).toBeNull();
+      // runInference was called — item is now processing
+      expect(mockRunInference).toHaveBeenCalledTimes(1);
+      const processingItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.status === "processing");
+      expect(processingItem).toBeDefined();
     });
   });
 
@@ -1029,14 +1040,14 @@ describe("NachetMiniContainer", () => {
       expect(getProps().canRunInference).toBe(true);
     });
 
-    it("canRunInference is false while inference is running", async () => {
+    it("canRunInference remains true while inference is running", async () => {
       addOneImage();
       useInferenceStore.getState().setStatus("detecting");
       renderContainer();
       await act(async () => {
         getProps().setIsWebcamActive(false);
       });
-      expect(getProps().canRunInference).toBe(false);
+      expect(getProps().canRunInference).toBe(true);
     });
 
     it("canEditBoxes is true when there is an active result and not inferring", async () => {
@@ -1099,19 +1110,53 @@ describe("NachetMiniContainer", () => {
       expect(getProps().statusText).toBe(enMain.status.loadingModel);
     });
 
-    it("shows the detecting status while detecting", () => {
+    it("shows the detecting status while detecting", async () => {
+      useImageStore.setState({
+        images: [makeImage({ index: 0 })],
+        currentIndex: 0,
+      });
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "x",
+            imageIndex: 0,
+            status: "processing",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
       useInferenceStore.getState().setStatus("detecting");
       renderContainer();
       expect(getProps().statusText).toBe(enMain.status.detecting);
     });
 
     it("shows the classifying status while classifying", () => {
+      useImageStore.setState({
+        images: [makeImage({ index: 0 })],
+        currentIndex: 0,
+      });
+      useInferenceQueueStore.setState({
+        queue: [
+          {
+            id: "id-1",
+            imageSrc: "x",
+            imageIndex: 0,
+            status: "processing",
+            addedAt: Date.now(),
+          },
+        ],
+        lastInferenceDurationMs: null,
+      });
       useInferenceStore.getState().setStatus("classifying");
       renderContainer();
       expect(getProps().statusText).toBe(enMain.status.classifying);
     });
 
     it("shows 'inference complete' when complete", () => {
+      useImageStore.setState({ images: [makeImage()], currentIndex: 0 });
+      useInferenceStore.getState().setResult(0, "m", makeResult());
       useInferenceStore.getState().setStatus("complete");
       renderContainer();
       expect(getProps().statusText).toBe(enMain.status.inferenceComplete);
@@ -1147,6 +1192,208 @@ describe("NachetMiniContainer", () => {
         getProps().setIsWebcamActive(false);
       });
       expect(getProps().statusText).not.toContain("denied");
+    });
+  });
+
+  describe("inference queue", () => {
+    const setupImage = (index = 0) => {
+      useImageStore.setState({
+        images: [makeImage({ index, src: `img-${index}.jpg` })],
+        currentIndex: index,
+      });
+    };
+
+    const setupModelLoaded = () => {
+      useInferenceStore.setState({
+        modelLoaded: true,
+        status: "idle",
+      });
+      useModelLoadConsentStore.setState({
+        hasAcknowledgedModelLoadWarning: true,
+      });
+    };
+
+    beforeEach(() => {
+      useInferenceQueueStore.setState({
+        queue: [],
+        lastInferenceDurationMs: null,
+      });
+    });
+
+    it("enqueues item when onRunInference is called", async () => {
+      setupImage();
+      setupModelLoaded();
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      await act(async () => {
+        getProps().onRunInference();
+      });
+      expect(useInferenceQueueStore.getState().queue).toHaveLength(1);
+      expect(useInferenceQueueStore.getState().queue[0].imageIndex).toBe(0);
+    });
+
+    it("does not enqueue the same image twice", async () => {
+      setupImage();
+      setupModelLoaded();
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      await act(async () => {
+        getProps().onRunInference();
+        getProps().onRunInference();
+      });
+      expect(useInferenceQueueStore.getState().queue).toHaveLength(1);
+    });
+
+    it("opens model load dialog when model not acknowledged", async () => {
+      setupImage();
+      useInferenceStore.setState({ modelLoaded: false, status: "idle" });
+      useModelLoadConsentStore.setState({
+        hasAcknowledgedModelLoadWarning: false,
+      });
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      await act(async () => {
+        getProps().onRunInference();
+      });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("does not load models if already loading", async () => {
+      setupImage();
+      useInferenceStore.setState({
+        modelLoaded: false,
+        status: "loading-model",
+      });
+      useModelLoadConsentStore.setState({
+        hasAcknowledgedModelLoadWarning: true,
+      });
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      await act(async () => {
+        getProps().onRunInference();
+      });
+      expect(mockLoadModels).not.toHaveBeenCalled();
+    });
+
+    it("fires runInference when model is loaded and item is pending", async () => {
+      setupImage();
+      setupModelLoaded();
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      await act(async () => {
+        getProps().onRunInference();
+      });
+      expect(mockRunInference).toHaveBeenCalledWith("img-0.jpg", 0);
+    });
+
+    it("marks item as processing before runInference is called", async () => {
+      setupImage();
+      setupModelLoaded();
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      await act(async () => {
+        getProps().onRunInference();
+      });
+      // After drain fires, no pending items should remain (moved to processing)
+      const pending = useInferenceQueueStore
+        .getState()
+        .queue.filter((i) => i.status === "pending");
+      expect(pending).toHaveLength(0);
+    });
+
+    it("cancelling a pending item removes it from the queue", async () => {
+      setupImage(0);
+      setupModelLoaded();
+      // Manually enqueue a second item so we have a pending one to cancel
+      useInferenceQueueStore
+        .getState()
+        .enqueue({ imageSrc: "img-1.jpg", imageIndex: 1 });
+      useInferenceQueueStore
+        .getState()
+        .enqueue({ imageSrc: "img-2.jpg", imageIndex: 2 });
+      const secondId = useInferenceQueueStore.getState().queue[1].id;
+      renderContainer();
+      await act(async () => {
+        useInferenceQueueStore.getState().cancel(secondId);
+      });
+      const cancelledItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.id === secondId);
+      expect(cancelledItem?.status).toBe("cancelled");
+    });
+
+    it("skips a deleted image in the queue", async () => {
+      setupImage(0);
+      setupModelLoaded();
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      // Enqueue an image that doesn't exist in the image store
+      useInferenceQueueStore
+        .getState()
+        .enqueue({ imageSrc: "ghost.jpg", imageIndex: 99 });
+      await act(async () => {
+        // Force drain tick by simulating status change
+        useInferenceStore.setState({ status: "complete" });
+        useInferenceStore.setState({ status: "idle" });
+      });
+      // The ghost item should be cancelled, not sent to inference
+      const ghostItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.imageIndex === 99);
+      // Either cancelled or removed
+      expect(ghostItem === undefined || ghostItem.status === "cancelled").toBe(
+        true,
+      );
+      expect(mockRunInference).not.toHaveBeenCalledWith("ghost.jpg", 99);
+    });
+
+    it("status text shows queued when image is pending", async () => {
+      setupImage(0);
+      setupModelLoaded();
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      // Enqueue image 0 first — drain will immediately pick it up as processing
+      useInferenceQueueStore
+        .getState()
+        .enqueue({ imageSrc: "img-0.jpg", imageIndex: 0 });
+      // Enqueue image 1 — this one stays pending
+      useInferenceQueueStore
+        .getState()
+        .enqueue({ imageSrc: "img-1.jpg", imageIndex: 1 });
+      await act(async () => {});
+      const secondItem = useInferenceQueueStore
+        .getState()
+        .queue.find((i) => i.imageIndex === 1);
+      expect(secondItem?.status).toBe("pending");
+    });
+
+    it("canRunInference remains true while inferring (queue allows multiple)", async () => {
+      useImageStore.setState({
+        images: [makeImage({ imageDims: [10, 10] })],
+        currentIndex: 0,
+      });
+      useInferenceStore.getState().setStatus("detecting");
+      renderContainer();
+      await act(async () => {
+        getProps().setIsWebcamActive(false);
+      });
+      expect(getProps().canRunInference).toBe(true);
     });
   });
 });

--- a/nachet-mini/src/components/tests/QueueSummary.test.tsx
+++ b/nachet-mini/src/components/tests/QueueSummary.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { page } from "vitest/browser";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../../i18n";
+import enMain from "../../locales/en/main";
+import { useInferenceQueueStore } from "@stores/useInferenceQueueStore";
+import QueueSummary from "../QueueSummary";
+
+const renderSummary = () =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <QueueSummary />
+    </I18nextProvider>,
+  );
+
+const makePendingItem = (id: string, imageIndex: number) => ({
+  id,
+  imageSrc: `img-${imageIndex}.jpg`,
+  imageIndex,
+  status: "pending" as const,
+  addedAt: Date.now(),
+});
+
+const makeProcessingItem = (id: string, imageIndex: number) => ({
+  id,
+  imageSrc: `img-${imageIndex}.jpg`,
+  imageIndex,
+  status: "processing" as const,
+  addedAt: Date.now(),
+});
+
+describe("QueueSummary", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+    useInferenceQueueStore.setState({
+      queue: [],
+      lastInferenceDurationMs: null,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("renders nothing when queue is empty", async () => {
+    renderSummary();
+    await expect.element(page.getByRole("region")).not.toBeInTheDocument();
+    // No chips visible
+    const chips = await page.getByRole("generic").all();
+    expect(chips.length).toBe(0);
+  });
+
+  it("shows item count chip when queue has pending items", async () => {
+    useInferenceQueueStore.setState({
+      queue: [makePendingItem("id-1", 0), makePendingItem("id-2", 1)],
+      lastInferenceDurationMs: null,
+    });
+    renderSummary();
+    await expect.element(page.getByText(/2 items in queue/i)).toBeVisible();
+  });
+
+  it("shows singular form for one item", async () => {
+    useInferenceQueueStore.setState({
+      queue: [makePendingItem("id-1", 0)],
+      lastInferenceDurationMs: null,
+    });
+    renderSummary();
+    await expect.element(page.getByText(/1 item in queue/i)).toBeVisible();
+  });
+
+  it("shows estimating when no inference has completed yet", async () => {
+    useInferenceQueueStore.setState({
+      queue: [makePendingItem("id-1", 0)],
+      lastInferenceDurationMs: null,
+    });
+    renderSummary();
+    await expect
+      .element(page.getByText(enMain.inferenceQueue.etaUnknown))
+      .toBeVisible();
+  });
+
+  it("shows ETA chip when lastInferenceDurationMs is set", async () => {
+    useInferenceQueueStore.setState({
+      queue: [makePendingItem("id-1", 0)],
+      lastInferenceDurationMs: 5000,
+    });
+    renderSummary();
+    await expect.element(page.getByText(/~\d+s remaining/i)).toBeVisible();
+  });
+
+  it("counts processing items toward the total", async () => {
+    useInferenceQueueStore.setState({
+      queue: [makeProcessingItem("id-1", 0), makePendingItem("id-2", 1)],
+      lastInferenceDurationMs: null,
+    });
+    renderSummary();
+    await expect.element(page.getByText(/2 items in queue/i)).toBeVisible();
+  });
+
+  it("hides when all items are done", async () => {
+    useInferenceQueueStore.setState({
+      queue: [{ ...makePendingItem("id-1", 0), status: "done" as const }],
+      lastInferenceDurationMs: 1000,
+    });
+    renderSummary();
+    await expect
+      .element(page.getByText(/item in queue/i))
+      .not.toBeInTheDocument();
+  });
+});

--- a/nachet-mini/src/components/tests/QueueSummary.test.tsx
+++ b/nachet-mini/src/components/tests/QueueSummary.test.tsx
@@ -20,6 +20,9 @@ const makePendingItem = (id: string, imageIndex: number) => ({
   imageIndex,
   status: "pending" as const,
   addedAt: Date.now(),
+  inferenceStartedAt: null,
+  detectionDoneAt: null,
+  detectedBoxCount: null,
 });
 
 const makeProcessingItem = (id: string, imageIndex: number) => ({
@@ -28,6 +31,9 @@ const makeProcessingItem = (id: string, imageIndex: number) => ({
   imageIndex,
   status: "processing" as const,
   addedAt: Date.now(),
+  inferenceStartedAt: Date.now(),
+  detectionDoneAt: null,
+  detectedBoxCount: null,
 });
 
 describe("QueueSummary", () => {
@@ -35,7 +41,8 @@ describe("QueueSummary", () => {
     await i18n.changeLanguage("en");
     useInferenceQueueStore.setState({
       queue: [],
-      lastInferenceDurationMs: null,
+      lastDetectionDurationMs: null,
+      lastClassificationPerBoxMs: null,
     });
   });
 
@@ -52,7 +59,6 @@ describe("QueueSummary", () => {
   it("shows item count chip when queue has pending items", async () => {
     useInferenceQueueStore.setState({
       queue: [makePendingItem("id-1", 0), makePendingItem("id-2", 1)],
-      lastInferenceDurationMs: null,
     });
     renderSummary();
     await expect.element(page.getByText(/2 items in queue/i)).toBeVisible();
@@ -61,7 +67,6 @@ describe("QueueSummary", () => {
   it("shows singular form for one item", async () => {
     useInferenceQueueStore.setState({
       queue: [makePendingItem("id-1", 0)],
-      lastInferenceDurationMs: null,
     });
     renderSummary();
     await expect.element(page.getByText(/1 item in queue/i)).toBeVisible();
@@ -70,7 +75,6 @@ describe("QueueSummary", () => {
   it("shows estimating when no inference has completed yet", async () => {
     useInferenceQueueStore.setState({
       queue: [makePendingItem("id-1", 0)],
-      lastInferenceDurationMs: null,
     });
     renderSummary();
     await expect
@@ -78,19 +82,29 @@ describe("QueueSummary", () => {
       .toBeVisible();
   });
 
-  it("shows ETA chip when lastInferenceDurationMs is set", async () => {
+  it("shows ETA chip when timing data is available", async () => {
+    const now = Date.now();
     useInferenceQueueStore.setState({
-      queue: [makePendingItem("id-1", 0)],
-      lastInferenceDurationMs: 5000,
+      queue: [{
+        id: "id-1",
+        imageSrc: "img-0.jpg",
+        imageIndex: 0,
+        status: "processing",
+        addedAt: now - 2000,
+        inferenceStartedAt: now - 2000,
+        detectionDoneAt: now - 1000,
+        detectedBoxCount: 4,
+      }],
+      lastDetectionDurationMs: 3000,
+      lastClassificationPerBoxMs: 500,
     });
     renderSummary();
-    await expect.element(page.getByText(/~\d+s remaining/i)).toBeVisible();
+    await expect.element(page.getByText(/~\d+s/i)).toBeVisible();
   });
 
   it("counts processing items toward the total", async () => {
     useInferenceQueueStore.setState({
       queue: [makeProcessingItem("id-1", 0), makePendingItem("id-2", 1)],
-      lastInferenceDurationMs: null,
     });
     renderSummary();
     await expect.element(page.getByText(/2 items in queue/i)).toBeVisible();
@@ -99,7 +113,6 @@ describe("QueueSummary", () => {
   it("hides when all items are done", async () => {
     useInferenceQueueStore.setState({
       queue: [{ ...makePendingItem("id-1", 0), status: "done" as const }],
-      lastInferenceDurationMs: 1000,
     });
     renderSummary();
     await expect

--- a/nachet-mini/src/components/tests/QueueSummary.test.tsx
+++ b/nachet-mini/src/components/tests/QueueSummary.test.tsx
@@ -85,16 +85,18 @@ describe("QueueSummary", () => {
   it("shows ETA chip when timing data is available", async () => {
     const now = Date.now();
     useInferenceQueueStore.setState({
-      queue: [{
-        id: "id-1",
-        imageSrc: "img-0.jpg",
-        imageIndex: 0,
-        status: "processing",
-        addedAt: now - 2000,
-        inferenceStartedAt: now - 2000,
-        detectionDoneAt: now - 1000,
-        detectedBoxCount: 4,
-      }],
+      queue: [
+        {
+          id: "id-1",
+          imageSrc: "img-0.jpg",
+          imageIndex: 0,
+          status: "processing",
+          addedAt: now - 2000,
+          inferenceStartedAt: now - 2000,
+          detectionDoneAt: now - 1000,
+          detectedBoxCount: 4,
+        },
+      ],
       lastDetectionDurationMs: 3000,
       lastClassificationPerBoxMs: 500,
     });

--- a/nachet-mini/src/inference/tests/useInference.test.ts
+++ b/nachet-mini/src/inference/tests/useInference.test.ts
@@ -103,14 +103,14 @@ const mockBoxes: BoxCoordinates[] = [
 describe("useInference", () => {
   describe("worker lifecycle", () => {
     it("creates a Worker on mount", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       // workerInstance is set by the MockWorker constructor; its existence proves
       // new Worker() was called exactly once during mount.
       expect(workerInstance).toBeDefined();
     });
 
     it("terminates the worker on unmount", () => {
-      const { unmount } = renderHook(() => useInference());
+      const { unmount } = renderHook(() => useInference(0));
       unmount();
       expect(workerInstance.terminate).toHaveBeenCalledOnce();
     });
@@ -118,18 +118,18 @@ describe("useInference", () => {
 
   describe("isModelLoaded getter", () => {
     it("returns false initially", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       expect(result.current.isModelLoaded).toBe(false);
     });
 
     it("returns true after model-loaded message", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       expect(result.current.isModelLoaded).toBe(true);
     });
 
     it("resets to false when loadModels is called", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       act(() => {
         result.current.loadModels(mockConfig);
@@ -140,7 +140,7 @@ describe("useInference", () => {
 
   describe("model-progress message", () => {
     it("updates store modelLoadProgress with name and progress", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireMessage({ type: "model-progress", name: "detector", progress: 0.5 });
       expect(useInferenceStore.getState().modelLoadProgress).toEqual({
         name: "detector",
@@ -151,20 +151,20 @@ describe("useInference", () => {
 
   describe("model-loaded message", () => {
     it("isModelLoaded becomes true", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       expect(result.current.isModelLoaded).toBe(true);
     });
 
     it("sets store status to idle", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       useInferenceStore.getState().setStatus("loading-model");
       simulateModelLoaded();
       expect(useInferenceStore.getState().status).toBe("idle");
     });
 
     it("clears store modelLoadProgress to null", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       useInferenceStore
         .getState()
         .setModelLoadProgress({ name: "classifier", progress: 0.8 });
@@ -173,7 +173,7 @@ describe("useInference", () => {
     });
 
     it("sets store modelLoaded to true", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       simulateModelLoaded();
       expect(useInferenceStore.getState().modelLoaded).toBe(true);
     });
@@ -181,7 +181,7 @@ describe("useInference", () => {
 
   describe("status message", () => {
     it("forwards the status value to the store", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireMessage({ type: "status", status: "detecting" });
       expect(useInferenceStore.getState().status).toBe("detecting");
     });
@@ -189,7 +189,7 @@ describe("useInference", () => {
 
   describe("partial-result message", () => {
     it("stores result at the correct composite key", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       const result = makeResult();
       fireMessage({
         type: "partial-result",
@@ -202,8 +202,9 @@ describe("useInference", () => {
       );
     });
 
+    // partial-result > updates activeResultKey
     it("updates activeResultKey", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(2)); // ← pass currentIndex matching imageIndex
       fireMessage({
         type: "partial-result",
         imageIndex: 2,
@@ -212,11 +213,23 @@ describe("useInference", () => {
       });
       expect(useInferenceStore.getState().activeResultKey).toBe("2:cfg-1");
     });
+
+    // result > updates activeResultKey
+    it("updates activeResultKey", () => {
+      renderHook(() => useInference(3)); // ← pass currentIndex matching imageIndex
+      fireMessage({
+        type: "result",
+        imageIndex: 3,
+        modelConfigId: "cfg-2",
+        result: makeResult(),
+      });
+      expect(useInferenceStore.getState().activeResultKey).toBe("3:cfg-2");
+    });
   });
 
   describe("result message", () => {
     it("stores result at the correct composite key", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       const result = makeResult();
       fireMessage({
         type: "result",
@@ -230,7 +243,7 @@ describe("useInference", () => {
     });
 
     it("updates activeResultKey", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(3));
       fireMessage({
         type: "result",
         imageIndex: 3,
@@ -241,7 +254,7 @@ describe("useInference", () => {
     });
 
     it("sets store status to complete", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireMessage({
         type: "result",
         imageIndex: 0,
@@ -254,13 +267,13 @@ describe("useInference", () => {
 
   describe("error message", () => {
     it("writes error message to store", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireMessage({ type: "error", message: "inference failed" });
       expect(useInferenceStore.getState().error).toBe("inference failed");
     });
 
     it("sets store status to error", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireMessage({ type: "error", message: "inference failed" });
       expect(useInferenceStore.getState().status).toBe("error");
     });
@@ -268,13 +281,13 @@ describe("useInference", () => {
 
   describe("worker.onerror handler", () => {
     it("writes error message to store", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireError("worker crashed");
       expect(useInferenceStore.getState().error).toBe("worker crashed");
     });
 
     it("sets store status to error", () => {
-      renderHook(() => useInference());
+      renderHook(() => useInference(0));
       fireError("worker crashed");
       expect(useInferenceStore.getState().status).toBe("error");
     });
@@ -282,7 +295,7 @@ describe("useInference", () => {
 
   describe("loadModels", () => {
     it("posts load-models message with the provided config", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       act(() => {
         result.current.loadModels(mockConfig);
       });
@@ -293,7 +306,7 @@ describe("useInference", () => {
     });
 
     it("resets isModelLoaded to false even if model was previously loaded", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       expect(result.current.isModelLoaded).toBe(true);
       act(() => {
@@ -303,7 +316,7 @@ describe("useInference", () => {
     });
 
     it("sets store status to loading-model", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       act(() => {
         result.current.loadModels(mockConfig);
       });
@@ -311,7 +324,7 @@ describe("useInference", () => {
     });
 
     it("sets store modelLoaded to false", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       act(() => {
         result.current.loadModels(mockConfig);
@@ -320,7 +333,7 @@ describe("useInference", () => {
     });
 
     it("does nothing after unmount", () => {
-      const { result, unmount } = renderHook(() => useInference());
+      const { result, unmount } = renderHook(() => useInference(0));
       unmount();
       act(() => {
         result.current.loadModels(mockConfig);
@@ -331,7 +344,7 @@ describe("useInference", () => {
 
   describe("runInference", () => {
     it("posts run-inference message when model is loaded", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       act(() => {
         result.current.runInference("data:image/png;base64,abc", 1);
@@ -344,7 +357,7 @@ describe("useInference", () => {
     });
 
     it("does nothing when model is not loaded", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       act(() => {
         result.current.runInference("data:image/png;base64,abc", 1);
       });
@@ -352,7 +365,7 @@ describe("useInference", () => {
     });
 
     it("does nothing after unmount", () => {
-      const { result, unmount } = renderHook(() => useInference());
+      const { result, unmount } = renderHook(() => useInference(0));
       simulateModelLoaded();
       unmount();
       act(() => {
@@ -364,7 +377,7 @@ describe("useInference", () => {
 
   describe("runClassifyOnly", () => {
     it("posts run-classify-only message with the full payload when model is loaded", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       simulateModelLoaded();
       act(() => {
         result.current.runClassifyOnly(
@@ -384,7 +397,7 @@ describe("useInference", () => {
     });
 
     it("does nothing when model is not loaded", () => {
-      const { result } = renderHook(() => useInference());
+      const { result } = renderHook(() => useInference(0));
       act(() => {
         result.current.runClassifyOnly(
           "data:image/png;base64,abc",
@@ -397,7 +410,7 @@ describe("useInference", () => {
     });
 
     it("does nothing after unmount", () => {
-      const { result, unmount } = renderHook(() => useInference());
+      const { result, unmount } = renderHook(() => useInference(0));
       simulateModelLoaded();
       unmount();
       act(() => {

--- a/nachet-mini/src/inference/useInference.ts
+++ b/nachet-mini/src/inference/useInference.ts
@@ -13,7 +13,8 @@ import { resultKey } from "@stores/useInferenceStore";
  * Usage:
  *   const { loadModels, runInference, isModelLoaded } = useInference();
  */
-export const useInference = () => {
+
+export const useInference = (currentIndex: number) => {
   const workerRef = useRef<Worker | null>(null);
   const isModelLoadedRef = useRef(false);
 
@@ -23,6 +24,8 @@ export const useInference = () => {
   const setModelLoaded = useInferenceStore((s) => s.setModelLoaded);
   const setModelLoadProgress = useInferenceStore((s) => s.setModelLoadProgress);
   const setError = useInferenceStore((s) => s.setError);
+
+  const currentIndexRef = useRef<number | null>(null);
 
   // Create worker on mount, terminate on unmount
   useEffect(() => {
@@ -47,11 +50,15 @@ export const useInference = () => {
           break;
         case "partial-result":
           setResult(msg.imageIndex, msg.modelConfigId, msg.result);
-          setActiveResultKey(resultKey(msg.imageIndex, msg.modelConfigId));
+          if (msg.imageIndex === currentIndexRef.current) {
+            setActiveResultKey(resultKey(msg.imageIndex, msg.modelConfigId));
+          }
           break;
         case "result":
           setResult(msg.imageIndex, msg.modelConfigId, msg.result);
-          setActiveResultKey(resultKey(msg.imageIndex, msg.modelConfigId));
+          if (msg.imageIndex === currentIndexRef.current) {
+            setActiveResultKey(resultKey(msg.imageIndex, msg.modelConfigId));
+          }
           setStatus("complete");
           break;
         case "error":
@@ -131,6 +138,10 @@ export const useInference = () => {
     },
     [],
   );
+
+  useEffect(() => {
+    currentIndexRef.current = currentIndex;
+  }, [currentIndex]);
 
   return {
     loadModels,

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -81,6 +81,7 @@ const main = {
     resultEntry: "{{time}} \u2014 {{modelId}}",
     boxes: "{{count}} boxes",
     removeResult: "Delete selected results",
+    cancelInference: "Cancel inference for image {{number}}",
     inferring: "Identifying...",
     queuePosition: "Queue position {{position}}",
   },

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -81,6 +81,8 @@ const main = {
     resultEntry: "{{time}} \u2014 {{modelId}}",
     boxes: "{{count}} boxes",
     removeResult: "Delete selected results",
+    inferring: "Identifying...",
+    queuePosition: "Queue position {{position}}",
   },
   metadata: {
     defaultsTitle: "Default Metadata",

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -114,6 +114,8 @@ const main = {
     },
   },
   validation: {
+    etaTooltip:
+      "Estimated time remaining. Accuracy improves as more inferences are completed.",
     invalidType: "File must be a PNG or JPEG image",
     fileTooLarge: "File size must be less than 10MB",
     dimensionsTooLarge: "Image dimensions must not exceed 8000x8000 pixels",
@@ -140,6 +142,10 @@ const main = {
     itemsQueued_other: "{{count}} items in queue",
     eta: "~{{time}}s remaining",
     etaUnknown: "Estimating...",
+    etaDetecting: "~{{time}}s · detecting",
+    etaClassifying: "~{{time}}s · classifying",
+    etaTooltip:
+      "Estimated time remaining. Accuracy improves as more inferences are completed.",
   },
 } as const;
 

--- a/nachet-mini/src/locales/en/main.ts
+++ b/nachet-mini/src/locales/en/main.ts
@@ -27,6 +27,7 @@ const main = {
     noModelLoaded: "No model loaded",
     cameraError: "Camera error: {{message}}",
     error: "Error: {{error}}",
+    queued: "Queued for inference",
   },
   modelLoader: {
     detector: "Detector",
@@ -84,6 +85,7 @@ const main = {
     cancelInference: "Cancel inference for image {{number}}",
     inferring: "Identifying...",
     queuePosition: "Queue position {{position}}",
+    inferring_: "Running",
   },
   metadata: {
     defaultsTitle: "Default Metadata",
@@ -132,6 +134,12 @@ const main = {
       "Nachet Mini runs identification in your browser. The first time you identify an image, the model files must be downloaded and initialized, which can take a while. Later visits should be faster because your browser will reuse cached model files.",
     cancel: "Cancel",
     continue: "Continue",
+  },
+  inferenceQueue: {
+    itemsQueued_one: "{{count}} item in queue",
+    itemsQueued_other: "{{count}} items in queue",
+    eta: "~{{time}}s remaining",
+    etaUnknown: "Estimating...",
   },
 } as const;
 

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -144,6 +144,10 @@ const main = {
     itemsQueued_other: "{{count}} éléments en file",
     eta: "~{{time}}s restantes",
     etaUnknown: "Estimation...",
+    etaDetecting: "~{{time}}s · détection",
+    etaClassifying: "~{{time}}s · classification",
+    etaTooltip:
+      "Temps restant estimé. La précision s'améliore avec chaque identification complétée.",
   },
 } as const;
 

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -82,6 +82,8 @@ const main = {
     resultEntry: "{{time}} \u2014 {{modelId}}",
     boxes: "{{count}} bo\u00eetes",
     removeResult: "Supprimer les r\u00e9sultats s\u00e9lectionn\u00e9s",
+    inferring: "Identification en cours...",
+    queuePosition: "Position dans la file : {{position}}",
   },
   metadata: {
     defaultsTitle: "Métadonnées par défaut",

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -84,6 +84,7 @@ const main = {
     removeResult: "Supprimer les r\u00e9sultats s\u00e9lectionn\u00e9s",
     inferring: "Identification en cours...",
     queuePosition: "Position dans la file : {{position}}",
+    cancelInference: "Annuler l'identification de l'image {{number}}",
   },
   metadata: {
     defaultsTitle: "Métadonnées par défaut",

--- a/nachet-mini/src/locales/fr/main.ts
+++ b/nachet-mini/src/locales/fr/main.ts
@@ -27,6 +27,7 @@ const main = {
     noModelLoaded: "Aucun mod\u00e8le charg\u00e9",
     cameraError: "Erreur de cam\u00e9ra\u00a0: {{message}}",
     error: "Erreur\u00a0: {{error}}",
+    queued: "En attente d'identification",
   },
   modelLoader: {
     detector: "D\u00e9tecteur",
@@ -85,6 +86,7 @@ const main = {
     inferring: "Identification en cours...",
     queuePosition: "Position dans la file : {{position}}",
     cancelInference: "Annuler l'identification de l'image {{number}}",
+    inferring_: "En cours",
   },
   metadata: {
     defaultsTitle: "Métadonnées par défaut",
@@ -136,6 +138,12 @@ const main = {
       "Nachet Mini effectue l'identification dans votre navigateur. La première fois que vous identifiez une image, les fichiers du modèle doivent être téléchargés et initialisés, ce qui peut prendre un certain temps. Les visites ultérieures devraient être plus rapides, car votre navigateur réutilisera les fichiers en cache.",
     cancel: "Annuler",
     continue: "Continuer",
+  },
+  inferenceQueue: {
+    itemsQueued_one: "{{count}} élément en file",
+    itemsQueued_other: "{{count}} éléments en file",
+    eta: "~{{time}}s restantes",
+    etaUnknown: "Estimation...",
   },
 } as const;
 

--- a/nachet-mini/src/stores/tests/useInferenceQueueStore.test.ts
+++ b/nachet-mini/src/stores/tests/useInferenceQueueStore.test.ts
@@ -10,7 +10,8 @@ const getStore = () => useInferenceQueueStore.getState();
 const reset = () =>
   useInferenceQueueStore.setState({
     queue: [],
-    lastInferenceDurationMs: null,
+    lastDetectionDurationMs: null,
+    lastClassificationPerBoxMs: null,
   });
 
 describe("useInferenceQueueStore", () => {
@@ -50,6 +51,14 @@ describe("useInferenceQueueStore", () => {
       expect(getStore().queue[0].addedAt).toBeGreaterThanOrEqual(before);
       expect(getStore().queue[0].addedAt).toBeLessThanOrEqual(after);
     });
+
+    it("initializes timing fields to null", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const item = getStore().queue[0];
+      expect(item.inferenceStartedAt).toBeNull();
+      expect(item.detectionDoneAt).toBeNull();
+      expect(item.detectedBoxCount).toBeNull();
+    });
   });
 
   // ─── cancel ─────────────────────────────────────────────────────────────────
@@ -87,12 +96,49 @@ describe("useInferenceQueueStore", () => {
       expect(getStore().queue[0].status).toBe("processing");
     });
 
+    it("sets inferenceStartedAt to a recent timestamp", () => {
+      const before = Date.now();
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      const after = Date.now();
+      const { inferenceStartedAt } = getStore().queue[0];
+      expect(inferenceStartedAt).not.toBeNull();
+      expect(inferenceStartedAt!).toBeGreaterThanOrEqual(before);
+      expect(inferenceStartedAt!).toBeLessThanOrEqual(after);
+    });
+
     it("does not affect other items", () => {
       getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
       getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
       const firstId = getStore().queue[0].id;
       getStore().markProcessing(firstId);
       expect(getStore().queue[1].status).toBe("pending");
+    });
+  });
+
+  // ─── markDetectionDone ──────────────────────────────────────────────────────
+
+  describe("markDetectionDone", () => {
+    it("sets detectionDoneAt and detectedBoxCount", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      const before = Date.now();
+      getStore().markDetectionDone(id, 800, 5);
+      const after = Date.now();
+      const item = getStore().queue[0];
+      expect(item.detectedBoxCount).toBe(5);
+      expect(item.detectionDoneAt).not.toBeNull();
+      expect(item.detectionDoneAt!).toBeGreaterThanOrEqual(before);
+      expect(item.detectionDoneAt!).toBeLessThanOrEqual(after);
+    });
+
+    it("updates lastDetectionDurationMs", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markDetectionDone(id, 800, 5);
+      expect(getStore().lastDetectionDurationMs).toBe(800);
     });
   });
 
@@ -107,11 +153,23 @@ describe("useInferenceQueueStore", () => {
       expect(getStore().queue).toHaveLength(0);
     });
 
-    it("updates lastInferenceDurationMs", () => {
+    it("updates lastClassificationPerBoxMs when box count is known", () => {
       getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
       const id = getStore().queue[0].id;
-      getStore().markDone(id, 1234);
-      expect(getStore().lastInferenceDurationMs).toBe(1234);
+      getStore().markProcessing(id);
+      getStore().markDetectionDone(id, 500, 2);
+      // classification took 1000ms for 2 boxes = 500ms per box
+      getStore().markDone(id, 1000);
+      expect(getStore().lastClassificationPerBoxMs).toBe(500);
+    });
+
+    it("does not update lastClassificationPerBoxMs when box count is null", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      // no markDetectionDone called — detectedBoxCount stays null
+      getStore().markDone(id, 1000);
+      expect(getStore().lastClassificationPerBoxMs).toBeNull();
     });
 
     it("also removes cancelled items in the same update", () => {
@@ -121,7 +179,6 @@ describe("useInferenceQueueStore", () => {
       const [firstId, secondId] = getStore().queue.map((i) => i.id);
       getStore().cancel(secondId);
       getStore().markDone(firstId, 500);
-      // only the third item should remain
       expect(getStore().queue).toHaveLength(1);
       expect(getStore().queue[0].imageIndex).toBe(2);
     });
@@ -139,9 +196,9 @@ describe("useInferenceQueueStore", () => {
   // ─── setLastInferenceDuration ───────────────────────────────────────────────
 
   describe("setLastInferenceDuration", () => {
-    it("updates lastInferenceDurationMs", () => {
+    it("updates lastDetectionDurationMs", () => {
       getStore().setLastInferenceDuration(999);
-      expect(getStore().lastInferenceDurationMs).toBe(999);
+      expect(getStore().lastDetectionDurationMs).toBe(999);
     });
   });
 
@@ -196,24 +253,64 @@ describe("useInferenceQueueStore", () => {
   // ─── selectEtaMs ────────────────────────────────────────────────────────────
 
   describe("selectEtaMs", () => {
-    it("returns null when lastInferenceDurationMs is null", () => {
+    it("returns null when no timing data available", () => {
       getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
       expect(selectEtaMs(getStore())).toBeNull();
     });
 
     it("returns null when queue is empty", () => {
-      getStore().setLastInferenceDuration(1000);
+      useInferenceQueueStore.setState({
+        lastDetectionDurationMs: 1000,
+        lastClassificationPerBoxMs: 500,
+      });
       expect(selectEtaMs(getStore())).toBeNull();
     });
 
-    it("returns duration * pendingCount when no item is processing", () => {
-      getStore().setLastInferenceDuration(1000);
+    it("returns null when no item is processing", () => {
+      useInferenceQueueStore.setState({
+        lastDetectionDurationMs: 1000,
+        lastClassificationPerBoxMs: 500,
+      });
       getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
       getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      expect(selectEtaMs(getStore())).toBeNull();
+    });
+
+    it("returns null on first inference before any timing is learned", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      expect(selectEtaMs(getStore())).toBeNull();
+    });
+
+    it("returns detection ETA when item is processing and timing is known", () => {
+      useInferenceQueueStore.setState({
+        lastDetectionDurationMs: 5000,
+        lastClassificationPerBoxMs: 100,
+      });
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
       const eta = selectEtaMs(getStore());
-      // 2 pending * 1000ms each
-      expect(eta).toBeGreaterThan(0);
-      expect(eta).toBeLessThanOrEqual(2000);
+      expect(eta).not.toBeNull();
+      expect(eta!).toBeGreaterThanOrEqual(1000);
+      expect(eta!).toBeLessThanOrEqual(5000);
+    });
+
+    it("returns classification ETA when detection is done", () => {
+      useInferenceQueueStore.setState({
+        lastDetectionDurationMs: 5000,
+        lastClassificationPerBoxMs: 500,
+      });
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      getStore().markDetectionDone(id, 5000, 4);
+      const eta = selectEtaMs(getStore());
+      // 4 boxes * 500ms = 2000ms total classification, minus elapsed
+      expect(eta).not.toBeNull();
+      expect(eta!).toBeGreaterThanOrEqual(1000);
+      expect(eta!).toBeLessThanOrEqual(2000);
     });
   });
 });

--- a/nachet-mini/src/stores/tests/useInferenceQueueStore.test.ts
+++ b/nachet-mini/src/stores/tests/useInferenceQueueStore.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useInferenceQueueStore,
+  selectNextPending,
+  selectEtaMs,
+} from "../useInferenceQueueStore";
+
+const getStore = () => useInferenceQueueStore.getState();
+
+const reset = () =>
+  useInferenceQueueStore.setState({
+    queue: [],
+    lastInferenceDurationMs: null,
+  });
+
+describe("useInferenceQueueStore", () => {
+  beforeEach(reset);
+
+  // ─── enqueue ────────────────────────────────────────────────────────────────
+
+  describe("enqueue", () => {
+    it("adds an item with status pending", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const { queue } = getStore();
+      expect(queue).toHaveLength(1);
+      expect(queue[0].status).toBe("pending");
+      expect(queue[0].imageSrc).toBe("a.jpg");
+      expect(queue[0].imageIndex).toBe(0);
+    });
+
+    it("assigns a unique id to each item", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      const { queue } = getStore();
+      expect(queue[0].id).not.toBe(queue[1].id);
+    });
+
+    it("preserves insertion order", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      getStore().enqueue({ imageSrc: "c.jpg", imageIndex: 2 });
+      const { queue } = getStore();
+      expect(queue.map((i) => i.imageIndex)).toEqual([0, 1, 2]);
+    });
+
+    it("sets addedAt to a recent timestamp", () => {
+      const before = Date.now();
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const after = Date.now();
+      expect(getStore().queue[0].addedAt).toBeGreaterThanOrEqual(before);
+      expect(getStore().queue[0].addedAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  // ─── cancel ─────────────────────────────────────────────────────────────────
+
+  describe("cancel", () => {
+    it("marks the item as cancelled", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().cancel(id);
+      expect(getStore().queue[0].status).toBe("cancelled");
+    });
+
+    it("does not affect other items", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      const firstId = getStore().queue[0].id;
+      getStore().cancel(firstId);
+      expect(getStore().queue[1].status).toBe("pending");
+    });
+
+    it("is a no-op for unknown ids", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().cancel("non-existent-id");
+      expect(getStore().queue[0].status).toBe("pending");
+    });
+  });
+
+  // ─── markProcessing ─────────────────────────────────────────────────────────
+
+  describe("markProcessing", () => {
+    it("sets the item status to processing", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      expect(getStore().queue[0].status).toBe("processing");
+    });
+
+    it("does not affect other items", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      const firstId = getStore().queue[0].id;
+      getStore().markProcessing(firstId);
+      expect(getStore().queue[1].status).toBe("pending");
+    });
+  });
+
+  // ─── markDone ───────────────────────────────────────────────────────────────
+
+  describe("markDone", () => {
+    it("removes the done item from the queue", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markProcessing(id);
+      getStore().markDone(id, 1000);
+      expect(getStore().queue).toHaveLength(0);
+    });
+
+    it("updates lastInferenceDurationMs", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      const id = getStore().queue[0].id;
+      getStore().markDone(id, 1234);
+      expect(getStore().lastInferenceDurationMs).toBe(1234);
+    });
+
+    it("also removes cancelled items in the same update", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      getStore().enqueue({ imageSrc: "c.jpg", imageIndex: 2 });
+      const [firstId, secondId] = getStore().queue.map((i) => i.id);
+      getStore().cancel(secondId);
+      getStore().markDone(firstId, 500);
+      // only the third item should remain
+      expect(getStore().queue).toHaveLength(1);
+      expect(getStore().queue[0].imageIndex).toBe(2);
+    });
+
+    it("preserves remaining pending items", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      const firstId = getStore().queue[0].id;
+      getStore().markDone(firstId, 500);
+      expect(getStore().queue).toHaveLength(1);
+      expect(getStore().queue[0].status).toBe("pending");
+    });
+  });
+
+  // ─── setLastInferenceDuration ───────────────────────────────────────────────
+
+  describe("setLastInferenceDuration", () => {
+    it("updates lastInferenceDurationMs", () => {
+      getStore().setLastInferenceDuration(999);
+      expect(getStore().lastInferenceDurationMs).toBe(999);
+    });
+  });
+
+  // ─── clearCompleted ─────────────────────────────────────────────────────────
+
+  describe("clearCompleted", () => {
+    it("removes done and cancelled items", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      getStore().enqueue({ imageSrc: "c.jpg", imageIndex: 2 });
+      const [firstId, secondId] = getStore().queue.map((i) => i.id);
+      getStore().cancel(firstId);
+      getStore().markProcessing(secondId);
+      getStore().clearCompleted();
+      expect(getStore().queue).toHaveLength(2);
+      expect(getStore().queue.map((i) => i.imageIndex)).toEqual([1, 2]);
+    });
+
+    it("is a no-op when queue is empty", () => {
+      getStore().clearCompleted();
+      expect(getStore().queue).toHaveLength(0);
+    });
+  });
+
+  // ─── selectNextPending ──────────────────────────────────────────────────────
+
+  describe("selectNextPending", () => {
+    it("returns the first pending item", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      const firstId = getStore().queue[0].id;
+      getStore().markProcessing(firstId);
+      const next = selectNextPending(getStore());
+      expect(next?.imageIndex).toBe(1);
+    });
+
+    it("returns null when no pending items", () => {
+      expect(selectNextPending(getStore())).toBeNull();
+    });
+
+    it("skips processing and cancelled items", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      getStore().enqueue({ imageSrc: "c.jpg", imageIndex: 2 });
+      const [firstId, secondId] = getStore().queue.map((i) => i.id);
+      getStore().markProcessing(firstId);
+      getStore().cancel(secondId);
+      expect(selectNextPending(getStore())?.imageIndex).toBe(2);
+    });
+  });
+
+  // ─── selectEtaMs ────────────────────────────────────────────────────────────
+
+  describe("selectEtaMs", () => {
+    it("returns null when lastInferenceDurationMs is null", () => {
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      expect(selectEtaMs(getStore())).toBeNull();
+    });
+
+    it("returns null when queue is empty", () => {
+      getStore().setLastInferenceDuration(1000);
+      expect(selectEtaMs(getStore())).toBeNull();
+    });
+
+    it("returns duration * pendingCount when no item is processing", () => {
+      getStore().setLastInferenceDuration(1000);
+      getStore().enqueue({ imageSrc: "a.jpg", imageIndex: 0 });
+      getStore().enqueue({ imageSrc: "b.jpg", imageIndex: 1 });
+      const eta = selectEtaMs(getStore());
+      // 2 pending * 1000ms each
+      expect(eta).toBeGreaterThan(0);
+      expect(eta).toBeLessThanOrEqual(2000);
+    });
+  });
+});

--- a/nachet-mini/src/stores/useInferenceQueueStore.ts
+++ b/nachet-mini/src/stores/useInferenceQueueStore.ts
@@ -12,10 +12,13 @@ interface InferenceQueueState {
   queue: QueuedInferenceItem[];
   lastInferenceDurationMs: number | null;
 
-  enqueue: (item: Omit<QueuedInferenceItem, "id" | "status" | "addedAt">) => void;
+  enqueue: (
+    item: Omit<QueuedInferenceItem, "id" | "status" | "addedAt">,
+  ) => void;
   cancel: (id: string) => void;
   markProcessing: (id: string) => void;
   markDone: (id: string, durationMs: number) => void;
+  setLastInferenceDuration: (durationMs: number) => void;
   clearCompleted: () => void;
 }
 
@@ -52,11 +55,18 @@ export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
 
   markDone: (id, durationMs) =>
     set((state) => ({
-      queue: state.queue.map((item) =>
-        item.id === id ? { ...item, status: "done" } : item,
-      ),
+      queue: state.queue
+        .map(
+          (item): QueuedInferenceItem =>
+            item.id === id ? { ...item, status: "done" } : item,
+        )
+        .filter(
+          (item) => item.status !== "done" && item.status !== "cancelled",
+        ),
       lastInferenceDurationMs: durationMs,
     })),
+  setLastInferenceDuration: (durationMs: number) =>
+    set({ lastInferenceDurationMs: durationMs }),
 
   clearCompleted: () =>
     set((state) => ({
@@ -76,7 +86,19 @@ export const selectNextPending = (state: InferenceQueueState) =>
   state.queue.find((item) => item.status === "pending") ?? null;
 
 export const selectEtaMs = (state: InferenceQueueState) => {
-  const remaining = selectActiveQueue(state).length;
-  if (remaining === 0 || state.lastInferenceDurationMs === null) return null;
-  return remaining * state.lastInferenceDurationMs;
+  if (state.lastInferenceDurationMs === null) return null;
+
+  const pendingCount = state.queue.filter((i) => i.status === "pending").length;
+  const processingItem = state.queue.find((i) => i.status === "processing");
+
+  if (pendingCount === 0 && !processingItem) return null;
+
+  const processingEta = processingItem
+    ? Math.max(
+        0,
+        state.lastInferenceDurationMs - (Date.now() - processingItem.addedAt),
+      )
+    : 0;
+
+  return processingEta + pendingCount * state.lastInferenceDurationMs;
 };

--- a/nachet-mini/src/stores/useInferenceQueueStore.ts
+++ b/nachet-mini/src/stores/useInferenceQueueStore.ts
@@ -66,8 +66,6 @@ export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
     })),
 }));
 
-(window as any).__queueStore = useInferenceQueueStore;
-
 // Selectors
 export const selectActiveQueue = (state: InferenceQueueState) =>
   state.queue.filter(

--- a/nachet-mini/src/stores/useInferenceQueueStore.ts
+++ b/nachet-mini/src/stores/useInferenceQueueStore.ts
@@ -66,6 +66,8 @@ export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
     })),
 }));
 
+(window as any).__queueStore = useInferenceQueueStore;
+
 // Selectors
 export const selectActiveQueue = (state: InferenceQueueState) =>
   state.queue.filter(

--- a/nachet-mini/src/stores/useInferenceQueueStore.ts
+++ b/nachet-mini/src/stores/useInferenceQueueStore.ts
@@ -6,25 +6,39 @@ export interface QueuedInferenceItem {
   imageIndex: number;
   status: "pending" | "processing" | "done" | "cancelled";
   addedAt: number;
+  inferenceStartedAt: number | null; // set when processing starts
+  detectionDoneAt: number | null; // set when detection completes
+  detectedBoxCount: number | null; // set when detection completes
 }
 
 interface InferenceQueueState {
   queue: QueuedInferenceItem[];
-  lastInferenceDurationMs: number | null;
+  lastDetectionDurationMs: number | null;
+  lastClassificationPerBoxMs: number | null;
 
   enqueue: (
-    item: Omit<QueuedInferenceItem, "id" | "status" | "addedAt">,
+    item: Omit<
+      QueuedInferenceItem,
+      | "id"
+      | "status"
+      | "addedAt"
+      | "inferenceStartedAt"
+      | "detectionDoneAt"
+      | "detectedBoxCount"
+    >,
   ) => void;
   cancel: (id: string) => void;
   markProcessing: (id: string) => void;
-  markDone: (id: string, durationMs: number) => void;
+  markDetectionDone: (id: string, durationMs: number, boxCount: number) => void;
+  markDone: (id: string, classificationDurationMs: number) => void;
   setLastInferenceDuration: (durationMs: number) => void;
   clearCompleted: () => void;
 }
 
 export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
   queue: [],
-  lastInferenceDurationMs: null,
+  lastDetectionDurationMs: null,
+  lastClassificationPerBoxMs: null,
 
   enqueue: (item) =>
     set((state) => ({
@@ -35,6 +49,9 @@ export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
           id: crypto.randomUUID(),
           status: "pending",
           addedAt: Date.now(),
+          inferenceStartedAt: null,
+          detectionDoneAt: null,
+          detectedBoxCount: null,
         },
       ],
     })),
@@ -49,24 +66,51 @@ export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
   markProcessing: (id) =>
     set((state) => ({
       queue: state.queue.map((item) =>
-        item.id === id ? { ...item, status: "processing" } : item,
+        item.id === id
+          ? { ...item, status: "processing", inferenceStartedAt: Date.now() }
+          : item,
       ),
     })),
 
-  markDone: (id, durationMs) =>
+  markDetectionDone: (id, durationMs, boxCount) =>
     set((state) => ({
-      queue: state.queue
-        .map(
-          (item): QueuedInferenceItem =>
-            item.id === id ? { ...item, status: "done" } : item,
-        )
-        .filter(
-          (item) => item.status !== "done" && item.status !== "cancelled",
-        ),
-      lastInferenceDurationMs: durationMs,
+      queue: state.queue.map(
+        (item): QueuedInferenceItem =>
+          item.id === id
+            ? {
+                ...item,
+                detectionDoneAt: Date.now(),
+                detectedBoxCount: boxCount,
+              }
+            : item,
+      ),
+      lastDetectionDurationMs: durationMs,
     })),
+
+  markDone: (id, classificationDurationMs) =>
+    set((state) => {
+      const item = state.queue.find((i) => i.id === id);
+      const boxCount = item?.detectedBoxCount ?? null;
+      const perBoxMs =
+        boxCount && boxCount > 0 ? classificationDurationMs / boxCount : null;
+
+      return {
+        queue: state.queue
+          .map(
+            (i): QueuedInferenceItem =>
+              i.id === id ? { ...i, status: "done" } : i,
+          )
+          .filter((i) => i.status !== "done" && i.status !== "cancelled"),
+        lastClassificationPerBoxMs:
+          perBoxMs ?? state.lastClassificationPerBoxMs,
+      };
+    }),
+
   setLastInferenceDuration: (durationMs: number) =>
-    set({ lastInferenceDurationMs: durationMs }),
+    set((state) => ({
+      lastDetectionDurationMs: durationMs,
+      lastClassificationPerBoxMs: state.lastClassificationPerBoxMs,
+    })),
 
   clearCompleted: () =>
     set((state) => ({
@@ -85,20 +129,34 @@ export const selectActiveQueue = (state: InferenceQueueState) =>
 export const selectNextPending = (state: InferenceQueueState) =>
   state.queue.find((item) => item.status === "pending") ?? null;
 
-export const selectEtaMs = (state: InferenceQueueState) => {
-  if (state.lastInferenceDurationMs === null) return null;
-
-  const pendingCount = state.queue.filter((i) => i.status === "pending").length;
+export const selectIsClassifying = (state: InferenceQueueState): boolean => {
   const processingItem = state.queue.find((i) => i.status === "processing");
+  return (
+    processingItem !== undefined && processingItem.detectionDoneAt !== null
+  );
+};
 
-  if (pendingCount === 0 && !processingItem) return null;
+export const selectEtaMs = (state: InferenceQueueState): number | null => {
+  const { lastDetectionDurationMs, lastClassificationPerBoxMs } = state;
+  const processingItem = state.queue.find((i) => i.status === "processing");
+  if (!processingItem) return null;
 
-  const processingEta = processingItem
-    ? Math.max(
-        0,
-        state.lastInferenceDurationMs - (Date.now() - processingItem.addedAt),
-      )
-    : 0;
+  // Don't show ETA until we have learned from at least one completed inference
+  if (lastDetectionDurationMs === null || lastClassificationPerBoxMs === null)
+    return null;
 
-  return processingEta + pendingCount * state.lastInferenceDurationMs;
+  const detectionDoneAt = processingItem.detectionDoneAt;
+  const isClassifying = detectionDoneAt !== null;
+
+  if (isClassifying && processingItem.detectedBoxCount !== null) {
+    const elapsedClassification = Date.now() - detectionDoneAt;
+    const totalClassification =
+      lastClassificationPerBoxMs * processingItem.detectedBoxCount;
+    return Math.max(1000, totalClassification - elapsedClassification);
+  } else {
+    const elapsed = processingItem.inferenceStartedAt
+      ? Date.now() - processingItem.inferenceStartedAt
+      : 0;
+    return Math.max(1000, lastDetectionDurationMs - elapsed);
+  }
 };

--- a/nachet-mini/src/stores/useInferenceQueueStore.ts
+++ b/nachet-mini/src/stores/useInferenceQueueStore.ts
@@ -1,0 +1,82 @@
+import { create } from "zustand";
+
+export interface QueuedInferenceItem {
+  id: string;
+  imageSrc: string;
+  imageIndex: number;
+  status: "pending" | "processing" | "done" | "cancelled";
+  addedAt: number;
+}
+
+interface InferenceQueueState {
+  queue: QueuedInferenceItem[];
+  lastInferenceDurationMs: number | null;
+
+  enqueue: (item: Omit<QueuedInferenceItem, "id" | "status" | "addedAt">) => void;
+  cancel: (id: string) => void;
+  markProcessing: (id: string) => void;
+  markDone: (id: string, durationMs: number) => void;
+  clearCompleted: () => void;
+}
+
+export const useInferenceQueueStore = create<InferenceQueueState>()((set) => ({
+  queue: [],
+  lastInferenceDurationMs: null,
+
+  enqueue: (item) =>
+    set((state) => ({
+      queue: [
+        ...state.queue,
+        {
+          ...item,
+          id: crypto.randomUUID(),
+          status: "pending",
+          addedAt: Date.now(),
+        },
+      ],
+    })),
+
+  cancel: (id) =>
+    set((state) => ({
+      queue: state.queue.map((item) =>
+        item.id === id ? { ...item, status: "cancelled" } : item,
+      ),
+    })),
+
+  markProcessing: (id) =>
+    set((state) => ({
+      queue: state.queue.map((item) =>
+        item.id === id ? { ...item, status: "processing" } : item,
+      ),
+    })),
+
+  markDone: (id, durationMs) =>
+    set((state) => ({
+      queue: state.queue.map((item) =>
+        item.id === id ? { ...item, status: "done" } : item,
+      ),
+      lastInferenceDurationMs: durationMs,
+    })),
+
+  clearCompleted: () =>
+    set((state) => ({
+      queue: state.queue.filter(
+        (item) => item.status !== "done" && item.status !== "cancelled",
+      ),
+    })),
+}));
+
+// Selectors
+export const selectActiveQueue = (state: InferenceQueueState) =>
+  state.queue.filter(
+    (item) => item.status === "pending" || item.status === "processing",
+  );
+
+export const selectNextPending = (state: InferenceQueueState) =>
+  state.queue.find((item) => item.status === "pending") ?? null;
+
+export const selectEtaMs = (state: InferenceQueueState) => {
+  const remaining = selectActiveQueue(state).length;
+  if (remaining === 0 || state.lastInferenceDurationMs === null) return null;
+  return remaining * state.lastInferenceDurationMs;
+};

--- a/nachet-mini/vite.config.ts
+++ b/nachet-mini/vite.config.ts
@@ -28,10 +28,14 @@ export default defineConfig({
     include: [
       "@mui/icons-material/GitHub",
       "@mui/icons-material/Close",
+      "@mui/icons-material/Cancel",
+      "@mui/icons-material/AccessTime", 
+      "@mui/icons-material/List",
       "react-webcam",
       "file-saver",
       "jszip",
       "zustand/middleware",
+      "zustand/react/shallow",
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary
Implements inference queue, allowing users to trigger inference on multiple 
images sequentially without waiting for each one to complete.

## Changes
- `useInferenceQueueStore` — new Zustand store managing the queue
- `NachetMiniContainer` — drain loop replacing single-pending-request pattern
- `ImageGallery` — queue position chips, spinner, cancel button per item
- `QueueSummary` — new component showing total queued count and live ETA
- `useInference` — active result key only updates for the selected image
- `NachetMiniView` — context-aware status text per selected image

## Outcomes
- ✅ Multiple images can be queued and processed in order
- ✅ Queue position indicator on each item
- ✅ Cancel button (pending items only)
- ✅ Queue summary with item count and ETA
- ✅ Results and boxes don't bleed across images during background inference

## Tests
- `useInferenceQueueStore.test.ts` — store unit tests
- `NachetMiniContainer.test.tsx` — queue behaviour integration tests
- `ImageGallery.test.tsx` — position chip and cancel button UI tests
- `QueueSummary.test.tsx` — summary bar UI tests