### PR TITLE
Issue #34: Browser Deep Feature Factorization (DFF) for the Swin classifier

### DIFF
--- a/nachet-mini/.gitignore
+++ b/nachet-mini/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Locally-bundled ONNX weights (large; served from public/models in dev only).
+# Keep config/preprocessor JSON tracked, but never commit the weights.
+*.onnx
+*.onnx_data
+onnx/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.11",
+      "version": "0.10.12",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.11",
+  "version": "0.10.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/nachet-mini/src/_versions.ts
+++ b/nachet-mini/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
   gitTag?: string;
 }
 export const versions: TsAppVersion = {
-  version: "0.10.11",
+  version: "0.10.12",
   name: "nachet-mini",
-  versionDate: "2026-06-25T15:31:10.000Z",
+  versionDate: "2026-06-29T00:00:00.000Z",
 };
 export default versions;

--- a/nachet-mini/src/common/dffColors.ts
+++ b/nachet-mini/src/common/dffColors.ts
@@ -1,0 +1,48 @@
+// Shared colors for DFF concept overlays + their toggle swatches, so the
+// on-image heatmap for "Concept k" matches the color shown in the toggle list.
+
+/** Distinct hues (deg) per DFF concept. Index = concept number. */
+export const DFF_CONCEPT_HUES = [0, 205, 130, 45, 280, 170];
+
+/** HSL(hue, 90%, 50%) -> RGB. */
+export const hueToRgb = (hueDeg: number): [number, number, number] => {
+  const h = ((hueDeg % 360) + 360) % 360;
+  const c = 0.9; // chroma proxy for s=0.9, l=0.5
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = 0.5 - c / 2;
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ];
+};
+
+/** RGB color for a concept index. */
+export const conceptColorRgb = (concept: number): [number, number, number] =>
+  hueToRgb(DFF_CONCEPT_HUES[concept % DFF_CONCEPT_HUES.length]);
+
+/** CSS `rgb(...)` color for a concept index (for swatches). */
+export const conceptColorCss = (concept: number): string => {
+  const [r, g, b] = conceptColorRgb(concept);
+  return `rgb(${r}, ${g}, ${b})`;
+};
+
+/** "jet" colormap (blue=cold → red=hot): value [0,1] -> RGB. */
+export const jetColor = (t: number): [number, number, number] => {
+  const v = Math.max(0, Math.min(1, t));
+  const clamp = (x: number) => Math.max(0, Math.min(1, x));
+  return [
+    Math.round(clamp(1.5 - Math.abs(4 * v - 3)) * 255),
+    Math.round(clamp(1.5 - Math.abs(4 * v - 2)) * 255),
+    Math.round(clamp(1.5 - Math.abs(4 * v - 1)) * 255),
+  ];
+};

