### PR TITLE
Use shared auth provider for frontend API requests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "2.9.16",
+  "version": "2.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "2.9.16",
+      "version": "2.9.17",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "2.9.16",
+  "version": "2.9.17",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,12 +4,12 @@ import Cookies from "js-cookie";
 import { Navbar, Appbar } from "./components/header";
 import Body from "./root/body";
 import Footer from "./components/footer";
-import { PublicClientApplication } from "@azure/msal-browser";
+import type { PublicClientApplication } from "@azure/msal-browser";
 import { NachetAuthProvider } from "./auth";
 
 interface AppProps {
   basename: string;
-  msalInstance: PublicClientApplication;
+  msalInstance?: PublicClientApplication;
   apiScopeClaim: string;
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,7 @@ const App = ({ basename, msalInstance, apiScopeClaim }: AppProps) => {
         msalInstance={msalInstance}
       >
         <Fragment>
-          <Navbar windowSize={windowSize} apiScopeClaim={apiScopeClaim} />
+          <Navbar />
           <Appbar windowSize={windowSize} />
           <Routes>
             <Route
@@ -72,7 +72,6 @@ const App = ({ basename, msalInstance, apiScopeClaim }: AppProps) => {
                   handleCreativeCommonsAgreement={
                     handleCreativeCommonsAgreement
                   }
-                  apiScopeClaim={apiScopeClaim}
                 />
               }
             />
@@ -87,7 +86,6 @@ const App = ({ basename, msalInstance, apiScopeClaim }: AppProps) => {
                   handleCreativeCommonsAgreement={
                     handleCreativeCommonsAgreement
                   }
-                  apiScopeClaim={apiScopeClaim}
                 />
               }
             />

--- a/frontend/src/auth/NachetAuthContext.tsx
+++ b/frontend/src/auth/NachetAuthContext.tsx
@@ -5,7 +5,13 @@ export type AuthProviderKind = "msal" | "oidc";
 export interface NachetAuthAccount {
   username: string;
   name?: string;
+  userId: string;
+  isGuest: boolean;
   idTokenClaims?: Record<string, unknown>;
+}
+
+export interface NachetAuthTokenOptions {
+  forceRefresh?: boolean;
 }
 
 export interface NachetAuthContextValue {
@@ -16,7 +22,10 @@ export interface NachetAuthContextValue {
   activeAccount: NachetAuthAccount | null;
   login: (scopes?: string[]) => Promise<void>;
   logout: () => Promise<void>;
-  getAccessToken: (scopes?: string[]) => Promise<string>;
+  getAccessToken: (
+    scopes?: string[],
+    options?: NachetAuthTokenOptions,
+  ) => Promise<string>;
 }
 
 export const NachetAuthContext = createContext<

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -1,15 +1,28 @@
-import { type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { type PublicClientApplication } from "@azure/msal-browser";
 import { MsalProvider } from "@azure/msal-react";
-import { NachetAuthContext } from "./NachetAuthContext";
+import { NachetAuthContext, useNachetAuth } from "./NachetAuthContext";
 import { MsalAuthProvider } from "./msal/MsalAuthProvider";
 import { OidcAuthProvider } from "./oidc/OidcAuthProvider";
+import { initializeApi } from "../common/api";
+import { errorLogger } from "../logging";
 
 export interface NachetAuthProviderProps {
   apiScopeClaim: string;
   children: ReactNode;
   msalInstance: PublicClientApplication;
 }
+
+const AuthApiBridge = () => {
+  const { getAccessToken } = useNachetAuth();
+
+  useEffect(() => {
+    initializeApi(getAccessToken);
+    errorLogger.setTokenProvider(async () => getAccessToken());
+  }, [getAccessToken]);
+
+  return null;
+};
 
 export const NachetAuthProvider = ({
   apiScopeClaim,
@@ -29,6 +42,7 @@ export const NachetAuthProvider = ({
           apiScopeClaim={apiScopeClaim}
           authContext={NachetAuthContext}
         >
+          <AuthApiBridge />
           {children}
         </MsalAuthProvider>
       </MsalProvider>
@@ -41,6 +55,7 @@ export const NachetAuthProvider = ({
         apiScopeClaim={oidcApiScopeClaim}
         authContext={NachetAuthContext}
       >
+        <AuthApiBridge />
         {children}
       </OidcAuthProvider>
     );

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -34,11 +34,14 @@ export const NachetAuthProvider = ({
   children,
   msalInstance,
 }: NachetAuthProviderProps) => {
-  const configuredProvider = (import.meta.env.VITE_AUTH_PROVIDER ?? "msal")
-    .trim()
-    .toLowerCase();
+  const authProviderEnv = import.meta.env.VITE_AUTH_PROVIDER?.trim();
+  const configuredProvider = authProviderEnv?.toLowerCase();
   const oidcApiScopeClaim =
     import.meta.env.VITE_OIDC_API_SCOPE_CLAIM?.trim() || apiScopeClaim;
+
+  if (configuredProvider !== "msal" && configuredProvider !== "oidc") {
+    throw new Error('VITE_AUTH_PROVIDER must be set to "msal" or "oidc".');
+  }
 
   if (configuredProvider === "msal") {
     if (!msalInstance) {
@@ -70,7 +73,5 @@ export const NachetAuthProvider = ({
     );
   }
 
-  throw new Error(
-    `Unsupported auth provider '${configuredProvider}'. Use 'msal' or 'oidc'.`,
-  );
+  throw new Error('VITE_AUTH_PROVIDER must be set to "msal" or "oidc".');
 };

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -10,14 +10,14 @@ import { errorLogger } from "../logging";
 export interface NachetAuthProviderProps {
   apiScopeClaim: string;
   children: ReactNode;
-  msalInstance: PublicClientApplication;
+  msalInstance?: PublicClientApplication;
 }
 
 const AuthApiBridge = () => {
   const { getAccessToken } = useNachetAuth();
 
   useEffect(() => {
-    initializeApi(getAccessToken);
+    initializeApi((options) => getAccessToken(undefined, options));
     errorLogger.setTokenProvider(async () => getAccessToken());
 
     return () => {
@@ -41,6 +41,10 @@ export const NachetAuthProvider = ({
     import.meta.env.VITE_OIDC_API_SCOPE_CLAIM?.trim() || apiScopeClaim;
 
   if (configuredProvider === "msal") {
+    if (!msalInstance) {
+      throw new Error("MSAL auth provider requires an MSAL instance.");
+    }
+
     return (
       <MsalProvider instance={msalInstance}>
         <MsalAuthProvider

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -4,7 +4,7 @@ import { MsalProvider } from "@azure/msal-react";
 import { NachetAuthContext, useNachetAuth } from "./NachetAuthContext";
 import { MsalAuthProvider } from "./msal/MsalAuthProvider";
 import { OidcAuthProvider } from "./oidc/OidcAuthProvider";
-import { initializeApi } from "../common/api";
+import { clearApiAuthentication, initializeApi } from "../common/api";
 import { errorLogger } from "../logging";
 
 export interface NachetAuthProviderProps {
@@ -19,6 +19,11 @@ const AuthApiBridge = () => {
   useEffect(() => {
     initializeApi(getAccessToken);
     errorLogger.setTokenProvider(async () => getAccessToken());
+
+    return () => {
+      clearApiAuthentication();
+      errorLogger.setTokenProvider(async () => null);
+    };
   }, [getAccessToken]);
 
   return null;

--- a/frontend/src/auth/msal/MsalAuthProvider.tsx
+++ b/frontend/src/auth/msal/MsalAuthProvider.tsx
@@ -11,6 +11,7 @@ import { acquireAccessToken } from "../../common/auth";
 import type {
   NachetAuthAccount,
   NachetAuthContextValue,
+  NachetAuthTokenOptions,
 } from "../NachetAuthContext";
 
 interface MsalAuthProviderProps {
@@ -20,10 +21,24 @@ interface MsalAuthProviderProps {
 }
 
 const mapAccount = (account: AccountInfo): NachetAuthAccount => {
+  const idTokenClaims = account.idTokenClaims as
+    | Record<string, unknown>
+    | undefined;
+  const oidClaim = idTokenClaims?.oid;
+  const subClaim = idTokenClaims?.sub;
+  const acctClaim = idTokenClaims?.acct;
+
   return {
     username: account.username,
     name: account.name,
-    idTokenClaims: account.idTokenClaims as Record<string, unknown> | undefined,
+    userId:
+      typeof oidClaim === "string"
+        ? oidClaim
+        : typeof subClaim === "string"
+          ? subClaim
+          : account.localAccountId,
+    isGuest: acctClaim !== 0,
+    idTokenClaims,
   };
 };
 
@@ -62,8 +77,11 @@ export const MsalAuthProvider = ({
   }, [instance]);
 
   const getAccessToken = useCallback(
-    async (scopes = defaultScopes): Promise<string> => {
-      return acquireAccessToken(instance, scopes);
+    async (
+      scopes = defaultScopes,
+      options?: NachetAuthTokenOptions,
+    ): Promise<string> => {
+      return acquireAccessToken(instance, scopes, options);
     },
     [defaultScopes, instance],
   );

--- a/frontend/src/auth/msal/MsalAuthProvider.tsx
+++ b/frontend/src/auth/msal/MsalAuthProvider.tsx
@@ -37,6 +37,8 @@ const mapAccount = (account: AccountInfo): NachetAuthAccount => {
         : typeof subClaim === "string"
           ? subClaim
           : account.localAccountId,
+    // Default to guest unless Entra explicitly marks the account as a member.
+    // Longer term, backend auth or configured claim mapping may own this.
     isGuest: acctClaim !== 0,
     idTokenClaims,
   };

--- a/frontend/src/auth/oidc/OidcAuthProvider.test.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.test.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NachetAuthContextValue } from "../NachetAuthContext";
 import { OidcAuthProvider } from "./OidcAuthProvider";
@@ -53,9 +53,30 @@ const TestConsumer = () => {
   );
 };
 
+const TokenConsumer = () => {
+  const auth = useContext(TestAuthContext);
+
+  return (
+    <button onClick={() => void auth?.getAccessToken().catch(() => undefined)}>
+      get token
+    </button>
+  );
+};
+
 describe("OidcAuthProvider", () => {
   beforeEach(() => {
     capturedAuthProviderSettings.value = undefined;
+    mockOidcAuth.value.isAuthenticated = true;
+    mockOidcAuth.value.isLoading = false;
+    mockOidcAuth.value.user = {
+      expired: false,
+      access_token: "oidc-access-token",
+      profile: {
+        preferred_username: "oidc-user@example.com",
+        name: "OIDC User",
+        sub: "oidc-subject",
+      },
+    };
     mockOidcAuth.value.signinRedirect.mockClear();
     mockOidcAuth.value.signinSilent.mockClear();
     mockOidcAuth.value.signoutRedirect.mockClear();
@@ -155,6 +176,40 @@ describe("OidcAuthProvider", () => {
 
     expect(capturedAuthProviderSettings.value).toMatchObject({
       scope: "openid profile api://nachet/access_as_user",
+    });
+  });
+
+  it("starts sign-in when silent token renewal fails", async () => {
+    import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
+    import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    mockOidcAuth.value.user = {
+      expired: true,
+      access_token: "expired-token",
+      profile: {
+        preferred_username: "oidc-user@example.com",
+        name: "OIDC User",
+        sub: "oidc-subject",
+      },
+    };
+    mockOidcAuth.value.signinSilent.mockRejectedValueOnce(
+      new Error("silent renewal failed"),
+    );
+
+    render(
+      <OidcAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        authContext={TestAuthContext}
+      >
+        <TokenConsumer />
+      </OidcAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText("get token"));
+
+    await waitFor(() => {
+      expect(mockOidcAuth.value.signinRedirect).toHaveBeenCalledWith({
+        scope: "openid profile email api://nachet/access_as_user",
+      });
     });
   });
 });

--- a/frontend/src/auth/oidc/OidcAuthProvider.test.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.test.tsx
@@ -63,6 +63,24 @@ const TokenConsumer = () => {
   );
 };
 
+const ConcurrentTokenConsumer = () => {
+  const auth = useContext(TestAuthContext);
+
+  return (
+    <button
+      onClick={() => {
+        if (!auth) {
+          return;
+        }
+
+        void Promise.allSettled([auth.getAccessToken(), auth.getAccessToken()]);
+      }}
+    >
+      get tokens concurrently
+    </button>
+  );
+};
+
 describe("OidcAuthProvider", () => {
   beforeEach(() => {
     capturedAuthProviderSettings.value = undefined;
@@ -182,6 +200,10 @@ describe("OidcAuthProvider", () => {
   it("starts sign-in when silent token renewal fails", async () => {
     import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
     import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    import.meta.env.VITE_OIDC_SCOPE = "openid profile email";
+    import.meta.env.VITE_OIDC_REDIRECT_URI = "http://localhost:5173/callback";
+    import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI =
+      "http://localhost:5173/";
     mockOidcAuth.value.user = {
       expired: true,
       access_token: "expired-token",
@@ -207,6 +229,55 @@ describe("OidcAuthProvider", () => {
     fireEvent.click(screen.getByText("get token"));
 
     await waitFor(() => {
+      expect(mockOidcAuth.value.signinRedirect).toHaveBeenCalledWith({
+        scope: "openid profile email api://nachet/access_as_user",
+      });
+    });
+  });
+
+  it("shares expired-token recovery across concurrent requests", async () => {
+    import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
+    import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    import.meta.env.VITE_OIDC_SCOPE = "openid profile email";
+    import.meta.env.VITE_OIDC_REDIRECT_URI = "http://localhost:5173/callback";
+    import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI =
+      "http://localhost:5173/";
+    mockOidcAuth.value.user = {
+      expired: true,
+      access_token: "expired-token",
+      profile: {
+        preferred_username: "oidc-user@example.com",
+        name: "OIDC User",
+        sub: "oidc-subject",
+      },
+    };
+
+    let rejectRenewal: (error: Error) => void = () => {};
+    mockOidcAuth.value.signinSilent.mockReturnValueOnce(
+      new Promise<null>((_, reject) => {
+        rejectRenewal = reject;
+      }),
+    );
+
+    render(
+      <OidcAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        authContext={TestAuthContext}
+      >
+        <ConcurrentTokenConsumer />
+      </OidcAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText("get tokens concurrently"));
+
+    await waitFor(() => {
+      expect(mockOidcAuth.value.signinSilent).toHaveBeenCalledTimes(1);
+    });
+
+    rejectRenewal(new Error("silent renewal failed"));
+
+    await waitFor(() => {
+      expect(mockOidcAuth.value.signinRedirect).toHaveBeenCalledTimes(1);
       expect(mockOidcAuth.value.signinRedirect).toHaveBeenCalledWith({
         scope: "openid profile email api://nachet/access_as_user",
       });

--- a/frontend/src/auth/oidc/OidcAuthProvider.test.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.test.tsx
@@ -63,6 +63,31 @@ const TokenConsumer = () => {
   );
 };
 
+const TokenCaptureConsumer = ({
+  forceRefresh = false,
+  scopes,
+}: {
+  forceRefresh?: boolean;
+  scopes?: string[];
+}) => {
+  const auth = useContext(TestAuthContext);
+
+  return (
+    <button
+      onClick={() => {
+        void auth
+          ?.getAccessToken(scopes, forceRefresh ? { forceRefresh } : undefined)
+          .then((token) => {
+            document.body.dataset.oidcToken = token;
+          })
+          .catch(() => undefined);
+      }}
+    >
+      capture token
+    </button>
+  );
+};
+
 const ConcurrentTokenConsumer = () => {
   const auth = useContext(TestAuthContext);
 
@@ -98,6 +123,7 @@ describe("OidcAuthProvider", () => {
     mockOidcAuth.value.signinRedirect.mockClear();
     mockOidcAuth.value.signinSilent.mockClear();
     mockOidcAuth.value.signoutRedirect.mockClear();
+    delete document.body.dataset.oidcToken;
     delete import.meta.env.VITE_OIDC_AUTHORITY;
     delete import.meta.env.VITE_OIDC_CLIENT_ID;
     delete import.meta.env.VITE_OIDC_SCOPE;
@@ -227,6 +253,139 @@ describe("OidcAuthProvider", () => {
     );
 
     fireEvent.click(screen.getByText("get token"));
+
+    await waitFor(() => {
+      expect(mockOidcAuth.value.signinRedirect).toHaveBeenCalledWith({
+        scope: "openid profile email api://nachet/access_as_user",
+      });
+    });
+  });
+
+  it("returns the cached token when it is fresh and the default scope is requested", async () => {
+    import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
+    import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    import.meta.env.VITE_OIDC_SCOPE = "openid profile email";
+    import.meta.env.VITE_OIDC_REDIRECT_URI = "http://localhost:5173/callback";
+    import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI =
+      "http://localhost:5173/";
+
+    render(
+      <OidcAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        authContext={TestAuthContext}
+      >
+        <TokenCaptureConsumer />
+      </OidcAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText("capture token"));
+
+    await waitFor(() => {
+      expect(document.body.dataset.oidcToken).toBe("oidc-access-token");
+    });
+    expect(mockOidcAuth.value.signinSilent).not.toHaveBeenCalled();
+  });
+
+  it("force-refreshes the token after a protected API 401", async () => {
+    import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
+    import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    import.meta.env.VITE_OIDC_SCOPE = "openid profile email";
+    import.meta.env.VITE_OIDC_REDIRECT_URI = "http://localhost:5173/callback";
+    import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI =
+      "http://localhost:5173/";
+    mockOidcAuth.value.signinSilent.mockResolvedValueOnce({
+      expired: false,
+      access_token: "fresh-oidc-token",
+      profile: {
+        preferred_username: "oidc-user@example.com",
+        name: "OIDC User",
+        sub: "oidc-subject",
+      },
+    });
+
+    render(
+      <OidcAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        authContext={TestAuthContext}
+      >
+        <TokenCaptureConsumer forceRefresh />
+      </OidcAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText("capture token"));
+
+    await waitFor(() => {
+      expect(document.body.dataset.oidcToken).toBe("fresh-oidc-token");
+    });
+    expect(mockOidcAuth.value.signinSilent).toHaveBeenCalledWith({
+      scope: "openid profile email api://nachet/access_as_user",
+    });
+  });
+
+  it("uses silent renewal when additional scopes are requested", async () => {
+    import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
+    import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    import.meta.env.VITE_OIDC_SCOPE = "openid profile email";
+    import.meta.env.VITE_OIDC_REDIRECT_URI = "http://localhost:5173/callback";
+    import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI =
+      "http://localhost:5173/";
+    mockOidcAuth.value.signinSilent.mockResolvedValueOnce({
+      expired: false,
+      access_token: "extra-scope-token",
+      profile: {
+        preferred_username: "oidc-user@example.com",
+        name: "OIDC User",
+        sub: "oidc-subject",
+      },
+    });
+
+    render(
+      <OidcAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        authContext={TestAuthContext}
+      >
+        <TokenCaptureConsumer scopes={["custom-scope"]} />
+      </OidcAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText("capture token"));
+
+    await waitFor(() => {
+      expect(document.body.dataset.oidcToken).toBe("extra-scope-token");
+    });
+    expect(mockOidcAuth.value.signinSilent).toHaveBeenCalledWith({
+      scope: "openid profile email api://nachet/access_as_user custom-scope",
+    });
+  });
+
+  it("starts sign-in when silent token renewal returns no fresh token", async () => {
+    import.meta.env.VITE_OIDC_AUTHORITY = "https://idp.example/realms/nachet";
+    import.meta.env.VITE_OIDC_CLIENT_ID = "frontend-client-id";
+    import.meta.env.VITE_OIDC_SCOPE = "openid profile email";
+    import.meta.env.VITE_OIDC_REDIRECT_URI = "http://localhost:5173/callback";
+    import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI =
+      "http://localhost:5173/";
+    mockOidcAuth.value.user = {
+      expired: true,
+      access_token: "expired-token",
+      profile: {
+        preferred_username: "oidc-user@example.com",
+        name: "OIDC User",
+        sub: "oidc-subject",
+      },
+    };
+    mockOidcAuth.value.signinSilent.mockResolvedValueOnce(null);
+
+    render(
+      <OidcAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        authContext={TestAuthContext}
+      >
+        <TokenCaptureConsumer />
+      </OidcAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText("capture token"));
 
     await waitFor(() => {
       expect(mockOidcAuth.value.signinRedirect).toHaveBeenCalledWith({

--- a/frontend/src/auth/oidc/OidcAuthProvider.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.tsx
@@ -110,6 +110,7 @@ const mapUser = (user: User | null) => {
     username,
     name,
     userId: getStringClaim(profile, ["oid", "sub"]) ?? username,
+    // Generic OIDC has no guest/member claim yet; claim mapping may own this later.
     isGuest: false,
     idTokenClaims: profile,
   };

--- a/frontend/src/auth/oidc/OidcAuthProvider.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.tsx
@@ -10,7 +10,10 @@ import {
   type User,
   type UserManagerSettings,
 } from "oidc-client-ts";
-import type { NachetAuthContextValue } from "../NachetAuthContext";
+import type {
+  NachetAuthContextValue,
+  NachetAuthTokenOptions,
+} from "../NachetAuthContext";
 import { AuthProvider } from "./react-oidc-context/AuthProvider";
 import { useAuth as useOidcAuth } from "./react-oidc-context/useAuth";
 
@@ -106,6 +109,8 @@ const mapUser = (user: User | null) => {
   return {
     username,
     name,
+    userId: getStringClaim(profile, ["oid", "sub"]) ?? username,
+    isGuest: false,
     idTokenClaims: profile,
   };
 };
@@ -126,9 +131,8 @@ const OidcAuthBridge = ({
     (scope: string) => {
       loginRedirectPromiseRef.current ??= Promise.resolve(
         oidc.signinRedirect({ scope }),
-      ).catch((error) => {
+      ).finally(() => {
         loginRedirectPromiseRef.current = null;
-        throw error;
       });
 
       return loginRedirectPromiseRef.current;
@@ -165,12 +169,15 @@ const OidcAuthBridge = ({
   }, [oidc]);
 
   const getAccessToken = useCallback(
-    async (scopes?: string[]) => {
-      if (oidc.user?.access_token && !oidc.user.expired) {
+    async (scopes?: string[], options?: NachetAuthTokenOptions) => {
+      const requestedScope = buildScope(defaultScope, scopes);
+      const canUseCachedToken =
+        !options?.forceRefresh && requestedScope === defaultScope;
+
+      if (canUseCachedToken && oidc.user?.access_token && !oidc.user.expired) {
         return oidc.user.access_token;
       }
 
-      const requestedScope = buildScope(defaultScope, scopes);
       let renewedUser: User | null | undefined;
       try {
         renewedUser = await signinSilentOnce(requestedScope);

--- a/frontend/src/auth/oidc/OidcAuthProvider.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, type Context, type ReactNode } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type Context,
+  type ReactNode,
+} from "react";
 import {
   WebStorageStateStore,
   type User,
@@ -110,13 +116,48 @@ const OidcAuthBridge = ({
   defaultScope,
 }: OidcAuthBridgeProps) => {
   const oidc = useOidcAuth();
+  const silentRenewPromisesRef = useRef<Map<string, Promise<User | null>>>(
+    new Map(),
+  );
+  const loginRedirectPromiseRef = useRef<Promise<void> | null>(null);
   const activeAccount = useMemo(() => mapUser(oidc.user), [oidc.user]);
+
+  const signinRedirectOnce = useCallback(
+    (scope: string) => {
+      loginRedirectPromiseRef.current ??= Promise.resolve(
+        oidc.signinRedirect({ scope }),
+      ).catch((error) => {
+        loginRedirectPromiseRef.current = null;
+        throw error;
+      });
+
+      return loginRedirectPromiseRef.current;
+    },
+    [oidc],
+  );
+
+  const signinSilentOnce = useCallback(
+    (scope: string) => {
+      const existingPromise = silentRenewPromisesRef.current.get(scope);
+      if (existingPromise) {
+        return existingPromise;
+      }
+
+      const renewPromise = oidc.signinSilent({ scope }).finally(() => {
+        silentRenewPromisesRef.current.delete(scope);
+      });
+      silentRenewPromisesRef.current.set(scope, renewPromise);
+
+      return renewPromise;
+    },
+    [oidc],
+  );
 
   const login = useCallback(
     async (scopes?: string[]) => {
-      await oidc.signinRedirect({ scope: buildScope(defaultScope, scopes) });
+      await signinRedirectOnce(buildScope(defaultScope, scopes));
     },
-    [defaultScope, oidc],
+    [defaultScope, signinRedirectOnce],
   );
 
   const logout = useCallback(async () => {
@@ -129,13 +170,12 @@ const OidcAuthBridge = ({
         return oidc.user.access_token;
       }
 
+      const requestedScope = buildScope(defaultScope, scopes);
       let renewedUser: User | null | undefined;
       try {
-        renewedUser = await oidc.signinSilent({
-          scope: buildScope(defaultScope, scopes),
-        });
+        renewedUser = await signinSilentOnce(requestedScope);
       } catch (error) {
-        await login(scopes);
+        await signinRedirectOnce(requestedScope);
         throw error;
       }
 
@@ -143,10 +183,10 @@ const OidcAuthBridge = ({
         return renewedUser.access_token;
       }
 
-      await login(scopes);
+      await signinRedirectOnce(requestedScope);
       throw new Error("Redirecting to sign in for a fresh OIDC access token.");
     },
-    [login, oidc],
+    [defaultScope, oidc.user, signinRedirectOnce, signinSilentOnce],
   );
 
   const authValue = useMemo<NachetAuthContextValue>(

--- a/frontend/src/auth/oidc/OidcAuthProvider.tsx
+++ b/frontend/src/auth/oidc/OidcAuthProvider.tsx
@@ -129,6 +129,20 @@ const OidcAuthBridge = ({
         return oidc.user.access_token;
       }
 
+      let renewedUser: User | null | undefined;
+      try {
+        renewedUser = await oidc.signinSilent({
+          scope: buildScope(defaultScope, scopes),
+        });
+      } catch (error) {
+        await login(scopes);
+        throw error;
+      }
+
+      if (renewedUser?.access_token && !renewedUser.expired) {
+        return renewedUser.access_token;
+      }
+
       await login(scopes);
       throw new Error("Redirecting to sign in for a fresh OIDC access token.");
     },

--- a/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
@@ -34,12 +34,16 @@ vi.mock("../oidc/OidcAuthProvider", () => ({
             {
               username: "oidc-user@example.com",
               name: "OIDC User",
+              userId: "oidc-subject",
+              isGuest: false,
               idTokenClaims: { sub: "oidc-subject" },
             },
           ],
           activeAccount: {
             username: "oidc-user@example.com",
             name: "OIDC User",
+            userId: "oidc-subject",
+            isGuest: false,
             idTokenClaims: { sub: "oidc-subject" },
           },
           login: vi.fn(),
@@ -99,10 +103,7 @@ describe("NachetAuthProvider API bridge", () => {
 
   it("initializes Axios with the shared auth provider before child API helpers run", async () => {
     render(
-      <NachetAuthProvider
-        apiScopeClaim="api://nachet/access_as_user"
-        msalInstance={{} as any}
-      >
+      <NachetAuthProvider apiScopeClaim="api://nachet/access_as_user">
         <ApiCallOnMount backendUrl="https://api.example.test" />
       </NachetAuthProvider>,
     );

--- a/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearApiAuthentication, fetchDevices } from "../../common/api";
+import { NachetAuthProvider } from "../";
+
+const mockOidcAuth = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+}));
+
+vi.mock("../../logging", () => ({
+  errorLogger: {
+    getCorrelationId: vi.fn(() => "test-correlation-id"),
+    getSessionId: vi.fn(() => "test-session-id"),
+    logApiError: vi.fn(),
+    logError: vi.fn(),
+    setCorrelationId: vi.fn(),
+    setTokenProvider: vi.fn(),
+  },
+}));
+
+vi.mock("../oidc/OidcAuthProvider", () => ({
+  OidcAuthProvider: ({ authContext, children }: any) => {
+    const Provider = authContext.Provider;
+
+    return (
+      <Provider
+        value={{
+          provider: "oidc",
+          isAuthenticated: true,
+          isLoading: false,
+          accounts: [
+            {
+              username: "oidc-user@example.com",
+              name: "OIDC User",
+              idTokenClaims: { sub: "oidc-subject" },
+            },
+          ],
+          activeAccount: {
+            username: "oidc-user@example.com",
+            name: "OIDC User",
+            idTokenClaims: { sub: "oidc-subject" },
+          },
+          login: vi.fn(),
+          logout: vi.fn(),
+          getAccessToken: mockOidcAuth.getAccessToken,
+        }}
+      >
+        {children}
+      </Provider>
+    );
+  },
+}));
+
+const ApiCallOnMount = ({ backendUrl }: { backendUrl: string }) => {
+  const [status, setStatus] = useState("pending");
+
+  useEffect(() => {
+    void fetchDevices({ backendUrl })
+      .then(() => {
+        setStatus("loaded");
+      })
+      .catch((error: unknown) => {
+        setStatus(error instanceof Error ? error.message : "failed");
+      });
+  }, [backendUrl]);
+
+  return <span data-testid="api-status">{status}</span>;
+};
+
+describe("NachetAuthProvider API bridge", () => {
+  const originalAdapter = axios.defaults.adapter;
+  const authorizationHeaders: Array<string | undefined> = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorizationHeaders.length = 0;
+    import.meta.env.VITE_AUTH_PROVIDER = "oidc";
+    mockOidcAuth.getAccessToken.mockResolvedValue("oidc-api-token");
+    axios.defaults.adapter = async (requestConfig: any) => {
+      authorizationHeaders.push(requestConfig.headers.Authorization);
+
+      return {
+        data: { devices: [] },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: requestConfig,
+      };
+    };
+  });
+
+  afterEach(() => {
+    clearApiAuthentication();
+    axios.defaults.adapter = originalAdapter;
+    delete import.meta.env.VITE_AUTH_PROVIDER;
+  });
+
+  it("initializes Axios with the shared auth provider before child API helpers run", async () => {
+    render(
+      <NachetAuthProvider
+        apiScopeClaim="api://nachet/access_as_user"
+        msalInstance={{} as any}
+      >
+        <ApiCallOnMount backendUrl="https://api.example.test" />
+      </NachetAuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("api-status").textContent).toBe("loaded");
+    });
+
+    expect(mockOidcAuth.getAccessToken).toHaveBeenCalledOnce();
+    expect(authorizationHeaders).toEqual(["Bearer oidc-api-token"]);
+  });
+});

--- a/frontend/src/auth/tests/NachetAuthProvider.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.test.tsx
@@ -15,6 +15,7 @@ vi.mock("../../common/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../common/api")>();
   return {
     ...actual,
+    clearApiAuthentication: vi.fn(),
     initializeApi: vi.fn(),
   };
 });

--- a/frontend/src/auth/tests/NachetAuthProvider.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.test.tsx
@@ -3,6 +3,7 @@ import { InteractionStatus } from "@azure/msal-browser";
 import { useIsAuthenticated, useMsal } from "@azure/msal-react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { acquireAccessToken } from "../../common/auth";
+import { initializeApi } from "../../common/api";
 import { NachetAuthProvider, useNachetAuth } from "../";
 
 vi.mock("@azure/msal-react", () => ({
@@ -38,12 +39,16 @@ vi.mock("../oidc/OidcAuthProvider", () => ({
             {
               username: "oidc-user@example.com",
               name: "OIDC User",
+              userId: "oidc-subject",
+              isGuest: false,
               idTokenClaims: { sub: "oidc-subject" },
             },
           ],
           activeAccount: {
             username: "oidc-user@example.com",
             name: "OIDC User",
+            userId: "oidc-subject",
+            isGuest: false,
             idTokenClaims: { sub: "oidc-subject" },
           },
           login: vi.fn(),
@@ -65,6 +70,7 @@ const mockAccount = {
   username: "user@example.com",
   name: "Test User",
   idTokenClaims: {
+    oid: "member-oid",
     acct: 0,
   },
 };
@@ -103,11 +109,13 @@ describe("NachetAuthProvider", () => {
     logoutRedirect: vi.fn(),
   };
 
-  const renderWithProvider = () =>
+  const renderWithProvider = ({
+    msalInstance = mockMsalInstance as any,
+  }: { msalInstance?: any } = {}) =>
     render(
       <NachetAuthProvider
         apiScopeClaim="api://nachet/scope"
-        msalInstance={mockMsalInstance as any}
+        msalInstance={msalInstance}
       >
         <TestConsumer />
       </NachetAuthProvider>,
@@ -166,11 +174,30 @@ describe("NachetAuthProvider", () => {
 
     fireEvent.click(screen.getByText("token"));
     await waitFor(() => {
-      expect(acquireAccessToken).toHaveBeenCalledWith(mockMsalInstance, [
-        "api://nachet/scope",
-      ]);
+      expect(acquireAccessToken).toHaveBeenCalledWith(
+        mockMsalInstance,
+        ["api://nachet/scope"],
+        undefined,
+      );
       expect(document.body.dataset.token).toBe("access-token");
     });
+  });
+
+  it("initializes API auth through the MSAL adapter by default", async () => {
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(initializeApi).toHaveBeenCalled();
+    });
+
+    const getAccessToken = (initializeApi as any).mock.calls[0][0];
+    await getAccessToken({ forceRefresh: true });
+
+    expect(acquireAccessToken).toHaveBeenCalledWith(
+      mockMsalInstance,
+      ["api://nachet/scope"],
+      { forceRefresh: true },
+    );
   });
 
   it("normalizes the configured provider name", () => {
@@ -212,7 +239,11 @@ describe("NachetAuthProvider", () => {
   it("selects the OIDC adapter when oidc is configured", () => {
     import.meta.env.VITE_AUTH_PROVIDER = "oidc";
 
-    renderWithProvider();
+    render(
+      <NachetAuthProvider apiScopeClaim="api://nachet/scope">
+        <TestConsumer />
+      </NachetAuthProvider>,
+    );
 
     expect(screen.getByTestId("provider").textContent).toBe("oidc");
     expect(screen.getByTestId("username").textContent).toBe(

--- a/frontend/src/auth/tests/NachetAuthProvider.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.test.tsx
@@ -208,12 +208,12 @@ describe("NachetAuthProvider", () => {
     expect(screen.getByTestId("provider").textContent).toBe("msal");
   });
 
-  it("uses MSAL when no auth provider is configured", () => {
+  it("fails closed when no auth provider is configured", () => {
     delete import.meta.env.VITE_AUTH_PROVIDER;
 
-    renderWithProvider();
-
-    expect(screen.getByTestId("provider").textContent).toBe("msal");
+    expect(() => renderWithProvider()).toThrow(
+      'VITE_AUTH_PROVIDER must be set to "msal" or "oidc".',
+    );
   });
 
   it("does not start login while another MSAL interaction is in progress", async () => {
@@ -263,6 +263,6 @@ describe("NachetAuthProvider", () => {
           <TestConsumer />
         </NachetAuthProvider>,
       ),
-    ).toThrow("Unsupported auth provider 'unknown'");
+    ).toThrow('VITE_AUTH_PROVIDER must be set to "msal" or "oidc".');
   });
 });

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -53,15 +53,15 @@ let isAuthProviderInitialized = false;
  *
  * @param getAccessToken - Provider-neutral token getter
  */
-export function initializeApi(getAccessToken: () => Promise<string>): void {
+export const initializeApi = (getAccessToken: () => Promise<string>): void => {
   setupAxiosInterceptor(getAccessToken);
   isAuthProviderInitialized = true;
-}
+};
 
-export function clearApiAuthentication(): void {
+export const clearApiAuthentication = (): void => {
   clearAxiosInterceptors();
   isAuthProviderInitialized = false;
-}
+};
 
 // Re-export resetRedirectFlag for use in main.tsx
 export { resetRedirectFlag };

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -41,9 +41,9 @@ import {
 import { errorLogger } from "../logging";
 import {
   setupAxiosInterceptor,
-  resetRedirectFlag,
   clearAxiosInterceptors,
 } from "./apiInterceptor";
+import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
 
 let isAuthProviderInitialized = false;
 
@@ -53,7 +53,9 @@ let isAuthProviderInitialized = false;
  *
  * @param getAccessToken - Provider-neutral token getter
  */
-export const initializeApi = (getAccessToken: () => Promise<string>): void => {
+export const initializeApi = (
+  getAccessToken: (options?: NachetAuthTokenOptions) => Promise<string>,
+): void => {
   setupAxiosInterceptor(getAccessToken);
   isAuthProviderInitialized = true;
 };
@@ -62,9 +64,6 @@ export const clearApiAuthentication = (): void => {
   clearAxiosInterceptors();
   isAuthProviderInitialized = false;
 };
-
-// Re-export resetRedirectFlag for use in main.tsx
-export { resetRedirectFlag };
 
 const handleAxios = async <T>(request: {
   method: string;
@@ -938,7 +937,7 @@ export const batchUploadImage = async ({
  * Authorization: Users can only create folders for themselves
  *
  * @param backendUrl - Backend API base URL
- * @param accessToken - Bearer token for authentication
+ * @param accessToken - Optional compatibility bearer token. App callers normally use the shared auth provider.
  * @param normalizedPath - Relative path from user's root (e.g., "avena-fatua" or "mycology/avena-fatua")
  * @param description - Optional folder description
  * @returns Promise resolving to CreateOrGetFolderResponse with folderId
@@ -948,7 +947,6 @@ export const batchUploadImage = async ({
  * @example
  * await createOrGetFolder({
  *   backendUrl: "https://api.example.com",
- *   accessToken: "bearer-token",
  *   normalizedPath: "mycology/avena-fatua",
  *   description: "Wild oat samples"
  * });
@@ -1012,7 +1010,7 @@ export const createOrGetFolder = async ({
  * Restrictions: Cannot update default folders for active users
  *
  * @param backendUrl - Backend API base URL
- * @param accessToken - Bearer token for authentication
+ * @param accessToken - Optional compatibility bearer token. App callers normally use the shared auth provider.
  * @param folderId - UUID of the folder to update
  * @param name - Optional new folder name (just the name, not full path)
  * @param description - Optional new description
@@ -1023,7 +1021,6 @@ export const createOrGetFolder = async ({
  * @example
  * await updateFolder({
  *   backendUrl: "https://api.example.com",
- *   accessToken: "bearer-token",
  *   folderId: "uuid-string",
  *   name: "new-folder-name",
  *   description: "Updated description"

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -39,7 +39,13 @@ import {
   safeUserInputSchema,
 } from "./validation";
 import { errorLogger } from "../logging";
-import { setupAxiosInterceptor, resetRedirectFlag } from "./apiInterceptor";
+import {
+  setupAxiosInterceptor,
+  resetRedirectFlag,
+  clearAxiosInterceptors,
+} from "./apiInterceptor";
+
+let isAuthProviderInitialized = false;
 
 /**
  * Initialize API module with axios interceptor for authentication
@@ -49,6 +55,12 @@ import { setupAxiosInterceptor, resetRedirectFlag } from "./apiInterceptor";
  */
 export function initializeApi(getAccessToken: () => Promise<string>): void {
   setupAxiosInterceptor(getAccessToken);
+  isAuthProviderInitialized = true;
+}
+
+export function clearApiAuthentication(): void {
+  clearAxiosInterceptors();
+  isAuthProviderInitialized = false;
 }
 
 // Re-export resetRedirectFlag for use in main.tsx
@@ -64,6 +76,15 @@ const handleAxios = async <T>(request: {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
   const requestHasAuthHeader = Boolean(request.headers.Authorization);
+  const requestRequiresAuth = request.authRequired !== false;
+
+  if (
+    requestRequiresAuth &&
+    !requestHasAuthHeader &&
+    !isAuthProviderInitialized
+  ) {
+    throw new ValueError("Auth provider is not initialized for API requests");
+  }
 
   // Add correlation and session IDs to headers
   const enhancedRequest = {
@@ -74,7 +95,7 @@ const handleAxios = async <T>(request: {
       "X-Session-ID": errorLogger.getSessionId(),
     },
     withCredentials: true,
-    ...(request.authRequired !== false && !requestHasAuthHeader
+    ...(requestRequiresAuth && !requestHasAuthHeader
       ? { nachetAuthRequired: true }
       : {}),
   };

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -40,20 +40,15 @@ import {
 } from "./validation";
 import { errorLogger } from "../logging";
 import { setupAxiosInterceptor, resetRedirectFlag } from "./apiInterceptor";
-import type { IPublicClientApplication } from "@azure/msal-browser";
 
 /**
  * Initialize API module with axios interceptor for authentication
  * Must be called once during app initialization
  *
- * @param msalInstance - MSAL instance for authentication
- * @param scopes - Array of scopes to request for tokens
+ * @param getAccessToken - Provider-neutral token getter
  */
-export function initializeApi(
-  msalInstance: IPublicClientApplication,
-  scopes: string[],
-): void {
-  setupAxiosInterceptor(msalInstance, scopes);
+export function initializeApi(getAccessToken: () => Promise<string>): void {
+  setupAxiosInterceptor(getAccessToken);
 }
 
 // Re-export resetRedirectFlag for use in main.tsx
@@ -64,9 +59,11 @@ const handleAxios = async <T>(request: {
   url: string;
   headers: { [label: string]: string };
   data?: any;
+  authRequired?: boolean;
 }): Promise<T> => {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
+  const requestHasAuthHeader = Boolean(request.headers.Authorization);
 
   // Add correlation and session IDs to headers
   const enhancedRequest = {
@@ -77,6 +74,9 @@ const handleAxios = async <T>(request: {
       "X-Session-ID": errorLogger.getSessionId(),
     },
     withCredentials: true,
+    ...(request.authRequired !== false && !requestHasAuthHeader
+      ? { nachetAuthRequired: true }
+      : {}),
   };
 
   const data = await axios(enhancedRequest)
@@ -147,6 +147,16 @@ const handleAxios = async <T>(request: {
   return data;
 };
 
+const getAuthHeaders = (
+  accessToken?: string | null,
+): Record<string, string> => {
+  if (accessToken === "" || accessToken === null) {
+    throw new ValueError("Access token is null or empty");
+  }
+
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+};
+
 export const pingBackend = async ({
   backendUrl,
 }: {
@@ -158,6 +168,7 @@ export const pingBackend = async ({
   const request = {
     method: "get",
     url: `${backendUrl}/health`,
+    authRequired: false,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
@@ -176,13 +187,10 @@ export const checkUserRegistration = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<{ isRegistered: boolean }> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -190,7 +198,7 @@ export const checkUserRegistration = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
   };
   const response = await handleAxios<unknown>(request);
@@ -206,13 +214,10 @@ export const readAzureStorageDir = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ReadAzureStorageDirApi> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -220,7 +225,7 @@ export const readAzureStorageDir = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     // data: {
     //   //   container_name: uuid,
@@ -240,14 +245,11 @@ export const createAzureStorageDir = async ({
   folderName,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
@@ -258,7 +260,7 @@ export const createAzureStorageDir = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       folderName: folderName,
@@ -282,14 +284,11 @@ export const deleteAzureStorageDir = async ({
   folderName,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
@@ -300,7 +299,7 @@ export const deleteAzureStorageDir = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       folderName: folderName,
@@ -323,14 +322,11 @@ export const deleteFolder = async ({
   folderId,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
 }): Promise<{ id: string; message: string }> => {
   if (!backendUrl) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (!accessToken) {
-    throw new ValueError("Access token is null or empty");
   }
   if (!folderId) {
     throw new ValueError("Folder ID is null or empty");
@@ -342,7 +338,7 @@ export const deleteFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
   };
 
@@ -373,7 +369,7 @@ export const inferenceRequest = async ({
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
 }): Promise<ImageSubmissionResponse> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -388,9 +384,7 @@ export const inferenceRequest = async ({
   if (curDir === "" || curDir == null) {
     throw new ValueError("Directory is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
+  const authHeaders = getAuthHeaders(accessToken);
 
   // Build payload object with all required and optional fields
   const payload = {
@@ -429,7 +423,7 @@ export const inferenceRequest = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...authHeaders,
     },
     data: validatedPayload,
   };
@@ -453,7 +447,7 @@ export const inferenceDirectRequest = async ({
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -468,9 +462,7 @@ export const inferenceDirectRequest = async ({
   if (curDir === "" || curDir == null) {
     throw new ValueError("Directory is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
+  const authHeaders = getAuthHeaders(accessToken);
 
   // Build payload object with all required and optional fields
   const payload = {
@@ -509,7 +501,7 @@ export const inferenceDirectRequest = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...authHeaders,
     },
     data: validatedPayload,
   };
@@ -526,13 +518,10 @@ export const fetchModelMetadata = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ModelMetadata[]> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -540,7 +529,7 @@ export const fetchModelMetadata = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -557,13 +546,10 @@ export const fetchDevices = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiDevicesResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -571,7 +557,7 @@ export const fetchDevices = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -590,7 +576,7 @@ export const getWorkflowStatus = async ({
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<WorkflowStatusResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -598,16 +584,13 @@ export const getWorkflowStatus = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/status`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -626,7 +609,7 @@ export const getWorkflowResults = async ({
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -634,16 +617,13 @@ export const getWorkflowResults = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/results`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -662,13 +642,10 @@ export const sendFeedbackNewBox = async ({
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "post",
@@ -676,7 +653,7 @@ export const sendFeedbackNewBox = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: feedbackData,
   };
@@ -695,13 +672,10 @@ export const sendPositiveFeedback = async ({
 }: {
   feedbackData: FeedbackDataPositive;
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "post",
@@ -709,7 +683,7 @@ export const sendPositiveFeedback = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: feedbackData,
   };
@@ -728,13 +702,10 @@ export const sendNegativeFeedback = async ({
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "post",
@@ -742,7 +713,7 @@ export const sendNegativeFeedback = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: feedbackData,
   };
@@ -784,13 +755,10 @@ export const requestClassList = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiSpeciesData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -798,7 +766,7 @@ export const requestClassList = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -817,7 +785,7 @@ export const batchUploadInit = async ({
   fileCount,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
   fileCount: number;
 }): Promise<{
@@ -825,9 +793,6 @@ export const batchUploadInit = async ({
 }> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderId === "" || folderId == null) {
     throw new ValueError("Folder ID is null or empty");
@@ -841,7 +806,7 @@ export const batchUploadInit = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       folderId: folderId,
@@ -863,7 +828,7 @@ export const batchUploadImage = async ({
 }: {
   backendUrl: string;
   data: BatchUploadMetadata;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<BatchUploadImageResponse> => {
   const {
     sessionId,
@@ -909,9 +874,7 @@ export const batchUploadImage = async ({
   if (magnification === 0 || magnification == null) {
     throw new ValueError("Magnification is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
+  const authHeaders = getAuthHeaders(accessToken);
 
   const request = {
     method: "post",
@@ -919,7 +882,7 @@ export const batchUploadImage = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...authHeaders,
     },
     data: {
       sessionId: sessionId,
@@ -977,16 +940,13 @@ export const createOrGetFolder = async ({
   description = "",
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   normalizedPath: string;
   description?: string;
 }): Promise<CreateOrGetFolderResponse> => {
   // Validation
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (normalizedPath === "" || normalizedPath == null) {
     throw new ValueError("Normalized path is null or empty");
@@ -1006,7 +966,7 @@ export const createOrGetFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       normalizedPath: normalizedPath,
@@ -1057,7 +1017,7 @@ export const updateFolder = async ({
   description,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
   name?: string;
   description?: string;
@@ -1065,9 +1025,6 @@ export const updateFolder = async ({
   // Validation
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderId === "" || folderId == null) {
     throw new ValueError("Folder ID is null or empty");
@@ -1104,7 +1061,7 @@ export const updateFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       ...(name && { name }),
@@ -1126,7 +1083,7 @@ export const sendLogToBackend = async ({
   logData,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   logData: {
     level: "ERROR" | "WARNING" | "INFO" | "DEBUG";
     message: string;
@@ -1141,16 +1098,13 @@ export const sendLogToBackend = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
   const request = {
     method: "post",
     url: `${backendUrl}/logs`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: logData,
   };

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -77,6 +77,8 @@ const handleAxios = async <T>(request: {
   const correlationId = errorLogger.getCorrelationId();
   const requestHasAuthHeader = Boolean(request.headers.Authorization);
   const requestRequiresAuth = request.authRequired !== false;
+  const requestCanUseAuthProvider =
+    requestRequiresAuth && (!requestHasAuthHeader || isAuthProviderInitialized);
 
   if (
     requestRequiresAuth &&
@@ -95,9 +97,7 @@ const handleAxios = async <T>(request: {
       "X-Session-ID": errorLogger.getSessionId(),
     },
     withCredentials: true,
-    ...(requestRequiresAuth && !requestHasAuthHeader
-      ? { nachetAuthRequired: true }
-      : {}),
+    ...(requestCanUseAuthProvider ? { nachetAuthRequired: true } : {}),
   };
 
   const data = await axios(enhancedRequest)

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -1,12 +1,17 @@
-import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
+import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
 import {
-  IPublicClientApplication,
   InteractionRequiredAuthError,
   BrowserAuthError,
 } from "@azure/msal-browser";
 
 // Track if we're currently in a redirect flow to prevent loops
 let isRedirecting = false;
+let requestInterceptorId: number | null = null;
+let responseInterceptorId: number | null = null;
+
+interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
+  nachetAuthRequired?: boolean;
+}
 
 /**
  * Checks if an error requires user interaction (redirect to login)
@@ -29,18 +34,41 @@ export function resetRedirectFlag(): void {
 }
 
 /**
- * Configure axios interceptor to handle 401 Unauthorized errors
- * and trigger redirect authentication when tokens expire
+ * Configure axios interceptor to handle 401 Unauthorized errors and retry once
+ * with a fresh token from the active auth provider.
  *
- * @param msalInstance - MSAL instance for authentication
- * @param scopes - Array of scopes to request for tokens
+ * @param getAccessToken - Provider-neutral token getter
  */
 export function setupAxiosInterceptor(
-  msalInstance: IPublicClientApplication,
-  scopes: string[],
+  getAccessToken: () => Promise<string>,
 ): void {
+  if (requestInterceptorId !== null) {
+    axios.interceptors.request.eject(requestInterceptorId);
+  }
+
+  if (responseInterceptorId !== null) {
+    axios.interceptors.response.eject(responseInterceptorId);
+  }
+
+  requestInterceptorId = axios.interceptors.request.use(
+    async (config: NachetAuthRequestConfig) => {
+      if (!config.nachetAuthRequired || config.headers?.Authorization) {
+        return config;
+      }
+
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("Access token is null or empty");
+      }
+
+      config.headers.Authorization = `Bearer ${accessToken}`;
+      return config;
+    },
+    (error) => Promise.reject(error),
+  );
+
   // Response interceptor to handle 401 errors
-  axios.interceptors.response.use(
+  responseInterceptorId = axios.interceptors.response.use(
     (response) => response, // Pass through successful responses
     async (error: AxiosError) => {
       const originalRequest = error.config as InternalAxiosRequestConfig & {
@@ -56,27 +84,12 @@ export function setupAxiosInterceptor(
           return Promise.reject(error);
         }
 
-        // Get the active account
-        const activeAccount = msalInstance.getActiveAccount();
-        const accounts = msalInstance.getAllAccounts();
-
-        if (!activeAccount && accounts.length === 0) {
-          // Let the error propagate - user is not authenticated
-          return Promise.reject(error);
-        }
-
-        const request = {
-          scopes,
-          account: activeAccount || accounts[0],
-        };
-
         try {
-          // Try to acquire token silently
-          const authResult = await msalInstance.acquireTokenSilent(request);
+          const accessToken = await getAccessToken();
 
           // Update the authorization header with new token
           if (originalRequest.headers) {
-            originalRequest.headers.Authorization = `Bearer ${authResult.accessToken}`;
+            originalRequest.headers.Authorization = `Bearer ${accessToken}`;
           }
 
           // Retry the original request with new token
@@ -87,9 +100,6 @@ export function setupAxiosInterceptor(
             // Set redirect flag to prevent loops
             isRedirecting = true;
 
-            // Trigger redirect authentication
-            await msalInstance.acquireTokenRedirect(request);
-            // This line will never be reached as user is redirected away
             return Promise.reject(tokenError);
           }
 

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -49,7 +49,7 @@ export function resetRedirectFlag(): void {
   isRedirecting = false;
 }
 
-export function clearAxiosInterceptors(): void {
+export const clearAxiosInterceptors = (): void => {
   if (requestInterceptorId !== null) {
     axios.interceptors.request.eject(requestInterceptorId);
     requestInterceptorId = null;
@@ -61,7 +61,7 @@ export function clearAxiosInterceptors(): void {
   }
 
   resetRedirectFlag();
-}
+};
 
 /**
  * Configure axios interceptor to handle 401 Unauthorized errors and retry once

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -13,6 +13,22 @@ interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
   nachetAuthRequired?: boolean;
 }
 
+function assertAccessToken(accessToken: string): string {
+  if (!accessToken) {
+    throw new Error("Access token is null or empty");
+  }
+
+  return accessToken;
+}
+
+function requestRequiresNachetAuth(
+  request?: InternalAxiosRequestConfig,
+): request is NachetAuthRequestConfig {
+  return Boolean(
+    (request as NachetAuthRequestConfig | undefined)?.nachetAuthRequired,
+  );
+}
+
 /**
  * Checks if an error requires user interaction (redirect to login)
  * @param error - The error to check
@@ -33,22 +49,30 @@ export function resetRedirectFlag(): void {
   isRedirecting = false;
 }
 
+export function clearAxiosInterceptors(): void {
+  if (requestInterceptorId !== null) {
+    axios.interceptors.request.eject(requestInterceptorId);
+    requestInterceptorId = null;
+  }
+
+  if (responseInterceptorId !== null) {
+    axios.interceptors.response.eject(responseInterceptorId);
+    responseInterceptorId = null;
+  }
+
+  resetRedirectFlag();
+}
+
 /**
  * Configure axios interceptor to handle 401 Unauthorized errors and retry once
- * with a fresh token from the active auth provider.
+ * with an access token from the active auth provider.
  *
  * @param getAccessToken - Provider-neutral token getter
  */
 export function setupAxiosInterceptor(
   getAccessToken: () => Promise<string>,
 ): void {
-  if (requestInterceptorId !== null) {
-    axios.interceptors.request.eject(requestInterceptorId);
-  }
-
-  if (responseInterceptorId !== null) {
-    axios.interceptors.response.eject(responseInterceptorId);
-  }
+  clearAxiosInterceptors();
 
   requestInterceptorId = axios.interceptors.request.use(
     async (config: NachetAuthRequestConfig) => {
@@ -56,12 +80,9 @@ export function setupAxiosInterceptor(
         return config;
       }
 
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
-        throw new Error("Access token is null or empty");
-      }
-
-      config.headers.Authorization = `Bearer ${accessToken}`;
+      config.headers.Authorization = `Bearer ${assertAccessToken(
+        await getAccessToken(),
+      )}`;
       return config;
     },
     (error) => Promise.reject(error),
@@ -76,7 +97,11 @@ export function setupAxiosInterceptor(
       };
 
       // Check if this is a 401 error and we haven't already retried
-      if (error.response?.status === 401 && !originalRequest?._retry) {
+      if (
+        error.response?.status === 401 &&
+        requestRequiresNachetAuth(originalRequest) &&
+        !originalRequest?._retry
+      ) {
         originalRequest._retry = true;
 
         // Prevent redirect loop
@@ -85,7 +110,7 @@ export function setupAxiosInterceptor(
         }
 
         try {
-          const accessToken = await getAccessToken();
+          const accessToken = assertAccessToken(await getAccessToken());
 
           // Update the authorization header with new token
           if (originalRequest.headers) {

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -1,11 +1,5 @@
 import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
-import {
-  InteractionRequiredAuthError,
-  BrowserAuthError,
-} from "@azure/msal-browser";
 
-// Track if we're currently in a redirect flow to prevent loops
-let isRedirecting = false;
 let requestInterceptorId: number | null = null;
 let responseInterceptorId: number | null = null;
 
@@ -13,41 +7,27 @@ interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
   nachetAuthRequired?: boolean;
 }
 
-function assertAccessToken(accessToken: string): string {
+interface AccessTokenOptions {
+  forceRefresh?: boolean;
+}
+
+type GetAccessToken = (options?: AccessTokenOptions) => Promise<string>;
+
+const assertAccessToken = (accessToken: string): string => {
   if (!accessToken) {
     throw new Error("Access token is null or empty");
   }
 
   return accessToken;
-}
+};
 
-function requestRequiresNachetAuth(
+const requestRequiresNachetAuth = (
   request?: InternalAxiosRequestConfig,
-): request is NachetAuthRequestConfig {
+): request is NachetAuthRequestConfig => {
   return Boolean(
     (request as NachetAuthRequestConfig | undefined)?.nachetAuthRequired,
   );
-}
-
-/**
- * Checks if an error requires user interaction (redirect to login)
- * @param error - The error to check
- * @returns true if the error requires redirect authentication
- */
-export function shouldTriggerRedirect(error: unknown): boolean {
-  return (
-    error instanceof InteractionRequiredAuthError ||
-    (error instanceof BrowserAuthError &&
-      error.errorCode === "monitor_window_timeout")
-  );
-}
-
-/**
- * Reset the redirect flag (called after successful redirect)
- */
-export function resetRedirectFlag(): void {
-  isRedirecting = false;
-}
+};
 
 export const clearAxiosInterceptors = (): void => {
   if (requestInterceptorId !== null) {
@@ -59,8 +39,6 @@ export const clearAxiosInterceptors = (): void => {
     axios.interceptors.response.eject(responseInterceptorId);
     responseInterceptorId = null;
   }
-
-  resetRedirectFlag();
 };
 
 /**
@@ -69,9 +47,7 @@ export const clearAxiosInterceptors = (): void => {
  *
  * @param getAccessToken - Provider-neutral token getter
  */
-export function setupAxiosInterceptor(
-  getAccessToken: () => Promise<string>,
-): void {
+export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
   clearAxiosInterceptors();
 
   requestInterceptorId = axios.interceptors.request.use(
@@ -104,13 +80,10 @@ export function setupAxiosInterceptor(
       ) {
         originalRequest._retry = true;
 
-        // Prevent redirect loop
-        if (isRedirecting) {
-          return Promise.reject(error);
-        }
-
         try {
-          const accessToken = assertAccessToken(await getAccessToken());
+          const accessToken = assertAccessToken(
+            await getAccessToken({ forceRefresh: true }),
+          );
 
           // Update the authorization header with new token
           if (originalRequest.headers) {
@@ -120,15 +93,6 @@ export function setupAxiosInterceptor(
           // Retry the original request with new token
           return axios(originalRequest);
         } catch (tokenError) {
-          // If silent token acquisition fails, check if redirect is needed
-          if (shouldTriggerRedirect(tokenError)) {
-            // Set redirect flag to prevent loops
-            isRedirecting = true;
-
-            return Promise.reject(tokenError);
-          }
-
-          // For other errors, just reject
           return Promise.reject(tokenError);
         }
       }
@@ -137,4 +101,4 @@ export function setupAxiosInterceptor(
       return Promise.reject(error);
     },
   );
-}
+};

--- a/frontend/src/common/auth.ts
+++ b/frontend/src/common/auth.ts
@@ -3,6 +3,7 @@ import {
   InteractionRequiredAuthError,
   BrowserAuthError,
 } from "@azure/msal-browser";
+import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
 
 // Track if we're currently in a redirect flow to prevent loops
 let isRedirecting = false;
@@ -12,7 +13,7 @@ let isRedirecting = false;
  * @param error - The error to check
  * @returns true if the error requires redirect authentication
  */
-export function shouldTriggerRedirect(error: unknown): boolean {
+export const shouldTriggerRedirect = (error: unknown): boolean => {
   return (
     error instanceof InteractionRequiredAuthError ||
     (error instanceof BrowserAuthError &&
@@ -20,14 +21,14 @@ export function shouldTriggerRedirect(error: unknown): boolean {
     (error instanceof BrowserAuthError &&
       error.errorCode === "interaction_in_progress")
   );
-}
+};
 
 /**
  * Reset the redirect flag (called after successful redirect)
  */
-export function resetAuthRedirectFlag(): void {
+export const resetAuthRedirectFlag = (): void => {
   isRedirecting = false;
-}
+};
 
 /**
  * Acquires an access token outside of React component context
@@ -38,10 +39,11 @@ export function resetAuthRedirectFlag(): void {
  * @returns Access token string
  * @throws Error if user is not signed in or token acquisition fails
  */
-export async function acquireAccessToken(
+export const acquireAccessToken = async (
   msalInstance: IPublicClientApplication,
   scopes: string[],
-): Promise<string> {
+  options: NachetAuthTokenOptions = {},
+): Promise<string> => {
   const activeAccount = msalInstance.getActiveAccount();
   const accounts = msalInstance.getAllAccounts();
 
@@ -54,6 +56,7 @@ export async function acquireAccessToken(
   const request = {
     scopes,
     account: activeAccount || accounts[0],
+    forceRefresh: options.forceRefresh,
   };
 
   try {
@@ -83,7 +86,7 @@ export async function acquireAccessToken(
     }
     throw error;
   }
-}
+};
 
 /**
  * Acquires an ID token
@@ -91,10 +94,10 @@ export async function acquireAccessToken(
  * @param scopes - Array of scopes to request
  * @returns ID token string
  */
-export async function acquireIdToken(
+export const acquireIdToken = async (
   msalInstance: IPublicClientApplication,
   scopes: string[],
-): Promise<string> {
+): Promise<string> => {
   const activeAccount = msalInstance.getActiveAccount();
   const accounts = msalInstance.getAllAccounts();
 
@@ -134,4 +137,4 @@ export async function acquireIdToken(
     }
     throw error;
   }
-}
+};

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -2,6 +2,7 @@ import { describe, it, vi, beforeEach, expect } from "vitest";
 import {
   createAzureStorageDir,
   deleteAzureStorageDir,
+  fetchDevices,
   fetchModelMetadata,
   inferenceRequest,
   readAzureStorageDir,
@@ -34,6 +35,18 @@ vi.mock("../../logging", () => ({
 
 beforeEach(() => {
   mockedAxios.mockClear();
+});
+
+describe("protected API auth initialization", () => {
+  it("should fail closed before sending protected requests without auth initialization", async () => {
+    await expect(
+      fetchDevices({ backendUrl: "http://localhost:8080" }),
+    ).rejects.toThrow(
+      new ValueError("Auth provider is not initialized for API requests"),
+    );
+
+    expect(mockedAxios).not.toHaveBeenCalled();
+  });
 });
 
 describe("readAzureStorageDir", () => {

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -1,6 +1,9 @@
 import axios from "axios";
-import { describe, expect, it, vi } from "vitest";
-import { setupAxiosInterceptor } from "../apiInterceptor";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAxiosInterceptors,
+  setupAxiosInterceptor,
+} from "../apiInterceptor";
 
 const runRequest = async (config: Record<string, unknown>) => {
   return axios({
@@ -18,6 +21,10 @@ const runRequest = async (config: Record<string, unknown>) => {
 };
 
 describe("apiInterceptor", () => {
+  afterEach(() => {
+    clearAxiosInterceptors();
+  });
+
   it("attaches a bearer token to protected Nachet API requests", async () => {
     setupAxiosInterceptor(vi.fn().mockResolvedValue("access-token"));
 
@@ -42,5 +49,76 @@ describe("apiInterceptor", () => {
     await expect(runRequest({ nachetAuthRequired: true })).rejects.toThrow(
       "Access token is null or empty",
     );
+  });
+
+  it("does not retry unrelated 401 responses with a bearer token", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("access-token");
+    setupAxiosInterceptor(getAccessToken);
+
+    await expect(
+      axios({
+        method: "get",
+        url: "https://example.test/not-nachet",
+        adapter: async (requestConfig: any) => {
+          return Promise.reject({
+            config: requestConfig,
+            response: {
+              data: null,
+              status: 401,
+              statusText: "Unauthorized",
+              headers: {},
+              config: requestConfig,
+            },
+          });
+        },
+      } as any),
+    ).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("retries marked protected requests once with a replacement token", async () => {
+    const getAccessToken = vi
+      .fn()
+      .mockResolvedValueOnce("initial-token")
+      .mockResolvedValueOnce("retry-token");
+    const authorizationHeaders: string[] = [];
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await axios({
+      method: "get",
+      url: "https://api.example.test/protected",
+      nachetAuthRequired: true,
+      adapter: async (requestConfig: any) => {
+        authorizationHeaders.push(requestConfig.headers.Authorization);
+        if (authorizationHeaders.length === 1) {
+          return Promise.reject({
+            config: requestConfig,
+            response: {
+              data: null,
+              status: 401,
+              statusText: "Unauthorized",
+              headers: {},
+              config: requestConfig,
+            },
+          });
+        }
+
+        return {
+          data: { ok: true },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: requestConfig,
+        };
+      },
+    } as any);
+
+    expect(response.data).toEqual({ ok: true });
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(authorizationHeaders[0]).toBe("Bearer initial-token");
+    expect(authorizationHeaders[1]).toBe("Bearer retry-token");
   });
 });

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { setupAxiosInterceptor } from "../apiInterceptor";
+
+const runRequest = async (config: Record<string, unknown>) => {
+  return axios({
+    method: "get",
+    url: "https://api.example.test/protected",
+    ...config,
+    adapter: async (requestConfig: any) => ({
+      data: null,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: requestConfig,
+    }),
+  } as any);
+};
+
+describe("apiInterceptor", () => {
+  it("attaches a bearer token to protected Nachet API requests", async () => {
+    setupAxiosInterceptor(vi.fn().mockResolvedValue("access-token"));
+
+    const response = await runRequest({ nachetAuthRequired: true });
+
+    expect(response.config.headers.Authorization).toBe("Bearer access-token");
+  });
+
+  it("does not attach a bearer token to requests without the Nachet API marker", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("access-token");
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await runRequest({});
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(response.config.headers.Authorization).toBeUndefined();
+  });
+
+  it("fails closed when a protected request cannot get a token", async () => {
+    setupAxiosInterceptor(vi.fn().mockResolvedValue(""));
+
+    await expect(runRequest({ nachetAuthRequired: true })).rejects.toThrow(
+      "Access token is null or empty",
+    );
+  });
+});

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -1,9 +1,7 @@
 import axios from "axios";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  clearAxiosInterceptors,
-  setupAxiosInterceptor,
-} from "../apiInterceptor";
+import { setupAxiosInterceptor } from "../apiInterceptor";
+import { clearApiAuthentication, fetchDevices, initializeApi } from "../api";
 
 const runRequest = async (config: Record<string, unknown>) => {
   return axios({
@@ -21,8 +19,11 @@ const runRequest = async (config: Record<string, unknown>) => {
 };
 
 describe("apiInterceptor", () => {
+  const originalAdapter = axios.defaults.adapter;
+
   afterEach(() => {
-    clearAxiosInterceptors();
+    clearApiAuthentication();
+    axios.defaults.adapter = originalAdapter;
   });
 
   it("attaches a bearer token to protected Nachet API requests", async () => {
@@ -119,6 +120,70 @@ describe("apiInterceptor", () => {
     expect(response.data).toEqual({ ok: true });
     expect(getAccessToken).toHaveBeenCalledTimes(2);
     expect(authorizationHeaders[0]).toBe("Bearer initial-token");
+    expect(authorizationHeaders[1]).toBe("Bearer retry-token");
+  });
+
+  it("attaches tokens to API helper requests through initializeApi", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("api-helper-token");
+    const authorizationHeaders: string[] = [];
+    axios.defaults.adapter = async (requestConfig: any) => {
+      authorizationHeaders.push(requestConfig.headers.Authorization);
+      return {
+        data: { devices: [] },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: requestConfig,
+      };
+    };
+
+    initializeApi(getAccessToken);
+
+    await expect(
+      fetchDevices({ backendUrl: "https://api.example.test" }),
+    ).resolves.toEqual({ devices: [] });
+    expect(getAccessToken).toHaveBeenCalledOnce();
+    expect(authorizationHeaders).toEqual(["Bearer api-helper-token"]);
+  });
+
+  it("retries stale explicit-token requests with a replacement token", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("retry-token");
+    const authorizationHeaders: string[] = [];
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await axios({
+      method: "get",
+      url: "https://api.example.test/protected",
+      nachetAuthRequired: true,
+      headers: { Authorization: "Bearer stale-token" },
+      adapter: async (requestConfig: any) => {
+        authorizationHeaders.push(requestConfig.headers.Authorization);
+        if (authorizationHeaders.length === 1) {
+          return Promise.reject({
+            config: requestConfig,
+            response: {
+              data: null,
+              status: 401,
+              statusText: "Unauthorized",
+              headers: {},
+              config: requestConfig,
+            },
+          });
+        }
+
+        return {
+          data: { ok: true },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: requestConfig,
+        };
+      },
+    } as any);
+
+    expect(response.data).toEqual({ ok: true });
+    expect(getAccessToken).toHaveBeenCalledOnce();
+    expect(authorizationHeaders[0]).toBe("Bearer stale-token");
     expect(authorizationHeaders[1]).toBe("Bearer retry-token");
   });
 });

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -119,6 +119,8 @@ describe("apiInterceptor", () => {
 
     expect(response.data).toEqual({ ok: true });
     expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(getAccessToken).toHaveBeenNthCalledWith(1);
+    expect(getAccessToken).toHaveBeenNthCalledWith(2, { forceRefresh: true });
     expect(authorizationHeaders[0]).toBe("Bearer initial-token");
     expect(authorizationHeaders[1]).toBe("Bearer retry-token");
   });
@@ -183,6 +185,7 @@ describe("apiInterceptor", () => {
 
     expect(response.data).toEqual({ ok: true });
     expect(getAccessToken).toHaveBeenCalledOnce();
+    expect(getAccessToken).toHaveBeenCalledWith({ forceRefresh: true });
     expect(authorizationHeaders[0]).toBe("Bearer stale-token");
     expect(authorizationHeaders[1]).toBe("Bearer retry-token");
   });

--- a/frontend/src/components/body/auth_popup/AuthPopup.tsx
+++ b/frontend/src/components/body/auth_popup/AuthPopup.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Dialog,
   DialogContent,
@@ -7,35 +6,22 @@ import {
   CircularProgress,
   Typography,
 } from "@mui/material";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { colours } from "../../../styles/colours";
 import { useTranslation } from "react-i18next";
+import { useNachetAuth } from "../../../auth";
 
 interface AuthPopupProps {
   open: boolean;
   onClose: () => void;
-  apiScopeClaim: string;
 }
 
-const AuthPopup: React.FC<AuthPopupProps> = ({
-  open,
-  onClose,
-  apiScopeClaim,
-}) => {
+const AuthPopup = ({ open, onClose }: AuthPopupProps) => {
   const { t } = useTranslation("popups");
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading, login } = useNachetAuth();
 
   const handleSignIn = async (): Promise<void> => {
     try {
-      if (inProgress !== InteractionStatus.None) {
-        console.warn("Interaction already in progress, please wait");
-        return;
-      }
-      await instance.loginRedirect({
-        scopes: [apiScopeClaim ?? ""],
-      });
+      await login();
     } catch (error) {
       console.error("Login failed:", error);
     }
@@ -45,8 +31,6 @@ const AuthPopup: React.FC<AuthPopupProps> = ({
   if (isAuthenticated) {
     return null;
   }
-
-  const isLoading = inProgress !== InteractionStatus.None;
 
   return (
     <Dialog

--- a/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
+++ b/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
@@ -8,9 +8,6 @@ import {
   useZodFieldValidation,
   ERROR_KEY_MAPPINGS,
 } from "@hooks";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
-import { acquireAccessToken } from "@common/auth";
 import { getSeedIdByTaxonomy } from "../../../utils/seedLookup";
 import {
   folderNameSchema,
@@ -29,19 +26,19 @@ import { useModalStore } from "@stores/useModalStore";
 import { BatchUploadPopupView } from "./BatchUploadPopupView";
 import { useTranslation } from "react-i18next";
 import { useNotificationStore } from "@stores/useNotificationStore";
+import { useNachetAuth } from "../../../auth";
 
 interface BatchUploadPopupContainerProps {
   backendUrl: string;
   containerName: string;
   uuid: string;
-  apiScopeClaim: string;
   setReadAzureStorage: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const BatchUploadPopupContainer = (
   props: BatchUploadPopupContainerProps,
 ) => {
-  const { backendUrl, apiScopeClaim, setReadAzureStorage } = props;
+  const { backendUrl, setReadAzureStorage } = props;
   const { closeBatchUploadPopup } = useModalStore();
   const { t } = useTranslation("validation");
   const { t: tErrors } = useTranslation("errors");
@@ -137,10 +134,9 @@ export const BatchUploadPopupContainer = (
     ERROR_KEY_MAPPINGS.description,
   );
 
-  const { speciesData } = useSpeciesData(backendUrl, apiScopeClaim);
-  const { devicesData } = useDeviceData(backendUrl, apiScopeClaim);
-  const { instance: msalInstance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { speciesData } = useSpeciesData(backendUrl);
+  const { devicesData } = useDeviceData(backendUrl);
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   // Folder creation state
   const [createdFolderId, setCreatedFolderId] = useState<string>("");
@@ -183,7 +179,7 @@ export const BatchUploadPopupContainer = (
       return;
     }
 
-    if (inProgress !== InteractionStatus.None || !isAuthenticated) {
+    if (authLoading || !isAuthenticated) {
       console.warn("Authentication in progress or user not authenticated");
       return;
     }
@@ -210,12 +206,8 @@ export const BatchUploadPopupContainer = (
     setFolderDescriptionError("");
 
     try {
-      const accessToken = await acquireAccessToken(msalInstance, [
-        apiScopeClaim,
-      ]);
       const result = await createOrGetFolder({
         backendUrl,
-        accessToken,
         normalizedPath: normalizedFolderName,
         description: descriptionValidationResult.data,
       });
@@ -504,7 +496,7 @@ export const BatchUploadPopupContainer = (
       return;
     }
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(tErrors("auth.inProgress"), 8000);
       return;
     }
@@ -541,29 +533,21 @@ export const BatchUploadPopupContainer = (
     }
 
     // Initialize batch upload session
-    acquireAccessToken(msalInstance, [apiScopeClaim])
-      .then((accessToken) => {
-        return batchUploadInit({
-          backendUrl,
-          accessToken,
-          folderId: createdFolderId,
-          fileCount,
-        }).then((response) => ({
-          accessToken,
-          sessionId: response.sessionId,
-        }));
+    batchUploadInit({
+      backendUrl,
+      folderId: createdFolderId,
+      fileCount,
+    })
+      .then((response) => {
+        return { sessionId: response.sessionId };
       })
       .then(({ sessionId }) => {
         // Create session in Zustand store
         createSession(sessionId, fileCount);
 
-        const scopes = apiScopeClaim ? [apiScopeClaim] : [];
-
         // Configure queue manager
         queueManagerRef.current.configure({
           backendUrl,
-          msalInstance,
-          scopes,
           uploadStore: {
             addUpload,
             updateUploadStatus,

--- a/frontend/src/components/body/directory_popup/DirectoryPopup.tsx
+++ b/frontend/src/components/body/directory_popup/DirectoryPopup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState, type Dispatch, type FC, type SetStateAction } from "react";
 import {
   Box,
   Dialog,
@@ -9,9 +9,6 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import { colours } from "@styles/colours";
 import { useBackendUrl } from "@hooks";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
-import { acquireAccessToken } from "@common/auth";
 import { createOrGetFolder, updateFolder, deleteFolder } from "@common/api";
 import { normalizedPathSchema, descriptionSchema } from "@common/validation";
 import { getZodErrorKey } from "@common/zodErrorMap";
@@ -25,10 +22,10 @@ import { PopupActionButtons } from "@components/common";
 import { useDirectoryModalStore } from "@stores/useDirectoryModalStore";
 import { useFolderStore } from "@stores/useFolderStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
+import { useNachetAuth } from "../../../auth";
 
 interface params {
-  setReadAzureStorage: React.Dispatch<React.SetStateAction<boolean>>;
-  apiScopeClaim: string;
+  setReadAzureStorage: Dispatch<SetStateAction<boolean>>;
   mode: "create" | "edit" | "delete";
   initialData?: {
     folderId: string;
@@ -37,10 +34,10 @@ interface params {
   };
 }
 
-const DirectoryPopup: React.FC<params> = (props) => {
+const DirectoryPopup: FC<params> = (props) => {
   const { t } = useTranslation("popups");
   const { t: tValidation } = useTranslation("validation");
-  const { setReadAzureStorage, apiScopeClaim, mode, initialData } = props;
+  const { setReadAzureStorage, mode, initialData } = props;
   const { closeCreateDirectory, closeEditDirectory, closeDeleteDirectory } =
     useDirectoryModalStore();
   const { setCurDir } = useFolderStore();
@@ -57,8 +54,7 @@ const DirectoryPopup: React.FC<params> = (props) => {
   );
   const [validationError, setValidationError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
-  const { instance: msalInstance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
   const { addError, addWarning } = useNotificationStore();
 
   // Zod validation hook for auto-normalization on blur
@@ -80,7 +76,7 @@ const DirectoryPopup: React.FC<params> = (props) => {
       return;
     }
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       const warningKey =
         mode === "delete"
           ? "deleteDirectory.errors.authInProgress"
@@ -96,13 +92,11 @@ const DirectoryPopup: React.FC<params> = (props) => {
         return;
       }
 
-      acquireAccessToken(msalInstance, [apiScopeClaim])
-        .then(async (accessToken) => {
-          await deleteFolder({
-            backendUrl: backendURL,
-            accessToken,
-            folderId: initialData.folderId,
-          });
+      deleteFolder({
+        backendUrl: backendURL,
+        folderId: initialData.folderId,
+      })
+        .then(() => {
           console.log(`Folder deleted: ${initialData.folderId}`);
           closeDeleteDirectory();
           setCurDir(null);
@@ -157,13 +151,12 @@ const DirectoryPopup: React.FC<params> = (props) => {
 
     const sanitizedDescription = descriptionValidationResult.data;
 
-    acquireAccessToken(msalInstance, [apiScopeClaim])
-      .then(async (accessToken) => {
+    Promise.resolve()
+      .then(async () => {
         if (mode === "create") {
           // Create directory at root level using new API
           const result = await createOrGetFolder({
             backendUrl: backendURL,
-            accessToken,
             normalizedPath,
             description: sanitizedDescription,
           });
@@ -175,7 +168,6 @@ const DirectoryPopup: React.FC<params> = (props) => {
           }
           const result = await updateFolder({
             backendUrl: backendURL,
-            accessToken,
             folderId: initialData.folderId,
             name: normalizedPath,
             description: sanitizedDescription,

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -13,15 +13,13 @@ import {
 } from "@common/types";
 import { sendNegativeFeedback, sendPositiveFeedback } from "@common";
 import { useSpeciesData } from "@hooks";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
-import { acquireAccessToken } from "@common/auth";
 import { getUnscaledCoordinates } from "@common/imageutils";
 import { useImageStore } from "@stores/useImageStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
 import { useInferenceResultsStore } from "@stores/useInferenceResultsStore";
 import { MicroscopeFeedControlsView } from "./MicroscopeFeedControlsView";
 import { MicroscopeFeedWorkspaceView } from "./MicroscopeFeedWorkspaceView";
+import { useNachetAuth } from "../../../auth";
 
 interface MicroscopeFeedProps {
   webcamRef: React.RefObject<Webcam | null>;
@@ -40,7 +38,6 @@ interface MicroscopeFeedProps {
   toggleShowInference: (state: boolean) => void;
   backendUrl: string;
   uuid: string;
-  apiScopeClaim: string;
 }
 
 const MicroscopeFeed = (props: MicroscopeFeedProps) => {
@@ -58,7 +55,6 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     toggleShowInference,
     backendUrl,
     uuid,
-    apiScopeClaim,
   } = props;
 
   const { t } = useTranslation("main");
@@ -94,12 +90,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
   const [apiResultDismissed, setApiResultDismissed] = useState<boolean>(true);
   const [boxDragEnabled, setBoxDragEnabled] = useState<boolean>(true);
 
-  const { instance: msalInstance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const { speciesData, isLoading: classListLoading } = useSpeciesData(
-    backendUrl,
-    apiScopeClaim,
-  );
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
+  const { speciesData, isLoading: classListLoading } =
+    useSpeciesData(backendUrl);
 
   const classList: SpeciesData[] = useMemo(() => {
     if (!speciesData?.seeds) return [];
@@ -165,7 +158,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     }
     console.log("Submitting positive feedback for key: ", index);
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(t("microscopeFeed.errors.authInProgress"), 8000);
       return;
     }
@@ -180,13 +173,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     setApiResultDismissed(false);
 
     try {
-      const accessToken = await acquireAccessToken(msalInstance, [
-        apiScopeClaim,
-      ]);
       await sendPositiveFeedback({
         feedbackData: feedbackDataPositive,
         backendUrl,
-        accessToken,
       });
       console.log("Positive Feedback submitted successfully");
       // TODO: Update active inference result with feedback response
@@ -212,7 +201,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
       return;
     }
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       setApiError(t("microscopeFeed.errors.authInProgress"));
       setApiResultDismissed(false);
       return;
@@ -226,13 +215,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     setApiResultDismissed(false);
 
     try {
-      const accessToken = await acquireAccessToken(msalInstance, [
-        apiScopeClaim,
-      ]);
       await sendNegativeFeedback({
         feedbackData: feedbackDataNegative,
         backendUrl,
-        accessToken,
       });
       console.log("Negative Feedback submitted successfully");
       // TODO: Update active inference result with feedback response

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
@@ -129,18 +129,8 @@ export const MicroscopeFeedControlsView = (
     padding: 0,
   };
 
-  // Derive isGuest from accountInfo
-  // acct === 0 means member account, acct !== 0 or undefined means guest account
-  // Defensive: treat missing/undefined acct as guest (hide D button)
   const isGuest = useMemo(() => {
-    const idTokenClaims = activeAccount?.idTokenClaims as
-      | { acct?: number }
-      | undefined;
-    const acctClaim = idTokenClaims?.acct;
-
-    // Only acct === 0 means member (show D button)
-    // Everything else (undefined, null, non-zero) means guest (hide D button)
-    return acctClaim !== 0;
+    return activeAccount?.isGuest ?? true;
   }, [activeAccount]);
 
   // Find the model name from metadata based on selectedModel (pipelineId)

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
@@ -14,13 +14,13 @@ import InfoIcon from "@mui/icons-material/Info";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import { colours } from "@styles/colours";
-import { useAccount } from "@azure/msal-react";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { useImageStore } from "@stores/useImageStore";
 import { useModalStore } from "@stores/useModalStore";
 import { useWebcamStore } from "@stores/useWebcamStore";
 import { useModelStore } from "@stores/useModelStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
+import { useNachetAuth } from "../../../auth";
 
 export interface MicroscopeFeedControlsViewProps {
   isWebcamActive: boolean;
@@ -94,7 +94,7 @@ export const MicroscopeFeedControlsView = (
   const { getMissingMetadataCount } = useDeviceStore();
   const { images: imageCache } = useImageStore();
   const { selectedModel, metadata } = useModelStore();
-  const accountInfo = useAccount();
+  const { activeAccount } = useNachetAuth();
 
   // Modal store actions
   const {
@@ -133,7 +133,7 @@ export const MicroscopeFeedControlsView = (
   // acct === 0 means member account, acct !== 0 or undefined means guest account
   // Defensive: treat missing/undefined acct as guest (hide D button)
   const isGuest = useMemo(() => {
-    const idTokenClaims = accountInfo?.idTokenClaims as
+    const idTokenClaims = activeAccount?.idTokenClaims as
       | { acct?: number }
       | undefined;
     const acctClaim = idTokenClaims?.acct;
@@ -141,7 +141,7 @@ export const MicroscopeFeedControlsView = (
     // Only acct === 0 means member (show D button)
     // Everything else (undefined, null, non-zero) means guest (hide D button)
     return acctClaim !== 0;
-  }, [accountInfo]);
+  }, [activeAccount]);
 
   // Find the model name from metadata based on selectedModel (pipelineId)
   const selectedModelName = useMemo(() => {

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useAccount } from "@azure/msal-react";
 import { environment } from "../../environments/environment";
 import { Box, Link } from "@mui/material";
 import CanadaLogo from "../../assets/Canada_logo.png";
@@ -7,9 +6,10 @@ import useBackendUrl from "@hooks/useBackendUrl";
 import { pingBackend } from "@common/api";
 import { colours } from "../../styles/colours";
 import { useTranslation } from "react-i18next";
+import { useNachetAuth } from "../../auth";
 
 const Footer: React.FC = () => {
-  const accountInfo = useAccount();
+  const { activeAccount } = useNachetAuth();
   const backendUrl = useBackendUrl();
   const { t } = useTranslation("footer");
   const [backendConnected, setBackendConnected] = useState<boolean | null>(
@@ -19,12 +19,16 @@ const Footer: React.FC = () => {
   // Derive isGuest from accountInfo
   // acct === 0 means member account, acct !== 0 means guest account
   const isGuest = (() => {
-    const idTokenClaims = accountInfo?.idTokenClaims as
+    const idTokenClaims = activeAccount?.idTokenClaims as
       | { acct?: number }
       | undefined;
     const acctClaim = idTokenClaims?.acct;
     return acctClaim !== 0;
   })();
+  const userOid =
+    typeof activeAccount?.idTokenClaims?.oid === "string"
+      ? activeAccount.idTokenClaims.oid
+      : "";
 
   // Check backend connectivity for guest users
   useEffect(() => {
@@ -138,7 +142,7 @@ const Footer: React.FC = () => {
             zIndex: 0,
           }}
         >
-          {t("oid", { oid: accountInfo?.idTokenClaims?.oid || "" })}
+          {t("oid", { oid: userOid })}
         </Box>
         <Box
           component="img"

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -16,19 +16,8 @@ const Footer: React.FC = () => {
     null,
   );
 
-  // Derive isGuest from accountInfo
-  // acct === 0 means member account, acct !== 0 means guest account
-  const isGuest = (() => {
-    const idTokenClaims = activeAccount?.idTokenClaims as
-      | { acct?: number }
-      | undefined;
-    const acctClaim = idTokenClaims?.acct;
-    return acctClaim !== 0;
-  })();
-  const userOid =
-    typeof activeAccount?.idTokenClaims?.oid === "string"
-      ? activeAccount.idTokenClaims.oid
-      : "";
+  const isGuest = activeAccount?.isGuest ?? true;
+  const userOid = activeAccount?.userId ?? "";
 
   // Check backend connectivity for guest users
   useEffect(() => {

--- a/frontend/src/components/header/navbar/Navbar.tsx
+++ b/frontend/src/components/header/navbar/Navbar.tsx
@@ -1,43 +1,24 @@
-import React from "react";
 import CFIALogo from "../../../assets/CFIA_blackfont.png";
 import { Button, IconButton, Box } from "@mui/material";
 import { colours } from "../../../styles/colours";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useTranslation } from "react-i18next";
+import { useNachetAuth } from "../../../auth";
 
-interface params {
-  windowSize: {
-    width: number;
-    height: number;
-  };
-  apiScopeClaim: string;
-}
-
-const Navbar: React.FC<params> = (props) => {
-  const { instance, inProgress, accounts } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const { apiScopeClaim } = props;
+const Navbar = () => {
+  const { accounts, isAuthenticated, login, logout } = useNachetAuth();
   const { t } = useTranslation("header");
-  const logout = async (): Promise<void> => {
+  const handleLogout = async (): Promise<void> => {
     try {
-      await instance.logoutRedirect();
+      await logout();
     } catch (error) {
       console.error("Logout failed:", error);
       throw error;
     }
   };
-  const login = async (): Promise<void> => {
+  const handleLogin = async (): Promise<void> => {
     try {
-      if (inProgress !== InteractionStatus.None) {
-        console.warn("Interaction already in progress, please wait");
-        return;
-      }
-      await instance.loginRedirect({
-        // scopes: ["openid", "profile", "email"],
-        scopes: [apiScopeClaim ?? ""],
-      });
+      await login();
     } catch (error) {
       console.error("Login failed:", error);
       throw error;
@@ -115,7 +96,7 @@ const Navbar: React.FC<params> = (props) => {
               variant="outlined"
               onClick={async () => {
                 try {
-                  await login();
+                  await handleLogin();
                 } catch (error) {
                   console.error("Login failed:", error);
                 }
@@ -131,7 +112,7 @@ const Navbar: React.FC<params> = (props) => {
                 sx={{ padding: 0, marginTop: "0.27vh", marginRight: "0.4vh" }}
                 onClick={async () => {
                   try {
-                    await logout();
+                    await handleLogout();
                   } catch (error) {
                     console.error("Logout failed:", error);
                   }

--- a/frontend/src/hooks/tests/useDeviceData.test.tsx
+++ b/frontend/src/hooks/tests/useDeviceData.test.tsx
@@ -3,21 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useDeviceData } from "../useDeviceData";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { fetchDevices } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
+import { useNachetAuth } from "../../auth";
 
 // Mock dependencies
 vi.mock("@stores/useDeviceStore");
 vi.mock("@common/api");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
+vi.mock("../../auth");
 
 describe("useDeviceData", () => {
   let mockSetDevicesData: any;
   let mockSetLoading: any;
   let mockSetError: any;
-  let mockMsalInstance: any;
   const mockDevicesData = {
     devices: [
       { id: "device-1", name: "Device 1" },
@@ -31,7 +27,6 @@ describe("useDeviceData", () => {
     mockSetDevicesData = vi.fn();
     mockSetLoading = vi.fn();
     mockSetError = vi.fn();
-    mockMsalInstance = {} as any;
 
     // Mock the store
     (useDeviceStore as any).mockReturnValue({
@@ -43,17 +38,10 @@ describe("useDeviceData", () => {
       setError: mockSetError,
     });
 
-    // Mock useMsal
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.None,
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
-
-    // Mock useIsAuthenticated
-    (useIsAuthenticated as any).mockReturnValue(true);
-
-    // Mock auth
-    (acquireAccessToken as any).mockResolvedValue("test-token");
 
     // Mock fetchDevices
     (fetchDevices as any).mockResolvedValue(mockDevicesData);
@@ -63,22 +51,15 @@ describe("useDeviceData", () => {
   });
 
   it("should fetch and set device data when authenticated", async () => {
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetLoading).toHaveBeenCalledWith(true);
     });
 
     await waitFor(() => {
-      expect(acquireAccessToken).toHaveBeenCalledWith(mockMsalInstance, [
-        "test-scope",
-      ]);
-    });
-
-    await waitFor(() => {
       expect(fetchDevices).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -92,15 +73,18 @@ describe("useDeviceData", () => {
   });
 
   it("should not fetch when backendUrl is empty", () => {
-    renderHook(() => useDeviceData("", "test-scope"));
+    renderHook(() => useDeviceData(""));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
 
   it("should not fetch when not authenticated", () => {
-    (useIsAuthenticated as any).mockReturnValue(false);
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
@@ -115,18 +99,18 @@ describe("useDeviceData", () => {
       setError: mockSetError,
     });
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.Login,
+  it("should not fetch while auth is loading", () => {
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
     });
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
@@ -135,7 +119,7 @@ describe("useDeviceData", () => {
     const mockError = new Error("Failed to fetch devices");
     (fetchDevices as any).mockRejectedValue(mockError);
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Failed to fetch devices");
@@ -156,7 +140,7 @@ describe("useDeviceData", () => {
   it("should handle non-Error rejection", async () => {
     (fetchDevices as any).mockRejectedValue("String error");
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Unknown error occurred");
@@ -178,7 +162,7 @@ describe("useDeviceData", () => {
     });
 
     const { result } = renderHook(() =>
-      useDeviceData("http://test-backend.com", "test-scope"),
+      useDeviceData("http://test-backend.com"),
     );
 
     expect(result.current.devicesData).toEqual(mockDevicesData);

--- a/frontend/src/hooks/tests/useFolderData.test.tsx
+++ b/frontend/src/hooks/tests/useFolderData.test.tsx
@@ -3,21 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useFolderData } from "../useFolderData";
 import { useFolderStore, FolderData } from "@stores/useFolderStore";
 import { readAzureStorageDir } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
+import { useNachetAuth } from "../../auth";
 
 // Mock dependencies
 vi.mock("@stores/useFolderStore");
 vi.mock("@common/api");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
+vi.mock("../../auth");
 
 describe("useFolderData", () => {
   let mockSetFolderData: any;
   let mockSetLoading: any;
   let mockSetError: any;
-  let mockMsalInstance: any;
   const mockApiResponse = {
     directories: [
       {
@@ -60,7 +56,6 @@ describe("useFolderData", () => {
     mockSetFolderData = vi.fn();
     mockSetLoading = vi.fn();
     mockSetError = vi.fn();
-    mockMsalInstance = {} as any;
 
     (useFolderStore as any).mockReturnValue({
       folderData: null,
@@ -71,20 +66,17 @@ describe("useFolderData", () => {
       setError: mockSetError,
     });
 
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.None,
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
-
-    (useIsAuthenticated as any).mockReturnValue(true);
-    (acquireAccessToken as any).mockResolvedValue("test-token");
     (readAzureStorageDir as any).mockResolvedValue(mockApiResponse);
 
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   it("should fetch and transform folder data when authenticated", async () => {
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetLoading).toHaveBeenCalledWith(true);
@@ -94,7 +86,6 @@ describe("useFolderData", () => {
     await waitFor(() => {
       expect(readAzureStorageDir).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -122,7 +113,7 @@ describe("useFolderData", () => {
       apiResponseWithoutDescription,
     );
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetFolderData).toHaveBeenCalledWith({
@@ -140,13 +131,16 @@ describe("useFolderData", () => {
   });
 
   it("should not fetch when backendUrl is empty", () => {
-    renderHook(() => useFolderData("", "test-scope"));
+    renderHook(() => useFolderData(""));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
   it("should not fetch when not authenticated", () => {
-    (useIsAuthenticated as any).mockReturnValue(false);
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    renderHook(() => useFolderData("http://test-backend.com"));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
@@ -160,17 +154,17 @@ describe("useFolderData", () => {
       setError: mockSetError,
     });
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.Login,
+  it("should not fetch while auth is loading", () => {
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
     });
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
@@ -178,7 +172,7 @@ describe("useFolderData", () => {
     const mockError = new Error("Failed to fetch folders");
     (readAzureStorageDir as any).mockRejectedValue(mockError);
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Failed to fetch folders");
@@ -190,7 +184,7 @@ describe("useFolderData", () => {
   it("should handle non-Error rejection", async () => {
     (readAzureStorageDir as any).mockRejectedValue("String error");
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Unknown error occurred");
@@ -211,7 +205,7 @@ describe("useFolderData", () => {
     });
 
     const { result } = renderHook(() =>
-      useFolderData("http://test-backend.com", "test-scope"),
+      useFolderData("http://test-backend.com"),
     );
 
     expect(result.current.folderData).toEqual(mockFolderData);

--- a/frontend/src/hooks/tests/useModelMetadata.test.tsx
+++ b/frontend/src/hooks/tests/useModelMetadata.test.tsx
@@ -3,21 +3,15 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useModelMetadata } from "../useModelMetadata";
 import { useModelStore } from "@stores/useModelStore";
 import { fetchModelMetadata } from "@common";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 
 // Mock dependencies
 vi.mock("@stores/useModelStore");
 vi.mock("@common");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
 
 describe("useModelMetadata", () => {
   let mockSetMetadata: any;
   let mockSetSelectedModel: any;
   let mockSetLoading: any;
-  let mockMsalInstance: any;
   const mockMetadata = [
     { pipelineId: "pipeline-1", name: "Model 1", default: false },
     { pipelineId: "pipeline-2", name: "Model 2", default: true },
@@ -30,7 +24,6 @@ describe("useModelMetadata", () => {
     mockSetMetadata = vi.fn();
     mockSetSelectedModel = vi.fn();
     mockSetLoading = vi.fn();
-    mockMsalInstance = {} as any;
 
     // Mock the store
     (useModelStore as any).mockReturnValue({
@@ -40,14 +33,6 @@ describe("useModelMetadata", () => {
       setSelectedModel: mockSetSelectedModel,
       setLoading: mockSetLoading,
     });
-
-    // Mock useMsal
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-    });
-
-    // Mock auth
-    (acquireAccessToken as any).mockResolvedValue("test-token");
 
     // Mock fetchModelMetadata
     (fetchModelMetadata as any).mockResolvedValue(mockMetadata);
@@ -61,9 +46,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -72,15 +56,8 @@ describe("useModelMetadata", () => {
     });
 
     await waitFor(() => {
-      expect(acquireAccessToken).toHaveBeenCalledWith(mockMsalInstance, [
-        "test-scope",
-      ]);
-    });
-
-    await waitFor(() => {
       expect(fetchModelMetadata).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -101,22 +78,20 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: false,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
     expect(fetchModelMetadata).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
+  it("should not fetch while auth is loading", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.Login,
+        authLoading: true,
       }),
     );
 
@@ -134,9 +109,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -155,9 +129,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -185,9 +158,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -215,9 +187,8 @@ describe("useModelMetadata", () => {
     const { result } = renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -230,9 +201,8 @@ describe("useModelMetadata", () => {
       ({ backendUrl }) =>
         useModelMetadata({
           backendUrl,
-          apiScopeClaim: "test-scope",
           isAuthenticated: true,
-          inProgress: InteractionStatus.None,
+          authLoading: false,
         }),
       {
         initialProps: { backendUrl: "http://test-backend-1.com" },

--- a/frontend/src/hooks/tests/useSpeciesData.test.tsx
+++ b/frontend/src/hooks/tests/useSpeciesData.test.tsx
@@ -3,21 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useSpeciesData } from "../useSpeciesData";
 import { useSpeciesStore } from "@stores/useSpeciesStore";
 import { requestClassList } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
+import { useNachetAuth } from "../../auth";
 
 // Mock dependencies
 vi.mock("@stores/useSpeciesStore");
 vi.mock("@common/api");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
+vi.mock("../../auth");
 
 describe("useSpeciesData", () => {
   let mockSetSpeciesData: any;
   let mockSetLoading: any;
   let mockSetError: any;
-  let mockMsalInstance: any;
   const mockSpeciesData = [
     { id: 1, name: "Species 1" },
     { id: 2, name: "Species 2" },
@@ -29,7 +25,6 @@ describe("useSpeciesData", () => {
     mockSetSpeciesData = vi.fn();
     mockSetLoading = vi.fn();
     mockSetError = vi.fn();
-    mockMsalInstance = {} as any;
 
     (useSpeciesStore as any).mockReturnValue({
       speciesData: null,
@@ -40,20 +35,17 @@ describe("useSpeciesData", () => {
       setError: mockSetError,
     });
 
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.None,
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
-
-    (useIsAuthenticated as any).mockReturnValue(true);
-    (acquireAccessToken as any).mockResolvedValue("test-token");
     (requestClassList as any).mockResolvedValue(mockSpeciesData);
 
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   it("should fetch and set species data when authenticated", async () => {
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetLoading).toHaveBeenCalledWith(true);
@@ -63,7 +55,6 @@ describe("useSpeciesData", () => {
     await waitFor(() => {
       expect(requestClassList).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -74,13 +65,16 @@ describe("useSpeciesData", () => {
   });
 
   it("should not fetch when backendUrl is empty", () => {
-    renderHook(() => useSpeciesData("", "test-scope"));
+    renderHook(() => useSpeciesData(""));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
   it("should not fetch when not authenticated", () => {
-    (useIsAuthenticated as any).mockReturnValue(false);
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    renderHook(() => useSpeciesData("http://test-backend.com"));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
@@ -94,17 +88,17 @@ describe("useSpeciesData", () => {
       setError: mockSetError,
     });
 
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.Login,
+  it("should not fetch while auth is loading", () => {
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
     });
 
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
@@ -112,7 +106,7 @@ describe("useSpeciesData", () => {
     const mockError = new Error("Failed to fetch species");
     (requestClassList as any).mockRejectedValue(mockError);
 
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Failed to fetch species");
@@ -132,7 +126,7 @@ describe("useSpeciesData", () => {
     });
 
     const { result } = renderHook(() =>
-      useSpeciesData("http://test-backend.com", "test-scope"),
+      useSpeciesData("http://test-backend.com"),
     );
 
     expect(result.current.speciesData).toEqual(mockSpeciesData);

--- a/frontend/src/hooks/tests/useWorkflowPolling.test.ts
+++ b/frontend/src/hooks/tests/useWorkflowPolling.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import { useWorkflowPolling } from "../useWorkflowPolling";
 import { useWorkflowStore } from "@stores/useWorkflowStore";
 import * as commonApi from "@common/index";
+import { useNachetAuth } from "../../auth";
 import { errorLogger } from "../../logging";
 import type { ApiInferenceData, WorkflowStatusResponse } from "@common/types";
 
@@ -18,10 +19,11 @@ vi.mock("../../logging", () => ({
   },
 }));
 
+vi.mock("../../auth");
+
 describe("useWorkflowPolling", () => {
   const mockWorkflowId = "workflow-123";
   const mockBackendUrl = "http://localhost:8080";
-  const mockAccessToken = "mock-token";
   const mockOnComplete = vi.fn();
   const mockOnError = vi.fn();
 
@@ -97,6 +99,11 @@ describe("useWorkflowPolling", () => {
     useWorkflowStore.setState({
       workflows: new Map(),
     });
+
+    vi.mocked(useNachetAuth).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    } as ReturnType<typeof useNachetAuth>);
   });
 
   afterEach(() => {
@@ -110,7 +117,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: false,
           onComplete: mockOnComplete,
         }),
@@ -127,7 +133,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: "",
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -143,7 +148,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: "",
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -154,12 +158,16 @@ describe("useWorkflowPolling", () => {
       expect(commonApi.getWorkflowStatus).not.toHaveBeenCalled();
     });
 
-    it("should not start polling when accessToken is empty", () => {
+    it("should not start polling when the user is not authenticated", () => {
+      vi.mocked(useNachetAuth).mockReturnValue({
+        isAuthenticated: false,
+        isLoading: false,
+      } as ReturnType<typeof useNachetAuth>);
+
       renderHook(() =>
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: "",
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -181,7 +189,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -205,7 +212,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -244,7 +250,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -282,7 +287,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -293,13 +297,11 @@ describe("useWorkflowPolling", () => {
       expect(commonApi.getWorkflowStatus).toHaveBeenCalledWith({
         backendUrl: mockBackendUrl,
         workflowId: mockWorkflowId,
-        accessToken: mockAccessToken,
       });
 
       expect(commonApi.getWorkflowResults).toHaveBeenCalledWith({
         backendUrl: mockBackendUrl,
         workflowId: mockWorkflowId,
-        accessToken: mockAccessToken,
       });
 
       expect(mockOnComplete).toHaveBeenCalledWith(mockInferenceResults);
@@ -328,7 +330,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -355,7 +356,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -391,7 +391,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -426,7 +425,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -461,7 +459,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -496,7 +493,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -531,7 +527,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -566,7 +561,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -591,7 +585,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -616,7 +609,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -652,7 +644,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -676,7 +667,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -700,7 +690,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -739,7 +728,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -767,7 +755,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -787,7 +774,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           // No onError provided
@@ -813,7 +799,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -836,7 +821,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -857,7 +841,6 @@ describe("useWorkflowPolling", () => {
           useWorkflowPolling({
             workflowId: mockWorkflowId,
             backendUrl: mockBackendUrl,
-            accessToken: mockAccessToken,
             enabled,
             onComplete: mockOnComplete,
           }),
@@ -894,7 +877,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -921,7 +903,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: false,
           onComplete: mockOnComplete,
         }),
@@ -939,7 +920,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),

--- a/frontend/src/hooks/useDeviceData.ts
+++ b/frontend/src/hooks/useDeviceData.ts
@@ -1,11 +1,9 @@
 import { useEffect } from "react";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { fetchDevices } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../auth";
 
-export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
+export const useDeviceData = (backendUrl: string) => {
   const {
     devicesData,
     isLoading,
@@ -14,8 +12,7 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
     setLoading,
     setError,
   } = useDeviceStore();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   useEffect(() => {
     const fetchDeviceData = async () => {
@@ -31,7 +28,7 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
         return; // Already have data, don't fetch again
       }
 
-      if (inProgress !== InteractionStatus.None) {
+      if (authLoading) {
         return; // Wait for interaction to complete
       }
 
@@ -39,8 +36,7 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
       setError(null);
 
       try {
-        const accessToken = await acquireAccessToken(instance, [apiScopeClaim]);
-        const response = await fetchDevices({ backendUrl, accessToken });
+        const response = await fetchDevices({ backendUrl });
         setDevicesData(response);
       } catch (err) {
         const errorMessage =
@@ -54,10 +50,8 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
 
     fetchDeviceData();
   }, [
-    apiScopeClaim,
+    authLoading,
     backendUrl,
-    instance,
-    inProgress,
     isAuthenticated,
     setError,
     setLoading,

--- a/frontend/src/hooks/useFolderData.ts
+++ b/frontend/src/hooks/useFolderData.ts
@@ -6,17 +6,14 @@
  */
 
 import { useEffect } from "react";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useFolderStore, FolderData } from "@stores/useFolderStore";
 import { readAzureStorageDir } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../auth";
 
-export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
+export const useFolderData = (backendUrl: string) => {
   const { folderData, isLoading, error, setFolderData, setLoading, setError } =
     useFolderStore();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   useEffect(() => {
     const fetchFolderData = async () => {
@@ -32,7 +29,7 @@ export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
         return; // Already have data, don't fetch again
       }
 
-      if (inProgress !== InteractionStatus.None) {
+      if (authLoading) {
         return; // Wait for interaction to complete
       }
 
@@ -40,8 +37,7 @@ export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
       setError(null);
 
       try {
-        const accessToken = await acquireAccessToken(instance, [apiScopeClaim]);
-        const response = await readAzureStorageDir({ backendUrl, accessToken });
+        const response = await readAzureStorageDir({ backendUrl });
 
         // Transform API response to match store format
         const directories: FolderData[] = response.directories.map((item) => ({
@@ -66,10 +62,8 @@ export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
 
     fetchFolderData();
   }, [
-    apiScopeClaim,
+    authLoading,
     backendUrl,
-    instance,
-    inProgress,
     isAuthenticated,
     setError,
     setLoading,

--- a/frontend/src/hooks/useModelMetadata.ts
+++ b/frontend/src/hooks/useModelMetadata.ts
@@ -8,41 +8,31 @@
 import { useEffect } from "react";
 import { useModelStore } from "@stores/useModelStore";
 import { fetchModelMetadata } from "@common";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 
 interface UseModelMetadataParams {
   backendUrl: string;
-  apiScopeClaim: string;
   isAuthenticated: boolean;
-  inProgress: InteractionStatus;
+  authLoading: boolean;
 }
 
 export const useModelMetadata = ({
   backendUrl,
-  apiScopeClaim,
   isAuthenticated,
-  inProgress,
+  authLoading,
 }: UseModelMetadataParams) => {
-  const { instance: msalInstance } = useMsal();
   const { metadata, selectedModel, setMetadata, setSelectedModel, setLoading } =
     useModelStore();
 
   useEffect(() => {
     // Only load metadata if user is authenticated and no interaction is in progress
-    if (!isAuthenticated || inProgress !== InteractionStatus.None) {
+    if (!isAuthenticated || authLoading) {
       return;
     }
 
     const loadModelMetadata = async () => {
       try {
         setLoading(true);
-        const accessToken = await acquireAccessToken(msalInstance, [
-          apiScopeClaim,
-        ]);
-
-        const metadata = await fetchModelMetadata({ backendUrl, accessToken });
+        const metadata = await fetchModelMetadata({ backendUrl });
         setMetadata(metadata);
 
         // Find the default model from the metadata
@@ -63,11 +53,9 @@ export const useModelMetadata = ({
 
     void loadModelMetadata();
   }, [
+    authLoading,
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
     isAuthenticated,
-    inProgress,
     setMetadata,
     setSelectedModel,
     setLoading,

--- a/frontend/src/hooks/useSpeciesData.ts
+++ b/frontend/src/hooks/useSpeciesData.ts
@@ -1,11 +1,9 @@
 import { useEffect } from "react";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useSpeciesStore } from "@stores/useSpeciesStore";
 import { requestClassList } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../auth";
 
-export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
+export const useSpeciesData = (backendUrl: string) => {
   const {
     speciesData,
     isLoading,
@@ -14,8 +12,7 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
     setLoading,
     setError,
   } = useSpeciesStore();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   useEffect(() => {
     const fetchSpeciesData = async () => {
@@ -31,7 +28,7 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
         return; // Already have data, don't fetch again
       }
 
-      if (inProgress !== InteractionStatus.None) {
+      if (authLoading) {
         return; // Wait for interaction to complete
       }
 
@@ -39,8 +36,7 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
       setError(null);
 
       try {
-        const accessToken = await acquireAccessToken(instance, [apiScopeClaim]);
-        const response = await requestClassList({ backendUrl, accessToken });
+        const response = await requestClassList({ backendUrl });
         setSpeciesData(response);
       } catch (err) {
         const errorMessage =
@@ -54,10 +50,8 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
 
     fetchSpeciesData();
   }, [
-    apiScopeClaim,
+    authLoading,
     backendUrl,
-    instance,
-    inProgress,
     isAuthenticated,
     setError,
     setLoading,

--- a/frontend/src/hooks/useWorkflowPolling.ts
+++ b/frontend/src/hooks/useWorkflowPolling.ts
@@ -3,6 +3,7 @@ import { getWorkflowStatus, getWorkflowResults } from "@common/index";
 import { useWorkflowStore } from "@stores/useWorkflowStore";
 import { ApiInferenceData, WorkflowStatus } from "@common/types";
 import { errorLogger } from "../logging";
+import { useNachetAuth } from "../auth";
 
 const POLLING_INTERVAL_MS = 10000; // 10 seconds
 const INITIAL_DELAY_MS = 20000; // 20 seconds - wait before first poll
@@ -18,7 +19,6 @@ const isTerminalState = (status: string): status is TerminalState => {
 interface UseWorkflowPollingParams {
   workflowId: string;
   backendUrl: string;
-  accessToken: string;
   enabled: boolean;
   onComplete: (results: ApiInferenceData) => void;
   onError?: (error: Error) => void;
@@ -28,7 +28,6 @@ interface UseWorkflowPollingParams {
  * Custom hook for polling workflow status and fetching results when complete
  * @param workflowId - The workflow ID to poll
  * @param backendUrl - Backend API URL
- * @param accessToken - Authentication token
  * @param enabled - Whether polling is enabled
  * @param onComplete - Callback when workflow completes successfully
  * @param onError - Optional callback when workflow fails
@@ -36,11 +35,11 @@ interface UseWorkflowPollingParams {
 export const useWorkflowPolling = ({
   workflowId,
   backendUrl,
-  accessToken,
   enabled,
   onComplete,
   onError,
 }: UseWorkflowPollingParams) => {
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
   const updateWorkflowStatus = useWorkflowStore(
     (state) => state.updateWorkflowStatus,
   );
@@ -74,7 +73,6 @@ export const useWorkflowPolling = ({
       const statusResponse = await getWorkflowStatus({
         backendUrl,
         workflowId,
-        accessToken,
       });
 
       console.log(
@@ -114,7 +112,6 @@ export const useWorkflowPolling = ({
           const results = await getWorkflowResults({
             backendUrl,
             workflowId,
-            accessToken,
           });
 
           console.log(
@@ -185,7 +182,6 @@ export const useWorkflowPolling = ({
   }, [
     workflowId,
     backendUrl,
-    accessToken,
     updateWorkflowStatus,
     removeWorkflow,
     onComplete,
@@ -194,7 +190,13 @@ export const useWorkflowPolling = ({
   ]);
 
   useEffect(() => {
-    if (!enabled || !workflowId || !backendUrl || !accessToken) {
+    if (
+      !enabled ||
+      !workflowId ||
+      !backendUrl ||
+      !isAuthenticated ||
+      authLoading
+    ) {
       return;
     }
 
@@ -217,7 +219,14 @@ export const useWorkflowPolling = ({
         pollingIntervalRef.current = null;
       }
     };
-  }, [enabled, workflowId, backendUrl, accessToken, pollWorkflowStatus]);
+  }, [
+    enabled,
+    workflowId,
+    backendUrl,
+    isAuthenticated,
+    authLoading,
+    pollWorkflowStatus,
+  ]);
 
   return {
     isPolling: enabled && pollingIntervalRef.current !== null,

--- a/frontend/src/logging/ErrorLogger.ts
+++ b/frontend/src/logging/ErrorLogger.ts
@@ -78,11 +78,20 @@ class ErrorLogger {
             headers["Authorization"] = `Bearer ${token}`;
           }
         } catch (tokenError) {
-          // Log token acquisition failure but continue without auth
+          // Backend logging is protected when the auth bridge is active.
+          // Keep console fallback rather than posting an unauthenticated log.
           console.warn(
-            "Failed to acquire token for logs endpoint:",
+            "Skipping backend log submission because log auth failed:",
             tokenError,
           );
+          return;
+        }
+
+        if (!headers.Authorization) {
+          console.warn(
+            "Skipping backend log submission because no auth token is available.",
+          );
+          return;
         }
       }
 

--- a/frontend/src/logging/tests/ErrorLogger.test.ts
+++ b/frontend/src/logging/tests/ErrorLogger.test.ts
@@ -186,45 +186,32 @@ describe("ErrorLogger (Singleton)", () => {
       );
     });
 
-    it("should continue without auth if token provider fails", async () => {
+    it("should skip backend logging if token provider fails", async () => {
       const tokenProvider = vi.fn().mockRejectedValue(new Error("Token error"));
       errorLogger.setTokenProvider(tokenProvider);
 
       await errorLogger.logError("Test");
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "Failed to acquire token for logs endpoint:",
+        "Skipping backend log submission because log auth failed:",
         expect.any(Error),
       );
-      expect(axios.post).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.not.objectContaining({
-            Authorization: expect.anything(),
-          }),
-        }),
-      );
+      expect(axios.post).not.toHaveBeenCalled();
 
       // Reset token provider
       errorLogger.setTokenProvider(null as any);
     });
 
-    it("should continue without auth if token provider returns null", async () => {
+    it("should skip backend logging if token provider returns null", async () => {
       const tokenProvider = vi.fn().mockResolvedValue(null);
       errorLogger.setTokenProvider(tokenProvider);
 
       await errorLogger.logError("Test");
 
-      expect(axios.post).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.not.objectContaining({
-            Authorization: expect.anything(),
-          }),
-        }),
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Skipping backend log submission because no auth token is available.",
       );
+      expect(axios.post).not.toHaveBeenCalled();
 
       // Reset token provider
       errorLogger.setTokenProvider(null as any);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,14 +11,9 @@ import { CacheProvider } from "@emotion/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { createEmotionCache } from "./common/emotionCache";
 import { ErrorBoundary } from "@components/body/index.ts";
-import { errorLogger } from "./logging";
 import { theme } from "./theme";
-import {
-  acquireAccessToken,
-  shouldTriggerRedirect,
-  resetAuthRedirectFlag,
-} from "./common/auth";
-import { initializeApi, resetRedirectFlag } from "./common/api";
+import { resetAuthRedirectFlag } from "./common/auth";
+import { resetRedirectFlag } from "./common/api";
 import "./i18n";
 import "./locales/types"; // Import TypeScript type definitions for i18n
 
@@ -101,37 +96,6 @@ msalInstance
         msalInstance.setActiveAccount(accounts[0]);
       }
     }
-
-    // Initialize axios interceptor for authentication
-    const scopes = apiScopeClaim ? [apiScopeClaim] : [];
-    initializeApi(msalInstance, scopes);
-
-    // Set up token provider for error logger
-    errorLogger.setTokenProvider(async () => {
-      try {
-        const token = await acquireAccessToken(msalInstance, scopes);
-        return token;
-      } catch (error) {
-        // Check if error requires redirect
-        if (shouldTriggerRedirect(error)) {
-          console.error(
-            "Error logger: Token acquisition failed. Redirecting to login...",
-          );
-          // Trigger redirect authentication
-          const activeAccount = msalInstance.getActiveAccount();
-          const accounts = msalInstance.getAllAccounts();
-          if (activeAccount || accounts.length > 0) {
-            await msalInstance.acquireTokenRedirect({
-              scopes,
-              account: activeAccount || accounts[0],
-            });
-          }
-        }
-        // If token acquisition fails, return null (logs will be sent without auth)
-        console.warn("Failed to acquire token for error logger:", error);
-        return null;
-      }
-    });
 
     // Create Emotion cache with CSP nonce support
     const emotionCache = createEmotionCache();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -70,9 +70,12 @@ const basename = process.env.REACT_APP_BASENAME ?? "/";
 const apiScopeClaim =
   (import.meta.env.VITE_AZURE_APP_ID_URI ?? "") +
   (import.meta.env.VITE_AZURE_API_SCOPE_CLAIM ?? "");
-const configuredAuthProvider = (import.meta.env.VITE_AUTH_PROVIDER ?? "msal")
-  .trim()
-  .toLowerCase();
+const authProviderEnv = import.meta.env.VITE_AUTH_PROVIDER?.trim();
+const configuredAuthProvider = authProviderEnv?.toLowerCase();
+
+if (configuredAuthProvider !== "msal" && configuredAuthProvider !== "oidc") {
+  throw new Error('VITE_AUTH_PROVIDER must be set to "msal" or "oidc".');
+}
 
 console.log("Azure API Scope Claim: ", apiScopeClaim);
 
@@ -125,8 +128,11 @@ const initializeMsalAndRender = async (): Promise<void> => {
   }
 };
 
-if (configuredAuthProvider === "msal") {
-  void initializeMsalAndRender();
-} else {
-  renderApp();
+switch (configuredAuthProvider) {
+  case "msal":
+    void initializeMsalAndRender();
+    break;
+  case "oidc":
+    renderApp();
+    break;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,7 +13,6 @@ import { createEmotionCache } from "./common/emotionCache";
 import { ErrorBoundary } from "@components/body/index.ts";
 import { theme } from "./theme";
 import { resetAuthRedirectFlag } from "./common/auth";
-import { resetRedirectFlag } from "./common/api";
 import "./i18n";
 import "./locales/types"; // Import TypeScript type definitions for i18n
 
@@ -67,27 +66,47 @@ const msalConfig: Configuration = {
   },
 };
 
-const msalInstance = new PublicClientApplication(msalConfig);
 const basename = process.env.REACT_APP_BASENAME ?? "/";
 const apiScopeClaim =
   (import.meta.env.VITE_AZURE_APP_ID_URI ?? "") +
   (import.meta.env.VITE_AZURE_API_SCOPE_CLAIM ?? "");
+const configuredAuthProvider = (import.meta.env.VITE_AUTH_PROVIDER ?? "msal")
+  .trim()
+  .toLowerCase();
 
 console.log("Azure API Scope Claim: ", apiScopeClaim);
 
-// Initialize MSAL and handle redirect promise before rendering app
-// This is critical for processing OAuth callbacks from Azure AD
-msalInstance
-  .initialize()
-  .then(() => {
-    return msalInstance.handleRedirectPromise();
-  })
-  .then((response) => {
+const renderApp = (msalClient?: PublicClientApplication): void => {
+  const emotionCache = createEmotionCache();
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <ThemeProvider theme={theme}>
+        <CacheProvider value={emotionCache}>
+          <ErrorBoundary>
+            <App
+              msalInstance={msalClient}
+              basename={basename}
+              apiScopeClaim={apiScopeClaim}
+            />
+          </ErrorBoundary>
+        </CacheProvider>
+      </ThemeProvider>
+    </React.StrictMode>,
+  );
+};
+
+const initializeMsalAndRender = async (): Promise<void> => {
+  const msalInstance = new PublicClientApplication(msalConfig);
+
+  try {
+    await msalInstance.initialize();
+    const response = await msalInstance.handleRedirectPromise();
+
     if (response) {
       // Set the active account after successful redirect
       msalInstance.setActiveAccount(response.account);
       // Reset redirect flags to allow future redirects if needed
-      resetRedirectFlag(); // For axios interceptor
       resetAuthRedirectFlag(); // For auth.ts
     } else {
       // Check if we have any cached accounts
@@ -97,44 +116,17 @@ msalInstance
       }
     }
 
-    // Create Emotion cache with CSP nonce support
-    const emotionCache = createEmotionCache();
-
-    // Render app after MSAL is initialized
-    ReactDOM.createRoot(document.getElementById("root")!).render(
-      <React.StrictMode>
-        <ThemeProvider theme={theme}>
-          <CacheProvider value={emotionCache}>
-            <ErrorBoundary>
-              <App
-                msalInstance={msalInstance}
-                basename={basename}
-                apiScopeClaim={apiScopeClaim}
-              />
-            </ErrorBoundary>
-          </CacheProvider>
-        </ThemeProvider>
-      </React.StrictMode>,
-    );
-  })
-  .catch((error) => {
+    renderApp(msalInstance);
+  } catch (error) {
     console.error("Error initializing MSAL:", error);
 
     // Still render the app even if there's an error, so user can see auth popup
-    const emotionCache = createEmotionCache();
-    ReactDOM.createRoot(document.getElementById("root")!).render(
-      <React.StrictMode>
-        <ThemeProvider theme={theme}>
-          <CacheProvider value={emotionCache}>
-            <ErrorBoundary>
-              <App
-                msalInstance={msalInstance}
-                basename={basename}
-                apiScopeClaim={apiScopeClaim}
-              />
-            </ErrorBoundary>
-          </CacheProvider>
-        </ThemeProvider>
-      </React.StrictMode>,
-    );
-  });
+    renderApp(msalInstance);
+  }
+};
+
+if (configuredAuthProvider === "msal") {
+  void initializeMsalAndRender();
+} else {
+  renderApp();
+}

--- a/frontend/src/root/body/body.test.tsx
+++ b/frontend/src/root/body/body.test.tsx
@@ -2,6 +2,19 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Body from "./body";
 
+vi.mock("../../auth", () => ({
+  useNachetAuth: () => ({
+    isAuthenticated: false,
+    isLoading: false,
+    activeAccount: null,
+    accounts: [],
+    login: vi.fn(),
+    logout: vi.fn(),
+    getAccessToken: vi.fn(),
+    provider: "msal",
+  }),
+}));
+
 // Mock the hooks
 vi.mock("@hooks", () => ({
   useBackendUrl: () => "http://localhost:8080",
@@ -195,7 +208,6 @@ const mockProps = {
   signedIn: false,
   setUuid: vi.fn(),
   user: null,
-  apiScopeClaim: "test-api-scope-claim",
 };
 
 const mockAddEventListener = vi.fn();

--- a/frontend/src/root/body/body.tsx
+++ b/frontend/src/root/body/body.tsx
@@ -166,13 +166,7 @@ const Body: React.FC<params> = (props) => {
 
   // Webcam devices hook
   useWebcamDevices();
-  const accountClaims = activeAccount?.idTokenClaims;
-  const uuid =
-    typeof accountClaims?.oid === "string"
-      ? accountClaims.oid
-      : typeof accountClaims?.sub === "string"
-        ? accountClaims.sub
-        : "";
+  const uuid = activeAccount?.userId ?? "";
   const { devicesData } = useDeviceData(backendUrl);
 
   // Model metadata hook

--- a/frontend/src/root/body/body.tsx
+++ b/frontend/src/root/body/body.tsx
@@ -39,9 +39,7 @@ import { useModelStore } from "@stores/useModelStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
 import { useInferenceResultsStore } from "@stores/useInferenceResultsStore";
 import { WorkflowQueueManager } from "../../services/WorkflowQueueManager";
-import { InteractionStatus } from "@azure/msal-browser";
-import { useMsal, useIsAuthenticated, useAccount } from "@azure/msal-react";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../../auth";
 import {
   getLabelOccurrence,
   loadToCanvas,
@@ -65,7 +63,6 @@ interface params {
   creativeCommonsPopupOpen: boolean;
   setCreativeCommonsPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handleCreativeCommonsAgreement: (agree: boolean) => void;
-  apiScopeClaim: string;
 }
 
 const Body: React.FC<params> = (props) => {
@@ -160,22 +157,29 @@ const Body: React.FC<params> = (props) => {
 
   const decodedTiff = useDecoderTiff(imageTiff);
   const backendUrl = useBackendUrl();
-  const apiScopeClaim = props.apiScopeClaim;
-  const { instance: msalInstance, inProgress, accounts } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const accountInfo = useAccount();
+  const {
+    accounts,
+    activeAccount,
+    isAuthenticated,
+    isLoading: authLoading,
+  } = useNachetAuth();
 
   // Webcam devices hook
   useWebcamDevices();
-  const uuid = accountInfo?.idTokenClaims?.oid ?? "";
-  const { devicesData } = useDeviceData(backendUrl, apiScopeClaim);
+  const accountClaims = activeAccount?.idTokenClaims;
+  const uuid =
+    typeof accountClaims?.oid === "string"
+      ? accountClaims.oid
+      : typeof accountClaims?.sub === "string"
+        ? accountClaims.sub
+        : "";
+  const { devicesData } = useDeviceData(backendUrl);
 
   // Model metadata hook
   useModelMetadata({
     backendUrl,
-    apiScopeClaim,
     isAuthenticated,
-    inProgress,
+    authLoading,
   });
 
   // Model store
@@ -204,15 +208,8 @@ const Body: React.FC<params> = (props) => {
 
   // Derive authPopupOpen from authentication state
   const authPopupOpen = useMemo(() => {
-    return !isAuthenticated && inProgress === InteractionStatus.None;
-  }, [isAuthenticated, inProgress]);
-
-  // Set active account if available
-  useEffect(() => {
-    if (accounts.length > 0 && !msalInstance.getActiveAccount()) {
-      msalInstance.setActiveAccount(accounts[0]);
-    }
-  }, [accounts, msalInstance]);
+    return !isAuthenticated && !authLoading;
+  }, [authLoading, isAuthenticated]);
 
   const captureFeed = (): void => {
     // takes screenshot of webcam feed and loads it to cache when capture button is pressed
@@ -234,7 +231,7 @@ const Body: React.FC<params> = (props) => {
       addError(t("auth.signInRequired"), "auth");
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(t("auth.inProgress"), 8000);
       return;
     }
@@ -252,17 +249,13 @@ const Body: React.FC<params> = (props) => {
       const folderName = curDir.folderName;
 
       setIsLoading(true);
-      acquireAccessToken(msalInstance, [apiScopeClaim])
-        .then((accessToken) => {
-          return inferenceDirectRequest({
-            backendUrl,
-            selectedModel,
-            imageObject,
-            curDir: folderName,
-            accessToken,
-            folderId: folderId,
-          });
-        })
+      inferenceDirectRequest({
+        backendUrl,
+        selectedModel,
+        imageObject,
+        curDir: folderName,
+        folderId: folderId,
+      })
         .then((response) => {
           setReadAzureStorage(!readAzureStorage);
           // TODO: Handle direct inference results with new inference store
@@ -288,7 +281,7 @@ const Body: React.FC<params> = (props) => {
       addError(t("auth.signInRequired"), "auth");
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(t("auth.inProgress"), 8000);
       return;
     }
@@ -335,12 +328,8 @@ const Body: React.FC<params> = (props) => {
       return;
     }
 
-    const scopes = apiScopeClaim ? [apiScopeClaim] : [];
-
     queueManagerRef.current.configure({
       backendUrl,
-      msalInstance,
-      scopes,
       pipelineId,
       pipelineName,
       curDir,
@@ -430,8 +419,6 @@ const Body: React.FC<params> = (props) => {
     });
   }, [
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
     pipelineId,
     pipelineName,
     curDir,
@@ -507,7 +494,7 @@ const Body: React.FC<params> = (props) => {
     if (!isAuthenticated) {
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       return;
     }
     if (backendUrl == null || backendUrl === "") {
@@ -523,12 +510,8 @@ const Body: React.FC<params> = (props) => {
 
     const checkRegistration = async () => {
       try {
-        const accessToken = await acquireAccessToken(msalInstance, [
-          apiScopeClaim,
-        ]);
         const response = await checkUserRegistration({
           backendUrl,
-          accessToken,
         });
 
         if (!response.isRegistered) {
@@ -550,10 +533,8 @@ const Body: React.FC<params> = (props) => {
   }, [
     uuid,
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
+    authLoading,
     isAuthenticated,
-    inProgress,
     registrationCheckComplete,
     t,
     addError,
@@ -563,7 +544,7 @@ const Body: React.FC<params> = (props) => {
     if (!isAuthenticated) {
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       return;
     }
     if (backendUrl == null || backendUrl === "") {
@@ -579,10 +560,7 @@ const Body: React.FC<params> = (props) => {
 
     const loadAzureStorageDir = async () => {
       try {
-        const accessToken = await acquireAccessToken(msalInstance, [
-          apiScopeClaim,
-        ]);
-        const response = await readAzureStorageDir({ backendUrl, accessToken });
+        const response = await readAzureStorageDir({ backendUrl });
         const directories: AzureStorageDirectoryItem[] = [];
         const folders = response.directories;
         folders.forEach((item: AzureStorageDirectoryItemApi) => {
@@ -609,10 +587,8 @@ const Body: React.FC<params> = (props) => {
   }, [
     uuid,
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
+    authLoading,
     isAuthenticated,
-    inProgress,
     registrationCheckComplete,
     readAzureStorage,
     t,
@@ -671,7 +647,6 @@ const Body: React.FC<params> = (props) => {
             onClose={() => {
               /* Auth popup closes automatically when user is authenticated */
             }}
-            apiScopeClaim={apiScopeClaim}
           />
         )}
         {registrationModalOpen && (
@@ -685,21 +660,18 @@ const Body: React.FC<params> = (props) => {
             backendUrl={backendUrl}
             uuid={uuid}
             containerName={uuid}
-            apiScopeClaim={apiScopeClaim}
             setReadAzureStorage={setReadAzureStorage}
           />
         )}
         {createDirectoryOpen && (
           <DirectoryPopup
             setReadAzureStorage={setReadAzureStorage}
-            apiScopeClaim={apiScopeClaim}
             mode="create"
           />
         )}
         {editDirectoryOpen && editingFolder && (
           <DirectoryPopup
             setReadAzureStorage={setReadAzureStorage}
-            apiScopeClaim={apiScopeClaim}
             mode="edit"
             initialData={{
               folderId: editingFolder.folderId,
@@ -711,7 +683,6 @@ const Body: React.FC<params> = (props) => {
         {delDirectoryOpen && curDir && (
           <DirectoryPopup
             setReadAzureStorage={setReadAzureStorage}
-            apiScopeClaim={apiScopeClaim}
             mode="delete"
             initialData={{
               folderId: curDir.folderId,
@@ -799,7 +770,6 @@ const Body: React.FC<params> = (props) => {
               onFreeformBoxChange={handleFreeformBoxChange}
               backendUrl={backendUrl}
               uuid={uuid}
-              apiScopeClaim={apiScopeClaim}
             />
           </Box>
           <Box

--- a/frontend/src/services/BatchUploadQueueManager.ts
+++ b/frontend/src/services/BatchUploadQueueManager.ts
@@ -2,8 +2,6 @@ import { getWorkflowStatus } from "@common";
 import { batchUploadImage } from "@common/api";
 import type { BatchUploadMetadata, WorkflowStatus } from "@common/types";
 import { errorLogger } from "../logging";
-import { acquireAccessToken } from "../common/auth";
-import type { IPublicClientApplication } from "@azure/msal-browser";
 
 interface QueueItem {
   file: File;
@@ -34,8 +32,6 @@ interface UploadStore {
 
 interface BatchUploadQueueManagerConfig {
   backendUrl: string;
-  msalInstance: IPublicClientApplication;
-  scopes: string[];
   uploadStore: UploadStore;
   onComplete: (workflowId: string, file: File, results: unknown) => void;
   onError: (workflowId: string, file: File, error: Error) => void;
@@ -130,19 +126,12 @@ export class BatchUploadQueueManager {
     const item = this.queue.shift()!;
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       // Convert file to base64 data URL
       const imageDataUrl = await this.fileToDataUrl(item.file);
 
       // Submit to backend
       const response = await batchUploadImage({
         backendUrl: this.config.backendUrl,
-        accessToken,
         data: {
           ...item.metadata,
           imageDataUrl,
@@ -283,16 +272,9 @@ export class BatchUploadQueueManager {
     }
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       const statusResponse = await getWorkflowStatus({
         backendUrl: this.config.backendUrl,
         workflowId,
-        accessToken,
       });
 
       // Update upload status in store

--- a/frontend/src/services/WorkflowQueueManager.ts
+++ b/frontend/src/services/WorkflowQueueManager.ts
@@ -5,8 +5,6 @@ import {
 } from "@common";
 import type { Images, ApiInferenceData } from "@common/types";
 import { errorLogger } from "../logging";
-import { acquireAccessToken } from "../common/auth";
-import type { IPublicClientApplication } from "@azure/msal-browser";
 
 interface QueueItem {
   imageIndex: number;
@@ -47,8 +45,6 @@ interface WorkflowStore {
 
 interface WorkflowQueueManagerConfig {
   backendUrl: string;
-  msalInstance: IPublicClientApplication;
-  scopes: string[];
   pipelineId: string;
   pipelineName: string;
   curDir: { folderId: string; folderName: string };
@@ -184,19 +180,12 @@ export class WorkflowQueueManager {
         return;
       }
 
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       // Submit to backend using the pipeline info from queue item
       const response = await inferenceRequest({
         backendUrl: this.config.backendUrl,
         selectedModel: item.pipelineId,
         imageObject: image as Images,
         curDir: this.config.curDir.folderName,
-        accessToken,
         folderId: this.config.curDir.folderId,
       });
 
@@ -316,16 +305,9 @@ export class WorkflowQueueManager {
     }
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       const statusResponse = await getWorkflowStatus({
         backendUrl: this.config.backendUrl,
         workflowId,
-        accessToken,
       });
 
       // Update workflow status in store
@@ -367,17 +349,10 @@ export class WorkflowQueueManager {
     this.stopPolling();
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       // Fetch results
       const results = await getWorkflowResults({
         backendUrl: this.config.backendUrl,
         workflowId,
-        accessToken,
       });
 
       // Clear current workflow BEFORE calling callback

--- a/frontend/src/services/tests/BatchUploadQueueManager.test.ts
+++ b/frontend/src/services/tests/BatchUploadQueueManager.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { BatchUploadQueueManager } from "../BatchUploadQueueManager";
 import * as api from "@common/api";
-import * as auth from "@common/auth";
 import { errorLogger } from "../../logging";
 
 // Mock dependencies
 vi.mock("@common/api");
-vi.mock("@common/auth");
 vi.mock("../../logging");
 
 describe("BatchUploadQueueManager", () => {
@@ -14,7 +12,6 @@ describe("BatchUploadQueueManager", () => {
   let mockUploadStore: any;
   let mockOnComplete: any;
   let mockOnError: any;
-  let mockMsalInstance: any;
   let mockConfig: any;
 
   beforeEach(() => {
@@ -32,19 +29,13 @@ describe("BatchUploadQueueManager", () => {
 
     mockOnComplete = vi.fn();
     mockOnError = vi.fn();
-    mockMsalInstance = {} as any;
 
     mockConfig = {
       backendUrl: "http://test-backend.com",
-      msalInstance: mockMsalInstance,
-      scopes: ["test-scope"],
       uploadStore: mockUploadStore,
       onComplete: mockOnComplete,
       onError: mockOnError,
     };
-
-    // Mock auth
-    (auth.acquireAccessToken as any).mockResolvedValue("test-token");
 
     // Mock FileReader for file conversion
     global.FileReader = class {
@@ -166,7 +157,6 @@ describe("BatchUploadQueueManager", () => {
 
       expect(api.batchUploadImage).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
         data: expect.objectContaining({
           ...metadata,
           imageDataUrl: "data:image/jpeg;base64,testdata",

--- a/frontend/src/services/tests/WorkflowQueueManager.test.ts
+++ b/frontend/src/services/tests/WorkflowQueueManager.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { WorkflowQueueManager } from "../WorkflowQueueManager";
 import * as api from "@common/api";
-import * as auth from "@common/auth";
 import { errorLogger } from "../../logging";
 
 // Mock dependencies
 vi.mock("@common/api");
-vi.mock("@common/auth");
 vi.mock("../../logging");
 
 describe("WorkflowQueueManager", () => {
@@ -14,7 +12,6 @@ describe("WorkflowQueueManager", () => {
   let mockWorkflowStore: any;
   let mockOnComplete: any;
   let mockOnError: any;
-  let mockMsalInstance: any;
   let mockConfig: any;
 
   beforeEach(() => {
@@ -31,12 +28,9 @@ describe("WorkflowQueueManager", () => {
 
     mockOnComplete = vi.fn();
     mockOnError = vi.fn();
-    mockMsalInstance = {} as any;
 
     mockConfig = {
       backendUrl: "http://test-backend.com",
-      msalInstance: mockMsalInstance,
-      scopes: ["test-scope"],
       pipelineId: "pipeline-1",
       pipelineName: "Test Pipeline",
       curDir: { folderId: "folder-1", folderName: "Test Folder" },
@@ -46,9 +40,6 @@ describe("WorkflowQueueManager", () => {
       onComplete: mockOnComplete,
       onError: mockOnError,
     };
-
-    // Mock auth
-    (auth.acquireAccessToken as any).mockResolvedValue("test-token");
   });
 
   afterEach(() => {
@@ -153,7 +144,6 @@ describe("WorkflowQueueManager", () => {
         selectedModel: "pipeline-1",
         imageObject: mockImage,
         curDir: "Test Folder",
-        accessToken: "test-token",
         folderId: "folder-1",
       });
       expect(mockWorkflowStore.removeWorkflow).toHaveBeenCalled();
@@ -276,7 +266,6 @@ describe("WorkflowQueueManager", () => {
       expect(api.getWorkflowResults).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
         workflowId: "workflow-1",
-        accessToken: "test-token",
       });
 
       expect(mockOnComplete).toHaveBeenCalledWith(


### PR DESCRIPTION
Relates to #818  
Follow-up to #827

## Summary

This PR builds on the provider-neutral auth foundation from #827 and moves frontend API authentication onto the shared Nachet auth provider.

The main change is that hooks, services, and UI call sites no longer fetch and pass access tokens manually. Protected Nachet API requests are marked centrally, and the Axios auth bridge attaches bearer tokens through the active auth provider. This keeps the frontend provider-neutral while preserving the existing Microsoft Entra/MSAL path.

## What Changed

- Added provider-neutral token attachment for protected Nachet API requests.
- Scoped auth retry behavior to protected Nachet API requests only.
- Added fail-closed behavior when protected requests run before auth is initialized.
- Migrated frontend hooks, services, and call sites away from direct MSAL hooks.
- Removed manual access-token plumbing from frontend call sites.
- Normalized account fields such as `userId` and `isGuest` behind the shared auth interface.
- Added cleanup for Axios auth interceptors when the provider bridge unmounts.
- Added tests for token attachment, scoped retry behavior, fail-closed initialization, OIDC token recovery, and auth bridge behavior.

## Notes

This does not remove MSAL. The official Microsoft Entra path still works through the MSAL adapter.

This does not change backend token validation. Backend provider-neutral JWT/OIDC validation remains a separate follow-up.

## Validation

- `npm run lint`
- `npm run test -- --run`
- `npm run build`
- `git diff --check`