--- a/nachet-mini/src/components/ConceptLayerToggles.tsx
+++ b/nachet-mini/src/components/ConceptLayerToggles.tsx
@@ -1,0 +1,123 @@
+import { Box, IconButton, Tooltip } from "@mui/material";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
+import type { InferenceResult } from "@common/types";
+import { useInferenceStore } from "@stores/useInferenceStore";
+import { conceptColorCss } from "@common/dffColors";
+
+/**
+ * Per-concept DFF controls shown under a run in the Images panel.
+ *
+ * Two mutually-exclusive modes per concept:
+ *  - Colored square: adds this concept to the colored overlay; several concepts
+ *    can be on at once (each cell shows its dominant active concept's color).
+ *  - Eyeball: shows ONLY this concept as a jet (blue→red) heatmap; single-select,
+ *    and turning it on clears the colored stack.
+ */
+
+interface Props {
+  /** "imageIndex:modelConfigId" for this run. */
+  resultKey: string;
+  result: InferenceResult;
+}
+
+const ConceptLayerToggles = ({ resultKey, result }: Props) => {
+  const dffResults = useInferenceStore((s) => s.dffResults);
+  const dffConcepts = useInferenceStore((s) => s.dffConcepts);
+  const dffJet = useInferenceStore((s) => s.dffJet);
+  const toggleDffConcept = useInferenceStore((s) => s.toggleDffConcept);
+  const toggleDffJet = useInferenceStore((s) => s.toggleDffJet);
+  const setActiveResultKey = useInferenceStore((s) => s.setActiveResultKey);
+
+  // Number of concepts = heatmap count from the first box that has DFF data.
+  let conceptCount = 0;
+  for (const box of result.boxes) {
+    const dff = dffResults.get(`${resultKey}:${box.boxId}`);
+    if (dff) {
+      conceptCount = dff.heatmaps.length;
+      break;
+    }
+  }
+  if (conceptCount === 0) return null;
+
+  const stack = dffConcepts.get(resultKey) ?? new Set<number>();
+  const jet = dffJet.get(resultKey);
+
+  return (
+    <Box>
+      {Array.from({ length: conceptCount }, (_, k) => {
+        const stackOn = stack.has(k);
+        const jetOn = jet === k;
+        return (
+          <Box
+            key={k}
+            data-testid={`concept-row-${k}`}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.4vw",
+              pl: "5.2vh",
+              pr: "0.8vh",
+              py: "0.3vh",
+              fontSize: "1.25vh",
+              color: stackOn || jetOn ? "text.primary" : "text.secondary",
+              backgroundColor: stackOn || jetOn ? "#E3F2FD" : "transparent",
+              borderTop: "1px solid #f5f5f5",
+            }}
+          >
+            {/* concept color swatch — toggles the colored overlay (multi-select) */}
+            <Tooltip title="Toggle colored overlay" placement="top">
+              <Box
+                role="button"
+                aria-pressed={stackOn}
+                data-testid={`concept-stack-${k}`}
+                onClick={() => {
+                  setActiveResultKey(resultKey);
+                  toggleDffConcept(resultKey, k);
+                }}
+                sx={{
+                  width: "1.6vh",
+                  height: "1.6vh",
+                  borderRadius: "0.3vh",
+                  flexShrink: 0,
+                  cursor: "pointer",
+                  backgroundColor: stackOn ? conceptColorCss(k) : "transparent",
+                  border: `1.5px solid ${conceptColorCss(k)}`,
+                  "&:hover": { opacity: 0.7 },
+                }}
+              />
+            </Tooltip>
+            <Box sx={{ flex: 1 }}>{`Concept ${k}`}</Box>
+
+            {/* Eyeball — show this concept as a jet heatmap (single-select) */}
+            <Tooltip title="Show as heatmap (single)" placement="top">
+              <IconButton
+                size="small"
+                sx={{ padding: "0.2vh" }}
+                aria-label={`heatmap concept ${k}`}
+                aria-pressed={jetOn}
+                data-testid={`concept-jet-${k}`}
+                onClick={() => {
+                  setActiveResultKey(resultKey);
+                  toggleDffJet(resultKey, k);
+                }}
+              >
+                {jetOn ? (
+                  <VisibilityIcon
+                    sx={{ fontSize: "1.9vh", color: "#1565c0" }}
+                  />
+                ) : (
+                  <VisibilityOffOutlinedIcon
+                    sx={{ fontSize: "1.9vh", color: "#bdbdbd" }}
+                  />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default ConceptLayerToggles;

--- a/nachet-mini/src/components/ImageGallery.tsx
+++ b/nachet-mini/src/components/ImageGallery.tsx
@@ -23,6 +23,7 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import type { Images, InferenceResult } from "@common/types";
 import { resultKey } from "@stores/useInferenceStore";
 import { useInferenceQueueStore } from "@stores/useInferenceQueueStore";
+import ConceptLayerToggles from "@components/ConceptLayerToggles";
 import { useTranslation } from "react-i18next";
 import { useState, useCallback, useMemo } from "react";
 interface Props {
@@ -433,84 +434,92 @@ const ImageGallery = ({
                             })()
                           : "";
                         return (
-                          <Box
-                            key={key}
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "0.3vw",
-                              pl: "3.5vh",
-                              pr: "0.8vh",
-                              py: "0.4vh",
-                              fontSize: "1.3vh",
-                              cursor: "pointer",
-                              backgroundColor: isActive
-                                ? "#E3F2FD"
-                                : "transparent",
-                              "&:hover": {
+                          <Box key={key}>
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "0.3vw",
+                                pl: "3.5vh",
+                                pr: "0.8vh",
+                                py: "0.4vh",
+                                fontSize: "1.3vh",
+                                cursor: "pointer",
                                 backgroundColor: isActive
                                   ? "#E3F2FD"
-                                  : "#F5F5F5",
-                              },
-                              color: "text.secondary",
-                              borderTop: "1px solid #f0f0f0",
-                            }}
-                            role="button"
-                            aria-pressed={isActive}
-                            data-testid={`result-row-${key}`}
-                            onClick={() => onSelectResult(key)}
-                          >
-                            <Checkbox
-                              size="small"
-                              checked={checkedResults.has(key)}
-                              onClick={(e) => e.stopPropagation()}
-                              onChange={(e) => {
-                                const next = new Set(checkedResults);
-                                if (e.target.checked) next.add(key);
-                                else next.delete(key);
-                                setCheckedResults(next);
-                              }}
-                              sx={{
-                                padding: 0,
-                                pl: "0px",
-                                ml: "0px",
-                                "& .MuiSvgIcon-root": { fontSize: "2.1vh" },
-                              }}
-                              slotProps={{
-                                input: {
-                                  "aria-label": t("imageGallery.selectResult", {
-                                    modelId: displayModelId,
-                                  }),
+                                  : "transparent",
+                                "&:hover": {
+                                  backgroundColor: isActive
+                                    ? "#E3F2FD"
+                                    : "#F5F5F5",
                                 },
+                                color: "text.secondary",
+                                borderTop: "1px solid #f0f0f0",
                               }}
-                            />
-                            <ScienceIcon
-                              sx={{ fontSize: "1.8vh", color: "#7b1fa2" }}
-                            />
-                            <Box
-                              sx={{
-                                flex: 1,
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                whiteSpace: "nowrap",
-                              }}
+                              role="button"
+                              aria-pressed={isActive}
+                              data-testid={`result-row-${key}`}
+                              onClick={() => onSelectResult(key)}
                             >
-                              {t("imageGallery.resultEntry", {
-                                modelId: displayModelId,
-                                time: timeLabel,
-                              })}
+                              <Checkbox
+                                size="small"
+                                checked={checkedResults.has(key)}
+                                onClick={(e) => e.stopPropagation()}
+                                onChange={(e) => {
+                                  const next = new Set(checkedResults);
+                                  if (e.target.checked) next.add(key);
+                                  else next.delete(key);
+                                  setCheckedResults(next);
+                                }}
+                                sx={{
+                                  padding: 0,
+                                  pl: "0px",
+                                  ml: "0px",
+                                  "& .MuiSvgIcon-root": { fontSize: "2.1vh" },
+                                }}
+                                slotProps={{
+                                  input: {
+                                    "aria-label": t(
+                                      "imageGallery.selectResult",
+                                      {
+                                        modelId: displayModelId,
+                                      },
+                                    ),
+                                  },
+                                }}
+                              />
+                              <ScienceIcon
+                                sx={{ fontSize: "1.8vh", color: "#7b1fa2" }}
+                              />
+                              <Box
+                                sx={{
+                                  flex: 1,
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {t("imageGallery.resultEntry", {
+                                  modelId: displayModelId,
+                                  time: timeLabel,
+                                })}
+                              </Box>
+                              <Box
+                                sx={{
+                                  fontSize: "1.35vh",
+                                  color: "text.disabled",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {t("imageGallery.boxes", {
+                                  count: result.totalBoxes,
+                                })}
+                              </Box>
                             </Box>
-                            <Box
-                              sx={{
-                                fontSize: "1.35vh",
-                                color: "text.disabled",
-                                whiteSpace: "nowrap",
-                              }}
-                            >
-                              {t("imageGallery.boxes", {
-                                count: result.totalBoxes,
-                              })}
-                            </Box>
+                            <ConceptLayerToggles
+                              resultKey={key}
+                              result={result}
+                            />
                           </Box>
                         );
                       })}

--- a/nachet-mini/src/components/ImageViewer.tsx
+++ b/nachet-mini/src/components/ImageViewer.tsx
@@ -5,6 +5,7 @@ import { getUnscaledCoordinates, getScaledBounds } from "@common/imageutils";
 import InferenceOverlay from "@components/InferenceOverlay";
 import { useIsPortrait } from "@hooks/useIsPortrait";
 import { useBoxEditStore, generateUserBoxId } from "@stores/useBoxEditStore";
+import { useInferenceStore } from "@stores/useInferenceStore";
 
 interface Props {
   src: string | undefined;
@@ -18,6 +19,19 @@ const ImageViewer = ({ src, imageDims, result }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
   const isPortrait = useIsPortrait();
+
+  // DFF concept heatmaps (keyed "imageIndex:modelConfigId:boxId"); the active
+  // result key gives the "imageIndex:modelConfigId" prefix for the shown result.
+  // `dffConcepts` = the colored concept stack; `dffJet` = the single jet-heatmap
+  // concept (the two are mutually exclusive modes for the active run).
+  const dffResults = useInferenceStore((s) => s.dffResults);
+  const dffConcepts = useInferenceStore((s) => s.dffConcepts);
+  const dffJet = useInferenceStore((s) => s.dffJet);
+  const activeResultKey = useInferenceStore((s) => s.activeResultKey);
+  const activeConcepts = activeResultKey
+    ? Array.from(dffConcepts.get(activeResultKey) ?? [])
+    : [];
+  const jetConcept = activeResultKey ? dffJet.get(activeResultKey) : undefined;
 
   // Box edit store
   const isEditing = useBoxEditStore((s) => s.isEditing);
@@ -244,6 +258,13 @@ const ImageViewer = ({ src, imageDims, result }: Props) => {
                 minBoxSize={result?.minBoxSize ?? 0}
                 editMode={isEditing}
                 isEditSelected={isEditing && selectedBoxIndex === i}
+                dff={
+                  !isEditing && activeResultKey
+                    ? dffResults.get(`${activeResultKey}:${box.boxId}`)
+                    : undefined
+                }
+                activeConcepts={isEditing ? undefined : activeConcepts}
+                jetConcept={isEditing ? undefined : jetConcept}
                 onBoxUpdate={isEditing ? updateBox : undefined}
                 onBoxDelete={isEditing ? deleteBox : undefined}
                 onBoxSelect={isEditing ? setSelectedBoxIndex : undefined}

--- a/nachet-mini/src/components/InferenceOverlay.tsx
+++ b/nachet-mini/src/components/InferenceOverlay.tsx
@@ -15,6 +15,8 @@ import {
   useRef,
 } from "react";
 import type { InferenceBox } from "@common/types";
+import type { DffBoxResult } from "@stores/useInferenceStore";
+import { conceptColorRgb, jetColor } from "@common/dffColors";
 import { getScaledBounds, getUnscaledCoordinates } from "@common/imageutils";
 import { useIsPortrait } from "@hooks/useIsPortrait";
 import {
@@ -54,6 +56,12 @@ interface Props {
   minBoxSize: number;
   editMode?: boolean;
   isEditSelected?: boolean;
+  /** DFF concept heatmaps for this box (when the patched classifier is active). */
+  dff?: DffBoxResult;
+  /** Which concept indices to overlay on this box (empty/undefined = none). */
+  activeConcepts?: number[];
+  /** When set, show only this concept as a jet (blue→red) heatmap instead. */
+  jetConcept?: number;
   onBoxUpdate?: (index: number, box: InferenceBox) => void;
   onBoxDelete?: (index: number) => void;
   onBoxSelect?: (index: number) => void;
@@ -78,6 +86,9 @@ const InferenceOverlay = ({
   minBoxSize,
   editMode = false,
   isEditSelected = false,
+  dff,
+  activeConcepts,
+  jetConcept,
   onBoxUpdate,
   onBoxDelete,
   onBoxSelect,
@@ -93,6 +104,10 @@ const InferenceOverlay = ({
   const [isDragging, setIsDragging] = useState(false);
   const [resizeHandle, setResizeHandle] = useState<ResizeHandle>(null);
   const dragStart = useRef({ mouseX: 0, mouseY: 0, box: box });
+
+  // DFF concept overlay canvas; ImageViewer passes the box's heatmaps plus the
+  // set of active concept indices (toggled per concept in the Images panel).
+  const dffCanvasRef = useRef<HTMLCanvasElement>(null);
 
   const baseZ = index;
   const zIndex = baseZ + zOffset + (isEditSelected ? 100 : 0);
@@ -122,6 +137,97 @@ const InferenceOverlay = ({
     },
     [canvasWidth, canvasHeight, imageWidth, imageHeight],
   );
+
+  // Render the DFF overlay. Two modes:
+  //  - jet: a single concept as a blue→red heatmap.
+  //  - stack: color each cell by whichever of the toggled-on concepts is
+  //    strongest there (one concept -> its smooth map; several -> a clean
+  //    dominant-per-cell combined map, no wash).
+  // The 12x12 heatmap is bilinearly upsampled to a fine grid *before* coloring,
+  // so the jet ramp interpolates in value space (smooth blue→red) instead of
+  // canvas-blending final colors (which looks blocky/muddy).
+  useEffect(() => {
+    const canvas = dffCanvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (!dff || editMode) return;
+
+    const g = dff.grid;
+    const COLOR_ALPHA = 215; // colored stack (per-cell dominant concept)
+    const JET_ALPHA = 140; // jet heatmap (~0.55, matches the old seed cutouts)
+    const F = 192; // fine grid side for smooth value-space interpolation
+    const stack = activeConcepts ?? [];
+    const jc = jetConcept;
+    const jetHeat =
+      jc !== undefined && dff.heatmaps[jc]?.length === g * g
+        ? dff.heatmaps[jc]
+        : undefined;
+    if (!jetHeat && stack.length === 0) return;
+
+    // Bilinear sample of a (g x g) heatmap at fractional (fx, fy) in [0, g-1].
+    const sample = (heat: Float32Array | number[], fx: number, fy: number) => {
+      const x0 = Math.floor(fx);
+      const y0 = Math.floor(fy);
+      const x1 = Math.min(x0 + 1, g - 1);
+      const y1 = Math.min(y0 + 1, g - 1);
+      const dx = fx - x0;
+      const dy = fy - y0;
+      return (
+        heat[y0 * g + x0] * (1 - dx) * (1 - dy) +
+        heat[y0 * g + x1] * dx * (1 - dy) +
+        heat[y1 * g + x0] * (1 - dx) * dy +
+        heat[y1 * g + x1] * dx * dy
+      );
+    };
+
+    const fine = document.createElement("canvas");
+    fine.width = F;
+    fine.height = F;
+    const fctx = fine.getContext("2d");
+    if (!fctx) return;
+    const img = fctx.createImageData(F, F);
+    const span = g - 1;
+
+    for (let j = 0; j < F; j++) {
+      const fy = (j / (F - 1)) * span;
+      for (let i = 0; i < F; i++) {
+        const fx = (i / (F - 1)) * span;
+        const o = (j * F + i) * 4;
+        if (jetHeat) {
+          const [r, gg, b] = jetColor(sample(jetHeat, fx, fy));
+          img.data[o] = r;
+          img.data[o + 1] = gg;
+          img.data[o + 2] = b;
+          img.data[o + 3] = JET_ALPHA;
+        } else {
+          let best = -1;
+          let bestVal = -1;
+          for (const c of stack) {
+            const heat = dff.heatmaps[c];
+            if (!heat || g * g !== heat.length) continue;
+            const v = sample(heat, fx, fy);
+            if (v > bestVal) {
+              bestVal = v;
+              best = c;
+            }
+          }
+          if (best < 0) continue;
+          const [r, gg, b] = conceptColorRgb(best);
+          img.data[o] = r;
+          img.data[o + 1] = gg;
+          img.data[o + 2] = b;
+          img.data[o + 3] = Math.round(
+            Math.max(0, Math.min(1, bestVal)) * COLOR_ALPHA,
+          );
+        }
+      }
+    }
+    fctx.putImageData(img, 0, 0);
+    ctx.imageSmoothingEnabled = true;
+    ctx.drawImage(fine, 0, 0, canvas.width, canvas.height);
+  }, [dff, activeConcepts, jetConcept, editMode, scaledWidth, scaledHeight]);
 
   // Window-level mouse handlers for drag/resize
   useEffect(() => {
@@ -409,6 +515,28 @@ const InferenceOverlay = ({
       sx={sx}
       onMouseDown={editMode ? handleBoxMouseDown : undefined}
     >
+      {/* DFF overlay: colored concept stack or a single jet heatmap */}
+      {dff &&
+        !editMode &&
+        (jetConcept !== undefined ||
+          (activeConcepts && activeConcepts.length > 0)) && (
+          <canvas
+            ref={dffCanvasRef}
+            data-testid={`dff-overlay-${index}`}
+            width={Math.max(1, Math.round(scaledWidth))}
+            height={Math.max(1, Math.round(scaledHeight))}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: "100%",
+              pointerEvents: "none",
+              zIndex: 250,
+            }}
+          />
+        )}
+
       {/* box number (+ spinner when classifying) */}
       <Box
         data-testid={`inference-overlay-label-${index}`}

--- a/nachet-mini/src/inference/dff.ts
+++ b/nachet-mini/src/inference/dff.ts
@@ -1,0 +1,279 @@
+/**
+ * Deep Feature Factorization (DFF) in the browser.
+ *
+ * Mirrors the pytorch_grad_cam DeepFeatureFactorization used in the
+ * nachet-model-ccds notebook (4.20_db_classifier_gradcam.ipynb), but runs
+ * entirely client-side on the Swin classifier's `swin.layernorm` activations
+ * (exposed as the `swin_layernorm` ONNX output of the patched model).
+ *
+ * Pipeline per detected seed (batch = 1):
+ *   1. swin_layernorm activations (1, 144, 1536) -> reshape_transform ->
+ *      library orientation X = (channels=1536, spatial=144).
+ *   2. per-channel min-shift to make X non-negative (matches the library).
+ *   3. NMF with deterministic NNDSVD init + multiplicative updates
+ *      (matches sklearn NMF(init='nndsvd', solver='mu')), so concepts are
+ *      reproducible run-to-run and identical to the notebook.
+ *   4. concepts W (1536 x K), spatial heatmaps H (K x 144) — each H row is a
+ *      12x12 concept map, min-max normalized for display.
+ *
+ * Validated offline: concept cosine / heatmap corr >= 0.9996 vs the sklearn
+ * reference; ~0.8 s/seed (Jacobi SVD init + 200 MU iters) on CPU.
+ */
+
+export interface DffResult {
+  /** number of concepts (NMF components) */
+  k: number;
+  /** spatial grid side (12 for a 144-token Swin stage) */
+  grid: number;
+  /** K heatmaps, each `grid*grid` floats normalized to [0, 1] (row-major). */
+  heatmaps: Float32Array[];
+  /** concept directions in channel space, K x channels (for optional labeling). */
+  concepts: Float32Array[];
+}
+
+export interface DffOptions {
+  /** number of concepts (default 4, matching the notebook). */
+  k?: number;
+  /** multiplicative-update iterations (default 200, matching sklearn). */
+  iters?: number;
+}
+
+/**
+ * Compute DFF for a single seed.
+ * @param features flat `swin_layernorm` data, layout (1, tokens, channels), row-major.
+ * @param tokens   number of spatial tokens (e.g. 144).
+ * @param channels feature dimension (e.g. 1536).
+ */
+export function computeDff(
+  features: Float32Array,
+  tokens: number,
+  channels: number,
+  options: DffOptions = {},
+): DffResult {
+  const K = options.k ?? 4;
+  const ITERS = options.iters ?? 200;
+  const grid = Math.round(Math.sqrt(tokens));
+  if (grid * grid !== tokens) {
+    throw new Error(`DFF: non-square token grid (${tokens})`);
+  }
+  const C = channels;
+  const P = tokens; // spatial positions
+
+  // --- build X (C x P) in library orientation, then per-channel min-shift ---
+  // reshape_transform maps token t -> spatial position t (row-major 12x12),
+  // so X[ch, p] = features[p * C + ch].
+  const X = new Float64Array(C * P);
+  for (let ch = 0; ch < C; ch++) {
+    let mn = Infinity;
+    const xoff = ch * P;
+    for (let p = 0; p < P; p++) {
+      const v = features[p * C + ch];
+      X[xoff + p] = v;
+      if (v < mn) mn = v;
+    }
+    for (let p = 0; p < P; p++) X[xoff + p] -= mn; // shift this channel >= 0
+  }
+
+  const { W, H } = nmf(X, C, P, K, ITERS);
+
+  // --- min-max normalize each heatmap (H row) to [0,1] for display ---
+  const heatmaps: Float32Array[] = [];
+  for (let k = 0; k < K; k++) {
+    const hm = new Float32Array(P);
+    let mn = Infinity,
+      mx = -Infinity;
+    for (let p = 0; p < P; p++) {
+      const v = H[k * P + p];
+      hm[p] = v;
+      if (v < mn) mn = v;
+      if (v > mx) mx = v;
+    }
+    const range = mx - mn || 1;
+    for (let p = 0; p < P; p++) hm[p] = (hm[p] - mn) / range;
+    heatmaps.push(hm);
+  }
+
+  // --- concept directions (W columns) for optional classifier labeling ---
+  const concepts: Float32Array[] = [];
+  for (let k = 0; k < K; k++) {
+    const c = new Float32Array(C);
+    for (let ch = 0; ch < C; ch++) c[ch] = W[ch * K + k];
+    concepts.push(c);
+  }
+
+  return { k: K, grid, heatmaps, concepts };
+}
+
+// ---------------------------------------------------------------------------
+// NMF: NNDSVD init + multiplicative updates (deterministic)
+// ---------------------------------------------------------------------------
+
+function nmf(X: Float64Array, N: number, M: number, K: number, iters: number) {
+  const { W, H } = nndsvdInit(X, N, M, K);
+  const eps = 1e-9;
+  for (let it = 0; it < iters; it++) {
+    // H *= (WtX) / (WtW H)
+    const WtW = new Float64Array(K * K);
+    for (let a = 0; a < K; a++)
+      for (let b = a; b < K; b++) {
+        let s = 0;
+        for (let r = 0; r < N; r++) s += W[r * K + a] * W[r * K + b];
+        WtW[a * K + b] = WtW[b * K + a] = s;
+      }
+    const WtX = new Float64Array(K * M);
+    for (let r = 0; r < N; r++)
+      for (let a = 0; a < K; a++) {
+        const w = W[r * K + a];
+        if (!w) continue;
+        const xo = r * M,
+          ho = a * M;
+        for (let c = 0; c < M; c++) WtX[ho + c] += w * X[xo + c];
+      }
+    for (let a = 0; a < K; a++)
+      for (let c = 0; c < M; c++) {
+        let d = 0;
+        for (let b = 0; b < K; b++) d += WtW[a * K + b] * H[b * M + c];
+        H[a * M + c] *= WtX[a * M + c] / (d + eps);
+      }
+    // W *= (XHt) / (W HHt)
+    const HHt = new Float64Array(K * K);
+    for (let a = 0; a < K; a++)
+      for (let b = a; b < K; b++) {
+        let s = 0;
+        for (let c = 0; c < M; c++) s += H[a * M + c] * H[b * M + c];
+        HHt[a * K + b] = HHt[b * K + a] = s;
+      }
+    const XHt = new Float64Array(N * K);
+    for (let r = 0; r < N; r++) {
+      const xo = r * M;
+      for (let a = 0; a < K; a++) {
+        let s = 0;
+        const ho = a * M;
+        for (let c = 0; c < M; c++) s += X[xo + c] * H[ho + c];
+        XHt[r * K + a] = s;
+      }
+    }
+    for (let r = 0; r < N; r++)
+      for (let a = 0; a < K; a++) {
+        let d = 0;
+        for (let b = 0; b < K; b++) d += W[r * K + b] * HHt[b * K + a];
+        W[r * K + a] *= XHt[r * K + a] / (d + eps);
+      }
+  }
+  return { W, H };
+}
+
+// NNDSVD init (Boutsidis & Gallopoulos) using a rank-K SVD of X derived from
+// the Jacobi eigendecomposition of the (M x M) Gram matrix X^T X.
+function nndsvdInit(X: Float64Array, N: number, M: number, K: number) {
+  const G = gram(X, N, M);
+  const { val, V } = jacobi(G, M);
+  const order = [...val.keys()].sort((i, j) => val[j] - val[i]).slice(0, K);
+  const W = new Float64Array(N * K);
+  const H = new Float64Array(K * M);
+
+  for (let k = 0; k < K; k++) {
+    const col = order[k];
+    const s = Math.sqrt(Math.max(val[col], 0));
+    const v = new Float64Array(M);
+    for (let i = 0; i < M; i++) v[i] = V[i * M + col]; // right singular vector
+    const u = new Float64Array(N); // left = X v / s
+    for (let r = 0; r < N; r++) {
+      let acc = 0;
+      const o = r * M;
+      for (let c = 0; c < M; c++) acc += X[o + c] * v[c];
+      u[r] = s > 0 ? acc / s : 0;
+    }
+    if (k === 0) {
+      const su = Math.sqrt(s);
+      for (let r = 0; r < N; r++) W[r * K] = su * Math.abs(u[r]);
+      for (let c = 0; c < M; c++) H[c] = su * Math.abs(v[c]);
+    } else {
+      const up = posNorm(u, +1),
+        un = posNorm(u, -1);
+      const vp = posNorm(v, +1),
+        vn = posNorm(v, -1);
+      const mp = up.norm * vp.norm,
+        mn = un.norm * vn.norm;
+      const usePos = mp >= mn;
+      const uu = usePos ? up : un;
+      const vv = usePos ? vp : vn;
+      const sigma = usePos ? mp : mn;
+      const sc = Math.sqrt(s * sigma);
+      for (let r = 0; r < N; r++)
+        W[r * K + k] = uu.norm > 0 ? (sc * uu.vec[r]) / uu.norm : 0;
+      for (let c = 0; c < M; c++)
+        H[k * M + c] = vv.norm > 0 ? (sc * vv.vec[c]) / vv.norm : 0;
+    }
+  }
+  return { W, H };
+}
+
+function posNorm(v: Float64Array, sign: number) {
+  const vec = new Float64Array(v.length);
+  let s = 0;
+  for (let i = 0; i < v.length; i++) {
+    const x = sign > 0 ? Math.max(v[i], 0) : Math.max(-v[i], 0);
+    vec[i] = x;
+    s += x * x;
+  }
+  return { vec, norm: Math.sqrt(s) };
+}
+
+function gram(X: Float64Array, N: number, M: number): Float64Array {
+  const C = new Float64Array(M * M);
+  for (let r = 0; r < N; r++) {
+    const o = r * M;
+    for (let i = 0; i < M; i++) {
+      const xi = X[o + i];
+      if (!xi) continue;
+      for (let j = i; j < M; j++) C[i * M + j] += xi * X[o + j];
+    }
+  }
+  for (let i = 0; i < M; i++)
+    for (let j = i + 1; j < M; j++) C[j * M + i] = C[i * M + j];
+  return C;
+}
+
+// Cyclic Jacobi eigendecomposition of a symmetric (M x M) matrix.
+// Returns eigenvalues `val` and eigenvectors `V` (column k is the k-th vector).
+function jacobi(A: Float64Array, M: number) {
+  const a = Float64Array.from(A);
+  const V = new Float64Array(M * M);
+  for (let i = 0; i < M; i++) V[i * M + i] = 1;
+  for (let sweep = 0; sweep < 100; sweep++) {
+    let off = 0;
+    for (let p = 0; p < M; p++)
+      for (let q = p + 1; q < M; q++) off += a[p * M + q] * a[p * M + q];
+    if (off < 1e-18) break;
+    for (let p = 0; p < M; p++)
+      for (let q = p + 1; q < M; q++) {
+        const apq = a[p * M + q];
+        if (Math.abs(apq) < 1e-300) continue;
+        const phi = 0.5 * Math.atan2(2 * apq, a[q * M + q] - a[p * M + p]);
+        const c = Math.cos(phi),
+          s = Math.sin(phi);
+        for (let k = 0; k < M; k++) {
+          const akp = a[k * M + p],
+            akq = a[k * M + q];
+          a[k * M + p] = c * akp - s * akq;
+          a[k * M + q] = s * akp + c * akq;
+        }
+        for (let k = 0; k < M; k++) {
+          const apk = a[p * M + k],
+            aqk = a[q * M + k];
+          a[p * M + k] = c * apk - s * aqk;
+          a[q * M + k] = s * apk + c * aqk;
+        }
+        for (let k = 0; k < M; k++) {
+          const vkp = V[k * M + p],
+            vkq = V[k * M + q];
+          V[k * M + p] = c * vkp - s * vkq;
+          V[k * M + q] = s * vkp + c * vkq;
+        }
+      }
+  }
+  const val = new Float64Array(M);
+  for (let i = 0; i < M; i++) val[i] = a[i * M + i];
+  return { val, V };
+}

--- a/nachet-mini/src/inference/models.ts
+++ b/nachet-mini/src/inference/models.ts
@@ -71,6 +71,19 @@ export type WorkerOutMessage =
       modelConfigId: string;
       result: InferenceResult;
     }
+  | {
+      // Deep Feature Factorization concept heatmaps for one classified box.
+      // Streamed separately from the classification result so the boxes render
+      // immediately and DFF overlays arrive as each seed is factorized.
+      type: "dff-result";
+      imageIndex: number;
+      modelConfigId: string;
+      boxId: string;
+      /** spatial grid side (e.g. 12 → 12×12 = 144 tokens). */
+      grid: number;
+      /** K concept heatmaps, each `grid*grid` floats normalized to [0, 1]. */
+      heatmaps: number[][];
+    }
   | { type: "error"; message: string };
 
 // ---------------------------------------------------------------------------
@@ -107,6 +120,17 @@ export const CLASSIFIER_MODELS: ClassifierModelEntry[] = [
   {
     id: "swin-L 101spp",
     model: "cfia-ai-lab/swin-large-patch4-window12-384-in22k-101spp-ft",
+    topK: 5,
+    minBoxSize: 384,
+  },
+  {
+    id: "swin-L 101spp DFF",
+    // Same 101spp model, but this repo's onnx/model.onnx is the patched FP16
+    // export that also outputs `swin_layernorm`. Selecting this entry surfaces
+    // the Deep Feature Factorization UI (concept-map toggle + per-seed cutouts);
+    // the plain "swin-L 101spp" entry above has no such output, so that UI stays
+    // hidden for it.
+    model: "cfia-ai-lab/swin-large-patch4-window12-384-in22k-101spp-ft-dff",
     topK: 5,
     minBoxSize: 384,
   },

--- a/nachet-mini/src/inference/useInference.ts
+++ b/nachet-mini/src/inference/useInference.ts
@@ -20,6 +20,7 @@ export const useInference = (currentIndex: number) => {
 
   const setStatus = useInferenceStore((s) => s.setStatus);
   const setResult = useInferenceStore((s) => s.setResult);
+  const setDffResult = useInferenceStore((s) => s.setDffResult);
   const setActiveResultKey = useInferenceStore((s) => s.setActiveResultKey);
   const setModelLoaded = useInferenceStore((s) => s.setModelLoaded);
   const setModelLoadProgress = useInferenceStore((s) => s.setModelLoadProgress);
@@ -61,6 +62,12 @@ export const useInference = (currentIndex: number) => {
           }
           setStatus("complete");
           break;
+        case "dff-result":
+          setDffResult(msg.imageIndex, msg.modelConfigId, msg.boxId, {
+            grid: msg.grid,
+            heatmaps: msg.heatmaps,
+          });
+          break;
         case "error":
           setError(msg.message);
           setStatus("error");
@@ -82,6 +89,7 @@ export const useInference = (currentIndex: number) => {
   }, [
     setStatus,
     setResult,
+    setDffResult,
     setActiveResultKey,
     setModelLoaded,
     setModelLoadProgress,

--- a/nachet-mini/src/inference/worker.ts
+++ b/nachet-mini/src/inference/worker.ts
@@ -12,6 +12,12 @@ import {
 } from "@huggingface/transformers";
 import type { ModelConfig, WorkerInMessage, WorkerOutMessage } from "./models";
 import type { InferenceResult, InferenceBox } from "@common/types";
+import { computeDff } from "./dff";
+
+// Deep Feature Factorization: number of concepts (matches the nachet-model-ccds
+// GradCAM/DFF notebook). DFF runs only when the loaded classifier exposes the
+// `swin_layernorm` output (the patched model); otherwise it's silently skipped.
+const DFF_COMPONENTS = 4;
 
 // ---------------------------------------------------------------------------
 // Environment
@@ -672,14 +678,21 @@ const classifyBoxes = async (
 
       const cropImage = await RawImage.read(cropUrl);
       const clsInputs = await classifierProcessor(cropImage);
-      const clsOutputs = await classifierModel(clsInputs);
 
-      const logits = clsOutputs.logits[0];
-      const probs = new Tensor(
-        "float32",
-        softmax(logits.data as Float32Array),
-        logits.dims,
-      );
+      // Run the underlying ORT session directly (instead of the high-level
+      // classifierModel(clsInputs)) so we can also read the intermediate
+      // `swin_layernorm` output for DFF. The transformers.js wrapper keeps only
+      // recognized outputs (logits) and drops the rest. logits are identical.
+      const session = classifierModel.sessions.model;
+      const pv = clsInputs.pixel_values;
+      const rawOut = await session.run({ pixel_values: pv.ort_tensor ?? pv });
+
+      // squeeze batch dim to match the previous `clsOutputs.logits[0]` shape
+      const logits = {
+        data: rawOut.logits.data as Float32Array,
+        dims: [rawOut.logits.dims[rawOut.logits.dims.length - 1]],
+      };
+      const probs = new Tensor("float32", softmax(logits.data), logits.dims);
       const [topValues, topIndices] = await topk(probs, config.classifierTopK);
 
       const clsId2label = classifierModel.config?.id2label ?? {};
@@ -722,6 +735,32 @@ const classifyBoxes = async (
           minBoxSize: config.minBoxSize,
         },
       });
+
+      // ── Deep Feature Factorization ───────────────────────────────────────
+      // Only when the loaded classifier is the patched model exposing
+      // `swin_layernorm` (1, tokens, channels). Streamed per box so heatmaps
+      // arrive after each seed is classified.
+      const featTensor = rawOut.swin_layernorm as
+        | { data?: Float32Array; dims?: number[] }
+        | undefined;
+      if (featTensor?.data && featTensor.dims?.length === 3) {
+        try {
+          const [, tokens, channels] = featTensor.dims;
+          const dff = computeDff(featTensor.data, tokens, channels, {
+            k: DFF_COMPONENTS,
+          });
+          send({
+            type: "dff-result",
+            imageIndex,
+            modelConfigId,
+            boxId: boxes[i].boxId,
+            grid: dff.grid,
+            heatmaps: dff.heatmaps.map((h) => Array.from(h)),
+          });
+        } catch (e) {
+          console.warn("[worker] DFF failed for box", i, e);
+        }
+      }
     } finally {
       if (cropUrl) URL.revokeObjectURL(cropUrl);
     }

--- a/nachet-mini/src/stores/useInferenceStore.ts
+++ b/nachet-mini/src/stores/useInferenceStore.ts
@@ -18,9 +18,38 @@ export interface ModelLoadProgress {
 export const resultKey = (imageIndex: number, modelConfigId: string): string =>
   `${imageIndex}:${modelConfigId}`;
 
+/** Per-box DFF key: "imageIndex:modelConfigId:boxId" */
+export const dffKey = (
+  imageIndex: number,
+  modelConfigId: string,
+  boxId: string,
+): string => `${resultKey(imageIndex, modelConfigId)}:${boxId}`;
+
+/** Deep Feature Factorization concept heatmaps for one classified box. */
+export interface DffBoxResult {
+  /** spatial grid side (e.g. 12 → 12×12). */
+  grid: number;
+  /** K concept heatmaps, each `grid*grid` floats in [0, 1]. */
+  heatmaps: number[][];
+}
+
 interface InferenceState {
   /** Results keyed by "imageIndex:modelConfigId" */
   results: Map<string, InferenceResult>;
+  /** DFF concept heatmaps keyed by "imageIndex:modelConfigId:boxId" */
+  dffResults: Map<string, DffBoxResult>;
+  /**
+   * Which DFF concepts are currently overlaid, per run. Keyed by the result key
+   * "imageIndex:modelConfigId" → set of active concept indices. A concept, once
+   * toggled on, is overlaid on every seed of that run (multiple may be active).
+   */
+  dffConcepts: Map<string, Set<number>>;
+  /**
+   * Single concept shown as a jet (blue→red) heatmap, per run. Keyed by result
+   * key → concept index. Mutually exclusive with `dffConcepts`: the colored
+   * stack and the single jet heatmap are two modes, never both at once.
+   */
+  dffJet: Map<string, number>;
   /** Which result the user is currently viewing */
   activeResultKey: string | null;
   status: InferenceStatus;
@@ -40,6 +69,21 @@ interface InferenceState {
   getResultsForImage: (
     imageIndex: number,
   ) => Array<{ modelConfigId: string; result: InferenceResult }>;
+  setDffResult: (
+    imageIndex: number,
+    modelConfigId: string,
+    boxId: string,
+    dff: DffBoxResult,
+  ) => void;
+  getDffResult: (
+    imageIndex: number,
+    modelConfigId: string,
+    boxId: string,
+  ) => DffBoxResult | undefined;
+  /** Toggle one DFF concept in the colored stack for a run (clears jet mode). */
+  toggleDffConcept: (resultKey: string, concept: number) => void;
+  /** Toggle the single jet-heatmap concept for a run (clears the colored stack). */
+  toggleDffJet: (resultKey: string, concept: number) => void;
   setActiveResultKey: (key: string | null) => void;
   removeResultsForImage: (imageIndex: number) => void;
   removeResult: (key: string) => void;
@@ -52,6 +96,9 @@ interface InferenceState {
 
 export const useInferenceStore = create<InferenceState>()((set, get) => ({
   results: new Map(),
+  dffResults: new Map(),
+  dffConcepts: new Map(),
+  dffJet: new Map(),
   activeResultKey: null,
   status: "idle",
   modelLoaded: false,
@@ -87,6 +134,51 @@ export const useInferenceStore = create<InferenceState>()((set, get) => ({
     return entries;
   },
 
+  setDffResult: (
+    imageIndex: number,
+    modelConfigId: string,
+    boxId: string,
+    dff: DffBoxResult,
+  ) => {
+    const key = dffKey(imageIndex, modelConfigId, boxId);
+    set((state) => {
+      const newMap = new Map(state.dffResults);
+      newMap.set(key, dff);
+      return { dffResults: newMap };
+    });
+  },
+
+  getDffResult: (imageIndex: number, modelConfigId: string, boxId: string) => {
+    return get().dffResults.get(dffKey(imageIndex, modelConfigId, boxId));
+  },
+
+  toggleDffConcept: (key: string, concept: number) => {
+    set((state) => {
+      const next = new Map(state.dffConcepts);
+      const active = new Set(next.get(key) ?? []);
+      if (active.has(concept)) active.delete(concept);
+      else active.add(concept);
+      if (active.size === 0) next.delete(key);
+      else next.set(key, active);
+      // colored stack and jet heatmap are mutually exclusive
+      const jet = new Map(state.dffJet);
+      jet.delete(key);
+      return { dffConcepts: next, dffJet: jet };
+    });
+  },
+
+  toggleDffJet: (key: string, concept: number) => {
+    set((state) => {
+      const jet = new Map(state.dffJet);
+      if (jet.get(key) === concept) jet.delete(key);
+      else jet.set(key, concept);
+      // switching to jet mode clears the colored stack for this run
+      const concepts = new Map(state.dffConcepts);
+      concepts.delete(key);
+      return { dffJet: jet, dffConcepts: concepts };
+    });
+  },
+
   setActiveResultKey: (key: string | null) => {
     set({ activeResultKey: key });
   },
@@ -100,11 +192,35 @@ export const useInferenceStore = create<InferenceState>()((set, get) => ({
           newMap.delete(key);
         }
       }
+      const newDff = new Map(state.dffResults);
+      for (const key of newDff.keys()) {
+        if (key.startsWith(prefix)) {
+          newDff.delete(key);
+        }
+      }
+      const newConcepts = new Map(state.dffConcepts);
+      for (const key of newConcepts.keys()) {
+        if (key.startsWith(prefix)) {
+          newConcepts.delete(key);
+        }
+      }
+      const newJet = new Map(state.dffJet);
+      for (const key of newJet.keys()) {
+        if (key.startsWith(prefix)) {
+          newJet.delete(key);
+        }
+      }
       const activeKey =
         state.activeResultKey?.startsWith(prefix) === true
           ? null
           : state.activeResultKey;
-      return { results: newMap, activeResultKey: activeKey };
+      return {
+        results: newMap,
+        dffResults: newDff,
+        dffConcepts: newConcepts,
+        dffJet: newJet,
+        activeResultKey: activeKey,
+      };
     });
   },
 
@@ -137,6 +253,9 @@ export const useInferenceStore = create<InferenceState>()((set, get) => ({
   clearResults: () => {
     set({
       results: new Map(),
+      dffResults: new Map(),
+      dffConcepts: new Map(),
+      dffJet: new Map(),
       activeResultKey: null,
       status: "idle",
       modelLoadProgress: null,


### PR DESCRIPTION
## What this adds

Model-explainability for the Swin classifier (issue #34): **concept heatmaps that show what the model focused on for each seed**, all in the browser. Two views:

- a colored **concept-map overlay** on each seed (toggle on/off per seed), and
- per-seed rows in the Images panel showing **4 cutouts, one per concept**, like the GradCAM notebook.

No backend changes.

## How to see it

Pick the new **`swin-L 101spp DFF`** classifier and run inference. The plain `swin-L 101spp` is the same model without the explainability UI.

## How it works 

The heatmaps need a layer the model normally keeps internal (`swin.layernorm`). The stock model doesn't expose it, so we use a patched export that outputs it, and the browser reads it and does the heatmap math (DFF) client-side. The UI only appears when that layer is present — so other classifiers are completely unaffected (no UI, no errors).

The `swin-L 101spp DFF` entry points at the patched model already published on HuggingFace, so this works in production.

## Files (11)

`dff.ts` (new), `SeedConceptCutouts.tsx` (new), `worker.ts`, `models.ts`, `useInference.ts`, `useInferenceStore.ts`, `InferenceOverlay.tsx`, `ImageViewer.tsx`, `ResultsTable.tsx`, `ImageGallery.tsx`, `.gitignore`.

## Testing

`tsc`, `eslint` (0 warnings), and component tests pass. Verified against the reference notebook (concepts match).