### PR TITLE
Add provider-neutral API auth bridge

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "2.9.17",
+  "version": "2.9.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "2.9.17",
+      "version": "2.9.18",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "2.9.18",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "2.9.18",
+      "version": "3.0.0",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "2.9.18",
+  "version": "3.0.0",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "2.9.17",
+  "version": "2.9.18",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -1,7 +1,11 @@
-import { useLayoutEffect, type ReactNode } from "react";
+import { useCallback, useLayoutEffect, type ReactNode } from "react";
 import { type PublicClientApplication } from "@azure/msal-browser";
 import { MsalProvider } from "@azure/msal-react";
-import { NachetAuthContext, useNachetAuth } from "./NachetAuthContext";
+import {
+  NachetAuthContext,
+  useNachetAuth,
+  type NachetAuthTokenOptions,
+} from "./NachetAuthContext";
 import { MsalAuthProvider } from "./msal/MsalAuthProvider";
 import { OidcAuthProvider } from "./oidc/OidcAuthProvider";
 import { getConfiguredAuthProvider } from "./authProviderConfig";
@@ -17,15 +21,22 @@ export interface NachetAuthProviderProps {
 const AuthApiBridge = () => {
   const { getAccessToken } = useNachetAuth();
 
+  // API and log requests use the provider's default API scope.
+  const getApiAccessToken = useCallback(
+    (options?: NachetAuthTokenOptions) => getAccessToken(undefined, options),
+    [getAccessToken],
+  );
+
   useLayoutEffect(() => {
-    initializeApi((options) => getAccessToken(undefined, options));
-    errorLogger.setTokenProvider(async () => getAccessToken());
+    // Install before child useEffect API calls run on mount.
+    initializeApi(getApiAccessToken);
+    errorLogger.setTokenProvider(getApiAccessToken);
 
     return () => {
       clearApiAuthentication();
-      errorLogger.setTokenProvider(async () => null);
+      errorLogger.setTokenProvider(null);
     };
-  }, [getAccessToken]);
+  }, [getApiAccessToken]);
 
   return null;
 };

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -1,16 +1,34 @@
-import { type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { type PublicClientApplication } from "@azure/msal-browser";
 import { MsalProvider } from "@azure/msal-react";
-import { NachetAuthContext } from "./NachetAuthContext";
+import { NachetAuthContext, useNachetAuth } from "./NachetAuthContext";
 import { MsalAuthProvider } from "./msal/MsalAuthProvider";
 import { OidcAuthProvider } from "./oidc/OidcAuthProvider";
 import { getConfiguredAuthProvider } from "./authProviderConfig";
+import { clearApiAuthentication, initializeApi } from "../common/api";
+import { errorLogger } from "../logging";
 
 export interface NachetAuthProviderProps {
   apiScopeClaim: string;
   children: ReactNode;
   msalInstance?: PublicClientApplication;
 }
+
+const AuthApiBridge = () => {
+  const { getAccessToken } = useNachetAuth();
+
+  useEffect(() => {
+    initializeApi((options) => getAccessToken(undefined, options));
+    errorLogger.setTokenProvider(async () => getAccessToken());
+
+    return () => {
+      clearApiAuthentication();
+      errorLogger.setTokenProvider(async () => null);
+    };
+  }, [getAccessToken]);
+
+  return null;
+};
 
 export const NachetAuthProvider = ({
   apiScopeClaim,
@@ -31,6 +49,7 @@ export const NachetAuthProvider = ({
             apiScopeClaim={apiScopeClaim}
             authContext={NachetAuthContext}
           >
+            <AuthApiBridge />
             {children}
           </MsalAuthProvider>
         </MsalProvider>
@@ -41,6 +60,7 @@ export const NachetAuthProvider = ({
           apiScopeClaim={apiScopeClaim}
           authContext={NachetAuthContext}
         >
+          <AuthApiBridge />
           {children}
         </OidcAuthProvider>
       );

--- a/frontend/src/auth/NachetAuthProvider.tsx
+++ b/frontend/src/auth/NachetAuthProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useLayoutEffect, type ReactNode } from "react";
 import { type PublicClientApplication } from "@azure/msal-browser";
 import { MsalProvider } from "@azure/msal-react";
 import { NachetAuthContext, useNachetAuth } from "./NachetAuthContext";
@@ -17,7 +17,7 @@ export interface NachetAuthProviderProps {
 const AuthApiBridge = () => {
   const { getAccessToken } = useNachetAuth();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     initializeApi((options) => getAccessToken(undefined, options));
     errorLogger.setTokenProvider(async () => getAccessToken());
 

--- a/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useState } from "react";
-import axios from "axios";
+import { useEffect, useState, type Context, type ReactNode } from "react";
+import axios, {
+  type AxiosAdapter,
+  type InternalAxiosRequestConfig,
+} from "axios";
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearApiAuthentication, fetchDevices } from "../../common/api";
 import { NachetAuthProvider } from "../";
+import type { NachetAuthContextValue } from "../NachetAuthContext";
 
 const mockOidcAuth = vi.hoisted(() => ({
   getAccessToken: vi.fn(),
@@ -20,8 +24,13 @@ vi.mock("../../logging", () => ({
   },
 }));
 
+interface MockOidcAuthProviderProps {
+  authContext: Context<NachetAuthContextValue | undefined>;
+  children: ReactNode;
+}
+
 vi.mock("../oidc/OidcAuthProvider", () => ({
-  OidcAuthProvider: ({ authContext, children }: any) => {
+  OidcAuthProvider: ({ authContext, children }: MockOidcAuthProviderProps) => {
     const Provider = authContext.Provider;
 
     return (
@@ -77,22 +86,34 @@ describe("NachetAuthProvider API bridge", () => {
   const originalAdapter = axios.defaults.adapter;
   const authorizationHeaders: Array<string | undefined> = [];
 
+  const okDevicesResponse = (requestConfig: InternalAxiosRequestConfig) => ({
+    data: { devices: [] },
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: requestConfig,
+  });
+
+  const getAuthorizationHeader = (
+    requestConfig: InternalAxiosRequestConfig,
+  ): string | undefined => {
+    const authorizationHeader = requestConfig.headers.Authorization;
+    return typeof authorizationHeader === "string"
+      ? authorizationHeader
+      : undefined;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     authorizationHeaders.length = 0;
     import.meta.env.VITE_AUTH_PROVIDER = "oidc";
     mockOidcAuth.getAccessToken.mockResolvedValue("oidc-api-token");
-    axios.defaults.adapter = async (requestConfig: any) => {
-      authorizationHeaders.push(requestConfig.headers.Authorization);
+    const adapter: AxiosAdapter = async (requestConfig) => {
+      authorizationHeaders.push(getAuthorizationHeader(requestConfig));
 
-      return {
-        data: { devices: [] },
-        status: 200,
-        statusText: "OK",
-        headers: {},
-        config: requestConfig,
-      };
+      return okDevicesResponse(requestConfig);
     };
+    axios.defaults.adapter = adapter;
   });
 
   afterEach(() => {

--- a/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearApiAuthentication, fetchDevices } from "../../common/api";
+import { NachetAuthProvider } from "../";
+
+const mockOidcAuth = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+}));
+
+vi.mock("../../logging", () => ({
+  errorLogger: {
+    getCorrelationId: vi.fn(() => "test-correlation-id"),
+    getSessionId: vi.fn(() => "test-session-id"),
+    logApiError: vi.fn(),
+    logError: vi.fn(),
+    setCorrelationId: vi.fn(),
+    setTokenProvider: vi.fn(),
+  },
+}));
+
+vi.mock("../oidc/OidcAuthProvider", () => ({
+  OidcAuthProvider: ({ authContext, children }: any) => {
+    const Provider = authContext.Provider;
+
+    return (
+      <Provider
+        value={{
+          provider: "oidc",
+          isAuthenticated: true,
+          isLoading: false,
+          accounts: [
+            {
+              username: "oidc-user@example.com",
+              name: "OIDC User",
+              userId: "oidc-subject",
+              isGuest: false,
+              idTokenClaims: { sub: "oidc-subject" },
+            },
+          ],
+          activeAccount: {
+            username: "oidc-user@example.com",
+            name: "OIDC User",
+            userId: "oidc-subject",
+            isGuest: false,
+            idTokenClaims: { sub: "oidc-subject" },
+          },
+          login: vi.fn(),
+          logout: vi.fn(),
+          getAccessToken: mockOidcAuth.getAccessToken,
+        }}
+      >
+        {children}
+      </Provider>
+    );
+  },
+}));
+
+const ApiCallOnMount = ({ backendUrl }: { backendUrl: string }) => {
+  const [status, setStatus] = useState("pending");
+
+  useEffect(() => {
+    void fetchDevices({ backendUrl })
+      .then(() => {
+        setStatus("loaded");
+      })
+      .catch((error: unknown) => {
+        setStatus(error instanceof Error ? error.message : "failed");
+      });
+  }, [backendUrl]);
+
+  return <span data-testid="api-status">{status}</span>;
+};
+
+describe("NachetAuthProvider API bridge", () => {
+  const originalAdapter = axios.defaults.adapter;
+  const authorizationHeaders: Array<string | undefined> = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorizationHeaders.length = 0;
+    import.meta.env.VITE_AUTH_PROVIDER = "oidc";
+    mockOidcAuth.getAccessToken.mockResolvedValue("oidc-api-token");
+    axios.defaults.adapter = async (requestConfig: any) => {
+      authorizationHeaders.push(requestConfig.headers.Authorization);
+
+      return {
+        data: { devices: [] },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: requestConfig,
+      };
+    };
+  });
+
+  afterEach(() => {
+    clearApiAuthentication();
+    axios.defaults.adapter = originalAdapter;
+    delete import.meta.env.VITE_AUTH_PROVIDER;
+  });
+
+  it("initializes Axios with the shared auth provider before child API helpers run", async () => {
+    render(
+      <NachetAuthProvider apiScopeClaim="api://nachet/access_as_user">
+        <ApiCallOnMount backendUrl="https://api.example.test" />
+      </NachetAuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("api-status").textContent).toBe("loaded");
+    });
+
+    expect(mockOidcAuth.getAccessToken).toHaveBeenCalledOnce();
+    expect(authorizationHeaders).toEqual(["Bearer oidc-api-token"]);
+  });
+});

--- a/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.apiBridge.test.tsx
@@ -97,7 +97,7 @@ describe("NachetAuthProvider API bridge", () => {
   const getAuthorizationHeader = (
     requestConfig: InternalAxiosRequestConfig,
   ): string | undefined => {
-    const authorizationHeader = requestConfig.headers.Authorization;
+    const authorizationHeader = requestConfig.headers.get("Authorization");
     return typeof authorizationHeader === "string"
       ? authorizationHeader
       : undefined;

--- a/frontend/src/auth/tests/NachetAuthProvider.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.test.tsx
@@ -6,6 +6,7 @@ import { useIsAuthenticated, useMsal } from "@azure/msal-react";
 import type { IMsalContext } from "@azure/msal-react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { acquireAccessToken } from "../../common/auth";
+import { initializeApi } from "../../common/api";
 import {
   NachetAuthProvider,
   useNachetAuth,
@@ -18,6 +19,19 @@ vi.mock("@azure/msal-react", () => ({
   useMsal: vi.fn(),
 }));
 vi.mock("../../common/auth");
+vi.mock("../../common/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../common/api")>();
+  return {
+    ...actual,
+    clearApiAuthentication: vi.fn(),
+    initializeApi: vi.fn(),
+  };
+});
+vi.mock("../../logging", () => ({
+  errorLogger: {
+    setTokenProvider: vi.fn(),
+  },
+}));
 vi.mock("../oidc/OidcAuthProvider", () => ({
   OidcAuthProvider: ({
     authContext,
@@ -211,6 +225,23 @@ describe("NachetAuthProvider", () => {
       );
       expect(document.body.dataset.token).toBe("access-token");
     });
+  });
+
+  it("initializes API auth through the MSAL adapter by default", async () => {
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(initializeApi).toHaveBeenCalled();
+    });
+
+    const getAccessToken = (initializeApi as any).mock.calls[0][0];
+    await getAccessToken({ forceRefresh: true });
+
+    expect(acquireAccessToken).toHaveBeenCalledWith(
+      mockMsalInstance,
+      ["api://nachet/scope"],
+      { forceRefresh: true },
+    );
   });
 
   it("normalizes the configured provider name", () => {

--- a/frontend/src/auth/tests/NachetAuthProvider.test.tsx
+++ b/frontend/src/auth/tests/NachetAuthProvider.test.tsx
@@ -228,13 +228,15 @@ describe("NachetAuthProvider", () => {
   });
 
   it("initializes API auth through the MSAL adapter by default", async () => {
+    const initializeApiMock = vi.mocked(initializeApi);
+
     renderWithProvider();
 
     await waitFor(() => {
-      expect(initializeApi).toHaveBeenCalled();
+      expect(initializeApiMock).toHaveBeenCalled();
     });
 
-    const getAccessToken = (initializeApi as any).mock.calls[0][0];
+    const getAccessToken = initializeApiMock.mock.calls[0][0];
     await getAccessToken({ forceRefresh: true });
 
     expect(acquireAccessToken).toHaveBeenCalledWith(

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -39,34 +39,53 @@ import {
   safeUserInputSchema,
 } from "./validation";
 import { errorLogger } from "../logging";
-import { setupAxiosInterceptor, resetRedirectFlag } from "./apiInterceptor";
-import type { IPublicClientApplication } from "@azure/msal-browser";
+import {
+  setupAxiosInterceptor,
+  clearAxiosInterceptors,
+} from "./apiInterceptor";
+import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
+
+let isAuthProviderInitialized = false;
 
 /**
  * Initialize API module with axios interceptor for authentication
  * Must be called once during app initialization
  *
- * @param msalInstance - MSAL instance for authentication
- * @param scopes - Array of scopes to request for tokens
+ * @param getAccessToken - Provider-neutral token getter
  */
-export function initializeApi(
-  msalInstance: IPublicClientApplication,
-  scopes: string[],
-): void {
-  setupAxiosInterceptor(msalInstance, scopes);
-}
+export const initializeApi = (
+  getAccessToken: (options?: NachetAuthTokenOptions) => Promise<string>,
+): void => {
+  setupAxiosInterceptor(getAccessToken);
+  isAuthProviderInitialized = true;
+};
 
-// Re-export resetRedirectFlag for use in main.tsx
-export { resetRedirectFlag };
+export const clearApiAuthentication = (): void => {
+  clearAxiosInterceptors();
+  isAuthProviderInitialized = false;
+};
 
 const handleAxios = async <T>(request: {
   method: string;
   url: string;
   headers: { [label: string]: string };
   data?: any;
+  authRequired?: boolean;
 }): Promise<T> => {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
+  const requestHasAuthHeader = Boolean(request.headers.Authorization);
+  const requestRequiresAuth = request.authRequired !== false;
+  const requestCanUseAuthProvider =
+    requestRequiresAuth && (!requestHasAuthHeader || isAuthProviderInitialized);
+
+  if (
+    requestRequiresAuth &&
+    !requestHasAuthHeader &&
+    !isAuthProviderInitialized
+  ) {
+    throw new ValueError("Auth provider is not initialized for API requests");
+  }
 
   // Add correlation and session IDs to headers
   const enhancedRequest = {
@@ -77,6 +96,7 @@ const handleAxios = async <T>(request: {
       "X-Session-ID": errorLogger.getSessionId(),
     },
     withCredentials: true,
+    ...(requestCanUseAuthProvider ? { nachetAuthRequired: true } : {}),
   };
 
   const data = await axios(enhancedRequest)
@@ -147,6 +167,16 @@ const handleAxios = async <T>(request: {
   return data;
 };
 
+const getAuthHeaders = (
+  accessToken?: string | null,
+): Record<string, string> => {
+  if (accessToken === "" || accessToken === null) {
+    throw new ValueError("Access token is null or empty");
+  }
+
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+};
+
 export const pingBackend = async ({
   backendUrl,
 }: {
@@ -158,6 +188,7 @@ export const pingBackend = async ({
   const request = {
     method: "get",
     url: `${backendUrl}/health`,
+    authRequired: false,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
@@ -176,13 +207,10 @@ export const checkUserRegistration = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<{ isRegistered: boolean }> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -190,7 +218,7 @@ export const checkUserRegistration = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
   };
   const response = await handleAxios<unknown>(request);
@@ -206,13 +234,10 @@ export const readAzureStorageDir = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ReadAzureStorageDirApi> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -220,7 +245,7 @@ export const readAzureStorageDir = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     // data: {
     //   //   container_name: uuid,
@@ -240,14 +265,11 @@ export const createAzureStorageDir = async ({
   folderName,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
@@ -258,7 +280,7 @@ export const createAzureStorageDir = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       folderName: folderName,
@@ -282,14 +304,11 @@ export const deleteAzureStorageDir = async ({
   folderName,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
@@ -300,7 +319,7 @@ export const deleteAzureStorageDir = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       folderName: folderName,
@@ -323,14 +342,11 @@ export const deleteFolder = async ({
   folderId,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
 }): Promise<{ id: string; message: string }> => {
   if (!backendUrl) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (!accessToken) {
-    throw new ValueError("Access token is null or empty");
   }
   if (!folderId) {
     throw new ValueError("Folder ID is null or empty");
@@ -342,7 +358,7 @@ export const deleteFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
   };
 
@@ -373,7 +389,7 @@ export const inferenceRequest = async ({
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
 }): Promise<ImageSubmissionResponse> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -388,9 +404,7 @@ export const inferenceRequest = async ({
   if (curDir === "" || curDir == null) {
     throw new ValueError("Directory is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
+  const authHeaders = getAuthHeaders(accessToken);
 
   // Build payload object with all required and optional fields
   const payload = {
@@ -429,7 +443,7 @@ export const inferenceRequest = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...authHeaders,
     },
     data: validatedPayload,
   };
@@ -453,7 +467,7 @@ export const inferenceDirectRequest = async ({
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -468,9 +482,7 @@ export const inferenceDirectRequest = async ({
   if (curDir === "" || curDir == null) {
     throw new ValueError("Directory is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
+  const authHeaders = getAuthHeaders(accessToken);
 
   // Build payload object with all required and optional fields
   const payload = {
@@ -509,7 +521,7 @@ export const inferenceDirectRequest = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...authHeaders,
     },
     data: validatedPayload,
   };
@@ -526,13 +538,10 @@ export const fetchModelMetadata = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ModelMetadata[]> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -540,7 +549,7 @@ export const fetchModelMetadata = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -557,13 +566,10 @@ export const fetchDevices = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiDevicesResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -571,7 +577,7 @@ export const fetchDevices = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -590,7 +596,7 @@ export const getWorkflowStatus = async ({
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<WorkflowStatusResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -598,16 +604,13 @@ export const getWorkflowStatus = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/status`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -626,7 +629,7 @@ export const getWorkflowResults = async ({
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -634,16 +637,13 @@ export const getWorkflowResults = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/results`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -662,13 +662,10 @@ export const sendFeedbackNewBox = async ({
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "post",
@@ -676,7 +673,7 @@ export const sendFeedbackNewBox = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: feedbackData,
   };
@@ -695,13 +692,10 @@ export const sendPositiveFeedback = async ({
 }: {
   feedbackData: FeedbackDataPositive;
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "post",
@@ -709,7 +703,7 @@ export const sendPositiveFeedback = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: feedbackData,
   };
@@ -728,13 +722,10 @@ export const sendNegativeFeedback = async ({
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "post",
@@ -742,7 +733,7 @@ export const sendNegativeFeedback = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: feedbackData,
   };
@@ -784,13 +775,10 @@ export const requestClassList = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<ApiSpeciesData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   const request = {
     method: "get",
@@ -798,7 +786,7 @@ export const requestClassList = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {},
   };
@@ -817,7 +805,7 @@ export const batchUploadInit = async ({
   fileCount,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
   fileCount: number;
 }): Promise<{
@@ -825,9 +813,6 @@ export const batchUploadInit = async ({
 }> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderId === "" || folderId == null) {
     throw new ValueError("Folder ID is null or empty");
@@ -841,7 +826,7 @@ export const batchUploadInit = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       folderId: folderId,
@@ -863,7 +848,7 @@ export const batchUploadImage = async ({
 }: {
   backendUrl: string;
   data: BatchUploadMetadata;
-  accessToken: string;
+  accessToken?: string | null;
 }): Promise<BatchUploadImageResponse> => {
   const {
     sessionId,
@@ -909,9 +894,7 @@ export const batchUploadImage = async ({
   if (magnification === 0 || magnification == null) {
     throw new ValueError("Magnification is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
+  const authHeaders = getAuthHeaders(accessToken);
 
   const request = {
     method: "post",
@@ -919,7 +902,7 @@ export const batchUploadImage = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...authHeaders,
     },
     data: {
       sessionId: sessionId,
@@ -954,7 +937,7 @@ export const batchUploadImage = async ({
  * Authorization: Users can only create folders for themselves
  *
  * @param backendUrl - Backend API base URL
- * @param accessToken - Bearer token for authentication
+ * @param accessToken - Optional compatibility bearer token. App callers normally use the shared auth provider.
  * @param normalizedPath - Relative path from user's root (e.g., "avena-fatua" or "mycology/avena-fatua")
  * @param description - Optional folder description
  * @returns Promise resolving to CreateOrGetFolderResponse with folderId
@@ -964,7 +947,6 @@ export const batchUploadImage = async ({
  * @example
  * await createOrGetFolder({
  *   backendUrl: "https://api.example.com",
- *   accessToken: "bearer-token",
  *   normalizedPath: "mycology/avena-fatua",
  *   description: "Wild oat samples"
  * });
@@ -977,16 +959,13 @@ export const createOrGetFolder = async ({
   description = "",
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   normalizedPath: string;
   description?: string;
 }): Promise<CreateOrGetFolderResponse> => {
   // Validation
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (normalizedPath === "" || normalizedPath == null) {
     throw new ValueError("Normalized path is null or empty");
@@ -1006,7 +985,7 @@ export const createOrGetFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       normalizedPath: normalizedPath,
@@ -1031,7 +1010,7 @@ export const createOrGetFolder = async ({
  * Restrictions: Cannot update default folders for active users
  *
  * @param backendUrl - Backend API base URL
- * @param accessToken - Bearer token for authentication
+ * @param accessToken - Optional compatibility bearer token. App callers normally use the shared auth provider.
  * @param folderId - UUID of the folder to update
  * @param name - Optional new folder name (just the name, not full path)
  * @param description - Optional new description
@@ -1042,7 +1021,6 @@ export const createOrGetFolder = async ({
  * @example
  * await updateFolder({
  *   backendUrl: "https://api.example.com",
- *   accessToken: "bearer-token",
  *   folderId: "uuid-string",
  *   name: "new-folder-name",
  *   description: "Updated description"
@@ -1057,7 +1035,7 @@ export const updateFolder = async ({
   description,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   folderId: string;
   name?: string;
   description?: string;
@@ -1065,9 +1043,6 @@ export const updateFolder = async ({
   // Validation
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
-  }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
   }
   if (folderId === "" || folderId == null) {
     throw new ValueError("Folder ID is null or empty");
@@ -1104,7 +1079,7 @@ export const updateFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: {
       ...(name && { name }),
@@ -1126,7 +1101,7 @@ export const sendLogToBackend = async ({
   logData,
 }: {
   backendUrl: string;
-  accessToken: string;
+  accessToken?: string | null;
   logData: {
     level: "ERROR" | "WARNING" | "INFO" | "DEBUG";
     message: string;
@@ -1141,16 +1116,13 @@ export const sendLogToBackend = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  if (accessToken === "" || accessToken == null) {
-    throw new ValueError("Access token is null or empty");
-  }
   const request = {
     method: "post",
     url: `${backendUrl}/logs`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      Authorization: `Bearer ${accessToken}`,
+      ...getAuthHeaders(accessToken),
     },
     data: logData,
   };

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -95,7 +95,7 @@ const handleAxios = async <T>(request: {
       "X-Session-ID": errorLogger.getSessionId(),
     },
     withCredentials: true,
-    nachetAuthRequired: requestCanUseAuthProvider,
+    useNachetAuthProvider: requestCanUseAuthProvider,
   };
 
   const data = await axios(enhancedRequest)

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -42,10 +42,9 @@ import { errorLogger } from "../logging";
 import {
   setupAxiosInterceptor,
   clearAxiosInterceptors,
+  hasApiAccessTokenProvider,
 } from "./apiInterceptor";
 import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
-
-let isAuthProviderInitialized = false;
 
 type GetApiAccessToken = (
   options?: NachetAuthTokenOptions,
@@ -59,12 +58,10 @@ type GetApiAccessToken = (
  */
 export const initializeApi = (getApiAccessToken: GetApiAccessToken): void => {
   setupAxiosInterceptor(getApiAccessToken);
-  isAuthProviderInitialized = true;
 };
 
 export const clearApiAuthentication = (): void => {
   clearAxiosInterceptors();
-  isAuthProviderInitialized = false;
 };
 
 const handleAxios = async <T>(request: {
@@ -76,15 +73,15 @@ const handleAxios = async <T>(request: {
 }): Promise<T> => {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
-  const requestHasAuthHeader = Boolean(request.headers.Authorization);
+  const requestHasExplicitAuthHeader = Boolean(request.headers.Authorization);
   const requestRequiresAuth = request.authRequired !== false;
   const requestCanUseAuthProvider =
-    requestRequiresAuth && (!requestHasAuthHeader || isAuthProviderInitialized);
+    requestRequiresAuth && hasApiAccessTokenProvider();
 
   if (
     requestRequiresAuth &&
-    !requestHasAuthHeader &&
-    !isAuthProviderInitialized
+    !requestHasExplicitAuthHeader &&
+    !requestCanUseAuthProvider
   ) {
     throw new ValueError("Auth provider is not initialized for API requests");
   }

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -74,7 +74,7 @@ const handleAxios = async <T>(request: {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
   const requestHasExplicitAuthHeader = Boolean(request.headers.Authorization);
-  const requestRequiresAuth = request.authRequired !== false;
+  const requestRequiresAuth = request.authRequired ?? true;
   const requestCanUseAuthProvider =
     requestRequiresAuth && hasApiAccessTokenProvider();
 
@@ -95,7 +95,7 @@ const handleAxios = async <T>(request: {
       "X-Session-ID": errorLogger.getSessionId(),
     },
     withCredentials: true,
-    ...(requestCanUseAuthProvider ? { nachetAuthRequired: true } : {}),
+    nachetAuthRequired: requestCanUseAuthProvider,
   };
 
   const data = await axios(enhancedRequest)

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosHeaders } from "axios";
 import { AzureAPIError, ValueError } from "./error";
 import {
   ApiInferenceData,
@@ -65,13 +65,13 @@ export const clearApiAuthentication = (): void => {
 const handleAxios = async <T>(request: {
   method: string;
   url: string;
-  headers: { [label: string]: string };
+  headers: Record<string, string>;
   data?: any;
   authRequired?: boolean;
 }): Promise<T> => {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
-  const requestHasExplicitAuthHeader = Boolean(request.headers.Authorization);
+  const requestHasExplicitAuthHeader = hasAuthorizationHeader(request.headers);
   const requestRequiresAuth = request.authRequired ?? true;
   const requestCanUseAuthProvider =
     requestRequiresAuth && hasApiAccessTokenProvider();
@@ -162,6 +162,15 @@ const handleAxios = async <T>(request: {
       throw new AzureAPIError(error.message || "Unknown error");
     });
   return data;
+};
+
+// API helpers build plain header objects before Axios normalizes header names.
+const hasAuthorizationHeader = (headers: Record<string, string>): boolean => {
+  const authorizationHeader = AxiosHeaders.from(headers).get("Authorization");
+
+  return (
+    typeof authorizationHeader === "string" && authorizationHeader.trim() !== ""
+  );
 };
 
 // During the API auth migration, callers either pass an explicit token

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -47,16 +47,18 @@ import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
 
 let isAuthProviderInitialized = false;
 
+type GetApiAccessToken = (
+  options?: NachetAuthTokenOptions,
+) => Promise<string>;
+
 /**
  * Initialize API module with axios interceptor for authentication
  * Must be called once during app initialization
  *
- * @param getAccessToken - Provider-neutral token getter
+ * @param getApiAccessToken - Provider-neutral token getter used per request
  */
-export const initializeApi = (
-  getAccessToken: (options?: NachetAuthTokenOptions) => Promise<string>,
-): void => {
-  setupAxiosInterceptor(getAccessToken);
+export const initializeApi = (getApiAccessToken: GetApiAccessToken): void => {
+  setupAxiosInterceptor(getApiAccessToken);
   isAuthProviderInitialized = true;
 };
 
@@ -212,13 +214,15 @@ export const checkUserRegistration = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/is-registered`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
   };
   const response = await handleAxios<unknown>(request);
@@ -239,13 +243,15 @@ export const readAzureStorageDir = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/get-directories`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     // data: {
     //   //   container_name: uuid,
@@ -274,13 +280,15 @@ export const createAzureStorageDir = async ({
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/create-dir`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {
       folderName: folderName,
@@ -313,13 +321,15 @@ export const deleteAzureStorageDir = async ({
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/del`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {
       folderName: folderName,
@@ -351,6 +361,7 @@ export const deleteFolder = async ({
   if (!folderId) {
     throw new ValueError("Folder ID is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
 
   const request = {
     method: "delete",
@@ -358,7 +369,7 @@ export const deleteFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
   };
 
@@ -543,13 +554,15 @@ export const fetchModelMetadata = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/model-endpoints-metadata`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {},
   };
@@ -571,13 +584,15 @@ export const fetchDevices = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/devices`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {},
   };
@@ -604,13 +619,15 @@ export const getWorkflowStatus = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/status`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {},
   };
@@ -637,13 +654,15 @@ export const getWorkflowResults = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/results`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {},
   };
@@ -667,13 +686,15 @@ export const sendFeedbackNewBox = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/feedback-new-box`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: feedbackData,
   };
@@ -697,13 +718,15 @@ export const sendPositiveFeedback = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/feedback-positive`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: feedbackData,
   };
@@ -727,13 +750,15 @@ export const sendNegativeFeedback = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/feedback-negative`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: feedbackData,
   };
@@ -780,13 +805,15 @@ export const requestClassList = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "get",
     url: `${backendUrl}/seeds`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {},
   };
@@ -820,13 +847,15 @@ export const batchUploadInit = async ({
   if (fileCount === 0 || fileCount == null) {
     throw new ValueError("Number of pictures is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/new-batch-import`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {
       folderId: folderId,
@@ -978,6 +1007,7 @@ export const createOrGetFolder = async ({
       `Invalid normalized path: ${pathValidation.error.issues[0].message}`,
     );
   }
+  const authHeaders = getAuthHeaders(accessToken);
 
   const request = {
     method: "post",
@@ -985,7 +1015,7 @@ export const createOrGetFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {
       normalizedPath: normalizedPath,
@@ -1072,6 +1102,7 @@ export const updateFolder = async ({
       );
     }
   }
+  const authHeaders = getAuthHeaders(accessToken);
 
   const request = {
     method: "put",
@@ -1079,7 +1110,7 @@ export const updateFolder = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: {
       ...(name && { name }),
@@ -1116,13 +1147,15 @@ export const sendLogToBackend = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
+  const authHeaders = getAuthHeaders(accessToken);
+
   const request = {
     method: "post",
     url: `${backendUrl}/logs`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...getAuthHeaders(accessToken),
+      ...authHeaders,
     },
     data: logData,
   };

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -46,9 +46,7 @@ import {
 } from "./apiInterceptor";
 import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
 
-type GetApiAccessToken = (
-  options?: NachetAuthTokenOptions,
-) => Promise<string>;
+type GetApiAccessToken = (options?: NachetAuthTokenOptions) => Promise<string>;
 
 /**
  * Initialize API module with axios interceptor for authentication
@@ -166,11 +164,11 @@ const handleAxios = async <T>(request: {
   return data;
 };
 
-const getAuthHeaders = (
-  accessToken?: string | null,
-): Record<string, string> => {
-  if (accessToken === "" || accessToken === null) {
-    throw new ValueError("Access token is null or empty");
+// During the API auth migration, callers either pass an explicit token
+// or omit it so the Axios auth bridge can attach one.
+const getAuthHeaders = (accessToken?: string): Record<string, string> => {
+  if (accessToken === "") {
+    throw new ValueError("Access token is empty");
   }
 
   return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
@@ -206,7 +204,7 @@ export const checkUserRegistration = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<{ isRegistered: boolean }> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -235,7 +233,7 @@ export const readAzureStorageDir = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ReadAzureStorageDirApi> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -268,7 +266,7 @@ export const createAzureStorageDir = async ({
   folderName,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -309,7 +307,7 @@ export const deleteAzureStorageDir = async ({
   folderName,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -349,7 +347,7 @@ export const deleteFolder = async ({
   folderId,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderId: string;
 }): Promise<{ id: string; message: string }> => {
   if (!backendUrl) {
@@ -397,7 +395,7 @@ export const inferenceRequest = async ({
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderId: string;
 }): Promise<ImageSubmissionResponse> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -475,7 +473,7 @@ export const inferenceDirectRequest = async ({
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderId: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -546,7 +544,7 @@ export const fetchModelMetadata = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ModelMetadata[]> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -576,7 +574,7 @@ export const fetchDevices = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ApiDevicesResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -608,7 +606,7 @@ export const getWorkflowStatus = async ({
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<WorkflowStatusResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -643,7 +641,7 @@ export const getWorkflowResults = async ({
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -678,7 +676,7 @@ export const sendFeedbackNewBox = async ({
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -710,7 +708,7 @@ export const sendPositiveFeedback = async ({
 }: {
   feedbackData: FeedbackDataPositive;
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -742,7 +740,7 @@ export const sendNegativeFeedback = async ({
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -797,7 +795,7 @@ export const requestClassList = async ({
   accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<ApiSpeciesData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -829,7 +827,7 @@ export const batchUploadInit = async ({
   fileCount,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderId: string;
   fileCount: number;
 }): Promise<{
@@ -874,7 +872,7 @@ export const batchUploadImage = async ({
 }: {
   backendUrl: string;
   data: BatchUploadMetadata;
-  accessToken?: string | null;
+  accessToken?: string;
 }): Promise<BatchUploadImageResponse> => {
   const {
     sessionId,
@@ -985,7 +983,7 @@ export const createOrGetFolder = async ({
   description = "",
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   normalizedPath: string;
   description?: string;
 }): Promise<CreateOrGetFolderResponse> => {
@@ -1062,7 +1060,7 @@ export const updateFolder = async ({
   description,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   folderId: string;
   name?: string;
   description?: string;
@@ -1129,7 +1127,7 @@ export const sendLogToBackend = async ({
   logData,
 }: {
   backendUrl: string;
-  accessToken?: string | null;
+  accessToken?: string;
   logData: {
     level: "ERROR" | "WARNING" | "INFO" | "DEBUG";
     message: string;

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -1,46 +1,71 @@
-import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
-import {
-  IPublicClientApplication,
-  InteractionRequiredAuthError,
-  BrowserAuthError,
-} from "@azure/msal-browser";
+import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
 
-// Track if we're currently in a redirect flow to prevent loops
-let isRedirecting = false;
+let requestInterceptorId: number | null = null;
+let responseInterceptorId: number | null = null;
 
-/**
- * Checks if an error requires user interaction (redirect to login)
- * @param error - The error to check
- * @returns true if the error requires redirect authentication
- */
-export function shouldTriggerRedirect(error: unknown): boolean {
-  return (
-    error instanceof InteractionRequiredAuthError ||
-    (error instanceof BrowserAuthError &&
-      error.errorCode === "monitor_window_timeout")
+interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
+  nachetAuthRequired?: boolean;
+}
+
+interface AccessTokenOptions {
+  forceRefresh?: boolean;
+}
+
+type GetAccessToken = (options?: AccessTokenOptions) => Promise<string>;
+
+const assertAccessToken = (accessToken: string): string => {
+  if (!accessToken) {
+    throw new Error("Access token is null or empty");
+  }
+
+  return accessToken;
+};
+
+const requestRequiresNachetAuth = (
+  request?: InternalAxiosRequestConfig,
+): request is NachetAuthRequestConfig => {
+  return Boolean(
+    (request as NachetAuthRequestConfig | undefined)?.nachetAuthRequired,
   );
-}
+};
+
+export const clearAxiosInterceptors = (): void => {
+  if (requestInterceptorId !== null) {
+    axios.interceptors.request.eject(requestInterceptorId);
+    requestInterceptorId = null;
+  }
+
+  if (responseInterceptorId !== null) {
+    axios.interceptors.response.eject(responseInterceptorId);
+    responseInterceptorId = null;
+  }
+};
 
 /**
- * Reset the redirect flag (called after successful redirect)
- */
-export function resetRedirectFlag(): void {
-  isRedirecting = false;
-}
-
-/**
- * Configure axios interceptor to handle 401 Unauthorized errors
- * and trigger redirect authentication when tokens expire
+ * Configure axios interceptor to handle 401 Unauthorized errors and retry once
+ * with an access token from the active auth provider.
  *
- * @param msalInstance - MSAL instance for authentication
- * @param scopes - Array of scopes to request for tokens
+ * @param getAccessToken - Provider-neutral token getter
  */
-export function setupAxiosInterceptor(
-  msalInstance: IPublicClientApplication,
-  scopes: string[],
-): void {
+export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
+  clearAxiosInterceptors();
+
+  requestInterceptorId = axios.interceptors.request.use(
+    async (config: NachetAuthRequestConfig) => {
+      if (!config.nachetAuthRequired || config.headers?.Authorization) {
+        return config;
+      }
+
+      config.headers.Authorization = `Bearer ${assertAccessToken(
+        await getAccessToken(),
+      )}`;
+      return config;
+    },
+    (error) => Promise.reject(error),
+  );
+
   // Response interceptor to handle 401 errors
-  axios.interceptors.response.use(
+  responseInterceptorId = axios.interceptors.response.use(
     (response) => response, // Pass through successful responses
     async (error: AxiosError) => {
       const originalRequest = error.config as InternalAxiosRequestConfig & {
@@ -48,52 +73,26 @@ export function setupAxiosInterceptor(
       };
 
       // Check if this is a 401 error and we haven't already retried
-      if (error.response?.status === 401 && !originalRequest?._retry) {
+      if (
+        error.response?.status === 401 &&
+        requestRequiresNachetAuth(originalRequest) &&
+        !originalRequest?._retry
+      ) {
         originalRequest._retry = true;
 
-        // Prevent redirect loop
-        if (isRedirecting) {
-          return Promise.reject(error);
-        }
-
-        // Get the active account
-        const activeAccount = msalInstance.getActiveAccount();
-        const accounts = msalInstance.getAllAccounts();
-
-        if (!activeAccount && accounts.length === 0) {
-          // Let the error propagate - user is not authenticated
-          return Promise.reject(error);
-        }
-
-        const request = {
-          scopes,
-          account: activeAccount || accounts[0],
-        };
-
         try {
-          // Try to acquire token silently
-          const authResult = await msalInstance.acquireTokenSilent(request);
+          const accessToken = assertAccessToken(
+            await getAccessToken({ forceRefresh: true }),
+          );
 
           // Update the authorization header with new token
           if (originalRequest.headers) {
-            originalRequest.headers.Authorization = `Bearer ${authResult.accessToken}`;
+            originalRequest.headers.Authorization = `Bearer ${accessToken}`;
           }
 
           // Retry the original request with new token
           return axios(originalRequest);
         } catch (tokenError) {
-          // If silent token acquisition fails, check if redirect is needed
-          if (shouldTriggerRedirect(tokenError)) {
-            // Set redirect flag to prevent loops
-            isRedirecting = true;
-
-            // Trigger redirect authentication
-            await msalInstance.acquireTokenRedirect(request);
-            // This line will never be reached as user is redirected away
-            return Promise.reject(tokenError);
-          }
-
-          // For other errors, just reject
           return Promise.reject(tokenError);
         }
       }
@@ -102,4 +101,4 @@ export function setupAxiosInterceptor(
       return Promise.reject(error);
     },
   );
-}
+};

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -54,13 +54,17 @@ export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
 
   requestInterceptorId = axios.interceptors.request.use(
     async (config: NachetAuthRequestConfig) => {
-      if (!config.nachetAuthRequired || config.headers?.Authorization) {
+      if (
+        !requestRequiresNachetAuth(config) ||
+        config.headers.has("Authorization")
+      ) {
         return config;
       }
 
-      config.headers.Authorization = `Bearer ${assertAccessToken(
-        await getAccessToken(),
-      )}`;
+      config.headers.set(
+        "Authorization",
+        `Bearer ${assertAccessToken(await getAccessToken())}`,
+      );
       return config;
     },
     (error) => Promise.reject(error),
@@ -89,9 +93,7 @@ export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
           );
 
           // Update the authorization header with new token
-          if (originalRequest.headers) {
-            originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-          }
+          originalRequest.headers.set("Authorization", `Bearer ${accessToken}`);
 
           // Retry the original request with new token
           return axios(originalRequest);

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -7,6 +7,10 @@ interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
   nachetAuthRequired?: boolean;
 }
 
+interface RetriableNachetAuthRequestConfig extends NachetAuthRequestConfig {
+  _retry?: boolean;
+}
+
 interface AccessTokenOptions {
   forceRefresh?: boolean;
 }
@@ -22,11 +26,9 @@ const assertAccessToken = (accessToken: string): string => {
 };
 
 const requestRequiresNachetAuth = (
-  request?: InternalAxiosRequestConfig,
-): request is NachetAuthRequestConfig => {
-  return Boolean(
-    (request as NachetAuthRequestConfig | undefined)?.nachetAuthRequired,
-  );
+  request?: NachetAuthRequestConfig,
+): boolean => {
+  return request?.nachetAuthRequired === true;
 };
 
 export const clearAxiosInterceptors = (): void => {
@@ -68,15 +70,16 @@ export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
   responseInterceptorId = axios.interceptors.response.use(
     (response) => response, // Pass through successful responses
     async (error: AxiosError) => {
-      const originalRequest = error.config as InternalAxiosRequestConfig & {
-        _retry?: boolean;
-      };
+      const originalRequest = error.config as
+        | RetriableNachetAuthRequestConfig
+        | undefined;
 
       // Check if this is a 401 error and we haven't already retried
       if (
         error.response?.status === 401 &&
+        originalRequest &&
         requestRequiresNachetAuth(originalRequest) &&
-        !originalRequest?._retry
+        !originalRequest._retry
       ) {
         originalRequest._retry = true;
 

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -5,7 +5,7 @@ let responseInterceptorId: number | null = null;
 let apiAccessTokenProvider: GetAccessToken | null = null;
 
 interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
-  nachetAuthRequired?: boolean;
+  useNachetAuthProvider?: boolean;
 }
 
 interface RetriableNachetAuthRequestConfig extends NachetAuthRequestConfig {
@@ -26,10 +26,10 @@ const assertAccessToken = (accessToken: string): string => {
   return accessToken;
 };
 
-const requestRequiresNachetAuth = (
+const requestUsesNachetAuthProvider = (
   request?: NachetAuthRequestConfig,
 ): boolean => {
-  return request?.nachetAuthRequired === true;
+  return request?.useNachetAuthProvider === true;
 };
 
 export const clearAxiosInterceptors = (): void => {
@@ -63,7 +63,7 @@ export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
   requestInterceptorId = axios.interceptors.request.use(
     async (config: NachetAuthRequestConfig) => {
       if (
-        !requestRequiresNachetAuth(config) ||
+        !requestUsesNachetAuthProvider(config) ||
         config.headers.has("Authorization")
       ) {
         return config;
@@ -90,7 +90,7 @@ export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
       if (
         error.response?.status === 401 &&
         originalRequest &&
-        requestRequiresNachetAuth(originalRequest) &&
+        requestUsesNachetAuthProvider(originalRequest) &&
         !originalRequest._retry
       ) {
         originalRequest._retry = true;

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
 
 let requestInterceptorId: number | null = null;
 let responseInterceptorId: number | null = null;
+let apiAccessTokenProvider: GetAccessToken | null = null;
 
 interface NachetAuthRequestConfig extends InternalAxiosRequestConfig {
   nachetAuthRequired?: boolean;
@@ -41,6 +42,12 @@ export const clearAxiosInterceptors = (): void => {
     axios.interceptors.response.eject(responseInterceptorId);
     responseInterceptorId = null;
   }
+
+  apiAccessTokenProvider = null;
+};
+
+export const hasApiAccessTokenProvider = (): boolean => {
+  return apiAccessTokenProvider !== null;
 };
 
 /**
@@ -51,6 +58,7 @@ export const clearAxiosInterceptors = (): void => {
  */
 export const setupAxiosInterceptor = (getAccessToken: GetAccessToken): void => {
   clearAxiosInterceptors();
+  apiAccessTokenProvider = getAccessToken;
 
   requestInterceptorId = axios.interceptors.request.use(
     async (config: NachetAuthRequestConfig) => {

--- a/frontend/src/common/apiInterceptor.ts
+++ b/frontend/src/common/apiInterceptor.ts
@@ -20,7 +20,7 @@ type GetAccessToken = (options?: AccessTokenOptions) => Promise<string>;
 
 const assertAccessToken = (accessToken: string): string => {
   if (!accessToken) {
-    throw new Error("Access token is null or empty");
+    throw new Error("Access token is empty");
   }
 
   return accessToken;

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -83,6 +83,7 @@ describe("readAzureStorageDir", () => {
         "X-Session-ID": "test-session-id",
       },
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -227,6 +228,7 @@ describe("createAzureStorageDir", () => {
         folderName: folderName,
       },
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -307,6 +309,7 @@ describe("deleteAzureStorageDir", () => {
         folderName: folderName,
       },
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -430,6 +433,7 @@ describe("inferenceRequest", () => {
         magnification: mockImageObject.magnification,
       },
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -625,6 +629,7 @@ describe("fetchModelMetadata", () => {
       },
       data: {},
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -722,6 +727,7 @@ describe("requestClassList", () => {
       },
       data: {},
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -768,6 +774,7 @@ describe("batchUploadInit", () => {
         fileCount: nbPictures,
       },
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -848,6 +855,7 @@ describe("batchUploadImage", () => {
         image: mockBatchUploadData.imageDataUrl,
       },
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -1024,6 +1032,7 @@ describe("sendPositiveFeedback", () => {
       },
       data: mockPositiveFeedbackData,
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -1113,6 +1122,7 @@ describe("sendNegativeFeedback", () => {
       },
       data: mockNegativeFeedbackData,
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 
@@ -1195,6 +1205,7 @@ describe("sendFeedbackNewBox", () => {
       },
       data: mockNewBoxFeedbackData,
       withCredentials: true,
+      nachetAuthRequired: false,
     });
   });
 

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -16,8 +16,15 @@ import {
 import axios from "axios";
 import { AzureAPIError, ValueError } from "../error";
 
-// mock axios
-vi.mock("axios");
+// mock axios while keeping AxiosHeaders available for api.ts header checks
+vi.mock("axios", async () => {
+  const actual = await vi.importActual<typeof import("axios")>("axios");
+
+  return {
+    ...actual,
+    default: vi.fn(),
+  };
+});
 const mockedAxios = vi.mocked(axios);
 
 // mock errorLogger

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -83,7 +83,7 @@ describe("readAzureStorageDir", () => {
         "X-Session-ID": "test-session-id",
       },
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -228,7 +228,7 @@ describe("createAzureStorageDir", () => {
         folderName: folderName,
       },
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -309,7 +309,7 @@ describe("deleteAzureStorageDir", () => {
         folderName: folderName,
       },
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -433,7 +433,7 @@ describe("inferenceRequest", () => {
         magnification: mockImageObject.magnification,
       },
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -629,7 +629,7 @@ describe("fetchModelMetadata", () => {
       },
       data: {},
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -727,7 +727,7 @@ describe("requestClassList", () => {
       },
       data: {},
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -774,7 +774,7 @@ describe("batchUploadInit", () => {
         fileCount: nbPictures,
       },
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -855,7 +855,7 @@ describe("batchUploadImage", () => {
         image: mockBatchUploadData.imageDataUrl,
       },
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -1032,7 +1032,7 @@ describe("sendPositiveFeedback", () => {
       },
       data: mockPositiveFeedbackData,
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -1122,7 +1122,7 @@ describe("sendNegativeFeedback", () => {
       },
       data: mockNegativeFeedbackData,
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 
@@ -1205,7 +1205,7 @@ describe("sendFeedbackNewBox", () => {
       },
       data: mockNewBoxFeedbackData,
       withCredentials: true,
-      nachetAuthRequired: false,
+      useNachetAuthProvider: false,
     });
   });
 

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -2,6 +2,7 @@ import { describe, it, vi, beforeEach, expect } from "vitest";
 import {
   createAzureStorageDir,
   deleteAzureStorageDir,
+  fetchDevices,
   fetchModelMetadata,
   inferenceRequest,
   readAzureStorageDir,
@@ -34,6 +35,18 @@ vi.mock("../../logging", () => ({
 
 beforeEach(() => {
   mockedAxios.mockClear();
+});
+
+describe("protected API auth initialization", () => {
+  it("should fail closed before sending protected requests without auth initialization", async () => {
+    await expect(
+      fetchDevices({ backendUrl: "http://localhost:8080" }),
+    ).rejects.toThrow(
+      new ValueError("Auth provider is not initialized for API requests"),
+    );
+
+    expect(mockedAxios).not.toHaveBeenCalled();
+  });
 });
 
 describe("readAzureStorageDir", () => {

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -108,16 +108,7 @@ describe("readAzureStorageDir", () => {
         backendUrl: "http://localhost:8080",
         accessToken: "",
       }),
-    ).rejects.toThrow(new ValueError("Access token is null or empty"));
-  });
-
-  it("should throw ValueError for null access token", async () => {
-    await expect(
-      readAzureStorageDir({
-        backendUrl: "http://localhost:8080",
-        accessToken: null as any,
-      }),
-    ).rejects.toThrow(new ValueError("Access token is null or empty"));
+    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should throw error has response", async () => {
@@ -249,7 +240,7 @@ describe("createAzureStorageDir", () => {
         accessToken: "",
         folderName: "folder",
       }),
-    ).rejects.toThrow(new ValueError("Access token is null or empty"));
+    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should throw ValueError for empty folder name", async () => {
@@ -330,7 +321,7 @@ describe("deleteAzureStorageDir", () => {
         accessToken: "",
         folderName: "folder",
       }),
-    ).rejects.toThrow(new ValueError("Access token is null or empty"));
+    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should throw ValueError for empty folder name", async () => {
@@ -500,7 +491,7 @@ describe("inferenceRequest", () => {
         accessToken: "",
         folderId: "folder-id",
       }),
-    ).rejects.toThrow(new ValueError("Access token is null or empty"));
+    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should handle inference service errors", async () => {

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -1,0 +1,192 @@
+import axios from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupAxiosInterceptor } from "../apiInterceptor";
+import { clearApiAuthentication, fetchDevices, initializeApi } from "../api";
+
+const runRequest = async (config: Record<string, unknown>) => {
+  return axios({
+    method: "get",
+    url: "https://api.example.test/protected",
+    ...config,
+    adapter: async (requestConfig: any) => ({
+      data: null,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: requestConfig,
+    }),
+  } as any);
+};
+
+describe("apiInterceptor", () => {
+  const originalAdapter = axios.defaults.adapter;
+
+  afterEach(() => {
+    clearApiAuthentication();
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  it("attaches a bearer token to protected Nachet API requests", async () => {
+    setupAxiosInterceptor(vi.fn().mockResolvedValue("access-token"));
+
+    const response = await runRequest({ nachetAuthRequired: true });
+
+    expect(response.config.headers.Authorization).toBe("Bearer access-token");
+  });
+
+  it("does not attach a bearer token to requests without the Nachet API marker", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("access-token");
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await runRequest({});
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(response.config.headers.Authorization).toBeUndefined();
+  });
+
+  it("fails closed when a protected request cannot get a token", async () => {
+    setupAxiosInterceptor(vi.fn().mockResolvedValue(""));
+
+    await expect(runRequest({ nachetAuthRequired: true })).rejects.toThrow(
+      "Access token is null or empty",
+    );
+  });
+
+  it("does not retry unrelated 401 responses with a bearer token", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("access-token");
+    setupAxiosInterceptor(getAccessToken);
+
+    await expect(
+      axios({
+        method: "get",
+        url: "https://example.test/not-nachet",
+        adapter: async (requestConfig: any) => {
+          return Promise.reject({
+            config: requestConfig,
+            response: {
+              data: null,
+              status: 401,
+              statusText: "Unauthorized",
+              headers: {},
+              config: requestConfig,
+            },
+          });
+        },
+      } as any),
+    ).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("retries marked protected requests once with a replacement token", async () => {
+    const getAccessToken = vi
+      .fn()
+      .mockResolvedValueOnce("initial-token")
+      .mockResolvedValueOnce("retry-token");
+    const authorizationHeaders: string[] = [];
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await axios({
+      method: "get",
+      url: "https://api.example.test/protected",
+      nachetAuthRequired: true,
+      adapter: async (requestConfig: any) => {
+        authorizationHeaders.push(requestConfig.headers.Authorization);
+        if (authorizationHeaders.length === 1) {
+          return Promise.reject({
+            config: requestConfig,
+            response: {
+              data: null,
+              status: 401,
+              statusText: "Unauthorized",
+              headers: {},
+              config: requestConfig,
+            },
+          });
+        }
+
+        return {
+          data: { ok: true },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: requestConfig,
+        };
+      },
+    } as any);
+
+    expect(response.data).toEqual({ ok: true });
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(getAccessToken).toHaveBeenNthCalledWith(1);
+    expect(getAccessToken).toHaveBeenNthCalledWith(2, { forceRefresh: true });
+    expect(authorizationHeaders[0]).toBe("Bearer initial-token");
+    expect(authorizationHeaders[1]).toBe("Bearer retry-token");
+  });
+
+  it("attaches tokens to API helper requests through initializeApi", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("api-helper-token");
+    const authorizationHeaders: string[] = [];
+    axios.defaults.adapter = async (requestConfig: any) => {
+      authorizationHeaders.push(requestConfig.headers.Authorization);
+      return {
+        data: { devices: [] },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: requestConfig,
+      };
+    };
+
+    initializeApi(getAccessToken);
+
+    await expect(
+      fetchDevices({ backendUrl: "https://api.example.test" }),
+    ).resolves.toEqual({ devices: [] });
+    expect(getAccessToken).toHaveBeenCalledOnce();
+    expect(authorizationHeaders).toEqual(["Bearer api-helper-token"]);
+  });
+
+  it("retries stale explicit-token requests with a replacement token", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("retry-token");
+    const authorizationHeaders: string[] = [];
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await axios({
+      method: "get",
+      url: "https://api.example.test/protected",
+      nachetAuthRequired: true,
+      headers: { Authorization: "Bearer stale-token" },
+      adapter: async (requestConfig: any) => {
+        authorizationHeaders.push(requestConfig.headers.Authorization);
+        if (authorizationHeaders.length === 1) {
+          return Promise.reject({
+            config: requestConfig,
+            response: {
+              data: null,
+              status: 401,
+              statusText: "Unauthorized",
+              headers: {},
+              config: requestConfig,
+            },
+          });
+        }
+
+        return {
+          data: { ok: true },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: requestConfig,
+        };
+      },
+    } as any);
+
+    expect(response.data).toEqual({ ok: true });
+    expect(getAccessToken).toHaveBeenCalledOnce();
+    expect(getAccessToken).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(authorizationHeaders[0]).toBe("Bearer stale-token");
+    expect(authorizationHeaders[1]).toBe("Bearer retry-token");
+  });
+});

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -4,7 +4,10 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from "axios";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setupAxiosInterceptor } from "../apiInterceptor";
+import {
+  hasApiAccessTokenProvider,
+  setupAxiosInterceptor,
+} from "../apiInterceptor";
 import { clearApiAuthentication, fetchDevices, initializeApi } from "../api";
 
 interface NachetAuthAxiosRequestConfig extends AxiosRequestConfig {
@@ -57,6 +60,18 @@ describe("apiInterceptor", () => {
   afterEach(() => {
     clearApiAuthentication();
     axios.defaults.adapter = originalAdapter;
+  });
+
+  it("tracks whether the API access token provider is configured", () => {
+    expect(hasApiAccessTokenProvider()).toBe(false);
+
+    setupAxiosInterceptor(vi.fn().mockResolvedValue("access-token"));
+
+    expect(hasApiAccessTokenProvider()).toBe(true);
+
+    clearApiAuthentication();
+
+    expect(hasApiAccessTokenProvider()).toBe(false);
   });
 
   it("attaches a bearer token to protected Nachet API requests", async () => {

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -79,7 +79,7 @@ describe("apiInterceptor", () => {
 
     const response = await runRequest({ useNachetAuthProvider: true });
 
-    expect(response.config.headers.Authorization).toBe("Bearer access-token");
+    expect(getAuthorizationHeader(response.config)).toBe("Bearer access-token");
   });
 
   it("does not attach a bearer token to requests without the Nachet API marker", async () => {
@@ -89,7 +89,7 @@ describe("apiInterceptor", () => {
     const response = await runRequest({});
 
     expect(getAccessToken).not.toHaveBeenCalled();
-    expect(response.config.headers.Authorization).toBeUndefined();
+    expect(getAuthorizationHeader(response.config)).toBeUndefined();
   });
 
   it("does not overwrite an existing authorization header", async () => {

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -11,7 +11,7 @@ import {
 import { clearApiAuthentication, fetchDevices, initializeApi } from "../api";
 
 interface NachetAuthAxiosRequestConfig extends AxiosRequestConfig {
-  nachetAuthRequired?: boolean;
+  useNachetAuthProvider?: boolean;
 }
 
 const okResponse = (
@@ -77,7 +77,7 @@ describe("apiInterceptor", () => {
   it("attaches a bearer token to protected Nachet API requests", async () => {
     setupAxiosInterceptor(vi.fn().mockResolvedValue("access-token"));
 
-    const response = await runRequest({ nachetAuthRequired: true });
+    const response = await runRequest({ useNachetAuthProvider: true });
 
     expect(response.config.headers.Authorization).toBe("Bearer access-token");
   });
@@ -97,7 +97,7 @@ describe("apiInterceptor", () => {
     setupAxiosInterceptor(getAccessToken);
 
     const response = await runRequest({
-      nachetAuthRequired: true,
+      useNachetAuthProvider: true,
       headers: { authorization: "Bearer explicit-token" },
     });
 
@@ -110,7 +110,7 @@ describe("apiInterceptor", () => {
   it("fails closed when a protected request cannot get a token", async () => {
     setupAxiosInterceptor(vi.fn().mockResolvedValue(""));
 
-    await expect(runRequest({ nachetAuthRequired: true })).rejects.toThrow(
+    await expect(runRequest({ useNachetAuthProvider: true })).rejects.toThrow(
       "Access token is null or empty",
     );
   });
@@ -154,7 +154,7 @@ describe("apiInterceptor", () => {
     const requestConfig: NachetAuthAxiosRequestConfig = {
       method: "get",
       url: "https://api.example.test/protected",
-      nachetAuthRequired: true,
+      useNachetAuthProvider: true,
       adapter: retryAdapter,
     };
 
@@ -202,7 +202,7 @@ describe("apiInterceptor", () => {
     const requestConfig: NachetAuthAxiosRequestConfig = {
       method: "get",
       url: "https://api.example.test/protected",
-      nachetAuthRequired: true,
+      useNachetAuthProvider: true,
       headers: { Authorization: "Bearer stale-token" },
       adapter: retryAdapter,
     };

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -111,7 +111,7 @@ describe("apiInterceptor", () => {
     setupAxiosInterceptor(vi.fn().mockResolvedValue(""));
 
     await expect(runRequest({ useNachetAuthProvider: true })).rejects.toThrow(
-      "Access token is null or empty",
+      "Access token is empty",
     );
   });
 

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -1,21 +1,54 @@
-import axios from "axios";
+import axios, {
+  type AxiosAdapter,
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig,
+} from "axios";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setupAxiosInterceptor } from "../apiInterceptor";
 import { clearApiAuthentication, fetchDevices, initializeApi } from "../api";
 
-const runRequest = async (config: Record<string, unknown>) => {
+interface NachetAuthAxiosRequestConfig extends AxiosRequestConfig {
+  nachetAuthRequired?: boolean;
+}
+
+const okResponse = (
+  requestConfig: InternalAxiosRequestConfig,
+  data: unknown = null,
+) => ({
+  data,
+  status: 200,
+  statusText: "OK",
+  headers: {},
+  config: requestConfig,
+});
+
+const unauthorizedResponse = (requestConfig: InternalAxiosRequestConfig) => ({
+  config: requestConfig,
+  response: {
+    data: null,
+    status: 401,
+    statusText: "Unauthorized",
+    headers: {},
+    config: requestConfig,
+  },
+});
+
+const getAuthorizationHeader = (
+  requestConfig: InternalAxiosRequestConfig,
+): string | undefined => {
+  const authorizationHeader = requestConfig.headers.Authorization;
+  return typeof authorizationHeader === "string"
+    ? authorizationHeader
+    : undefined;
+};
+
+const runRequest = async (config: NachetAuthAxiosRequestConfig) => {
   return axios({
     method: "get",
     url: "https://api.example.test/protected",
     ...config,
-    adapter: async (requestConfig: any) => ({
-      data: null,
-      status: 200,
-      statusText: "OK",
-      headers: {},
-      config: requestConfig,
-    }),
-  } as any);
+    adapter: async (requestConfig) => okResponse(requestConfig),
+  });
 };
 
 describe("apiInterceptor", () => {
@@ -60,19 +93,10 @@ describe("apiInterceptor", () => {
       axios({
         method: "get",
         url: "https://example.test/not-nachet",
-        adapter: async (requestConfig: any) => {
-          return Promise.reject({
-            config: requestConfig,
-            response: {
-              data: null,
-              status: 401,
-              statusText: "Unauthorized",
-              headers: {},
-              config: requestConfig,
-            },
-          });
+        adapter: async (requestConfig) => {
+          return Promise.reject(unauthorizedResponse(requestConfig));
         },
-      } as any),
+      }),
     ).rejects.toMatchObject({
       response: { status: 401 },
     });
@@ -85,37 +109,26 @@ describe("apiInterceptor", () => {
       .fn()
       .mockResolvedValueOnce("initial-token")
       .mockResolvedValueOnce("retry-token");
-    const authorizationHeaders: string[] = [];
+    const authorizationHeaders: Array<string | undefined> = [];
     setupAxiosInterceptor(getAccessToken);
 
-    const response = await axios({
+    const retryAdapter: AxiosAdapter = async (requestConfig) => {
+      authorizationHeaders.push(getAuthorizationHeader(requestConfig));
+      if (authorizationHeaders.length === 1) {
+        return Promise.reject(unauthorizedResponse(requestConfig));
+      }
+
+      return okResponse(requestConfig, { ok: true });
+    };
+
+    const requestConfig: NachetAuthAxiosRequestConfig = {
       method: "get",
       url: "https://api.example.test/protected",
       nachetAuthRequired: true,
-      adapter: async (requestConfig: any) => {
-        authorizationHeaders.push(requestConfig.headers.Authorization);
-        if (authorizationHeaders.length === 1) {
-          return Promise.reject({
-            config: requestConfig,
-            response: {
-              data: null,
-              status: 401,
-              statusText: "Unauthorized",
-              headers: {},
-              config: requestConfig,
-            },
-          });
-        }
+      adapter: retryAdapter,
+    };
 
-        return {
-          data: { ok: true },
-          status: 200,
-          statusText: "OK",
-          headers: {},
-          config: requestConfig,
-        };
-      },
-    } as any);
+    const response = await axios(requestConfig);
 
     expect(response.data).toEqual({ ok: true });
     expect(getAccessToken).toHaveBeenCalledTimes(2);
@@ -127,16 +140,10 @@ describe("apiInterceptor", () => {
 
   it("attaches tokens to API helper requests through initializeApi", async () => {
     const getAccessToken = vi.fn().mockResolvedValue("api-helper-token");
-    const authorizationHeaders: string[] = [];
-    axios.defaults.adapter = async (requestConfig: any) => {
-      authorizationHeaders.push(requestConfig.headers.Authorization);
-      return {
-        data: { devices: [] },
-        status: 200,
-        statusText: "OK",
-        headers: {},
-        config: requestConfig,
-      };
+    const authorizationHeaders: Array<string | undefined> = [];
+    axios.defaults.adapter = async (requestConfig) => {
+      authorizationHeaders.push(getAuthorizationHeader(requestConfig));
+      return okResponse(requestConfig, { devices: [] });
     };
 
     initializeApi(getAccessToken);
@@ -150,38 +157,27 @@ describe("apiInterceptor", () => {
 
   it("retries stale explicit-token requests with a replacement token", async () => {
     const getAccessToken = vi.fn().mockResolvedValue("retry-token");
-    const authorizationHeaders: string[] = [];
+    const authorizationHeaders: Array<string | undefined> = [];
     setupAxiosInterceptor(getAccessToken);
 
-    const response = await axios({
+    const retryAdapter: AxiosAdapter = async (requestConfig) => {
+      authorizationHeaders.push(getAuthorizationHeader(requestConfig));
+      if (authorizationHeaders.length === 1) {
+        return Promise.reject(unauthorizedResponse(requestConfig));
+      }
+
+      return okResponse(requestConfig, { ok: true });
+    };
+
+    const requestConfig: NachetAuthAxiosRequestConfig = {
       method: "get",
       url: "https://api.example.test/protected",
       nachetAuthRequired: true,
       headers: { Authorization: "Bearer stale-token" },
-      adapter: async (requestConfig: any) => {
-        authorizationHeaders.push(requestConfig.headers.Authorization);
-        if (authorizationHeaders.length === 1) {
-          return Promise.reject({
-            config: requestConfig,
-            response: {
-              data: null,
-              status: 401,
-              statusText: "Unauthorized",
-              headers: {},
-              config: requestConfig,
-            },
-          });
-        }
+      adapter: retryAdapter,
+    };
 
-        return {
-          data: { ok: true },
-          status: 200,
-          statusText: "OK",
-          headers: {},
-          config: requestConfig,
-        };
-      },
-    } as any);
+    const response = await axios(requestConfig);
 
     expect(response.data).toEqual({ ok: true });
     expect(getAccessToken).toHaveBeenCalledOnce();

--- a/frontend/src/common/tests/apiInterceptor.test.ts
+++ b/frontend/src/common/tests/apiInterceptor.test.ts
@@ -36,7 +36,7 @@ const unauthorizedResponse = (requestConfig: InternalAxiosRequestConfig) => ({
 const getAuthorizationHeader = (
   requestConfig: InternalAxiosRequestConfig,
 ): string | undefined => {
-  const authorizationHeader = requestConfig.headers.Authorization;
+  const authorizationHeader = requestConfig.headers.get("Authorization");
   return typeof authorizationHeader === "string"
     ? authorizationHeader
     : undefined;
@@ -75,6 +75,21 @@ describe("apiInterceptor", () => {
 
     expect(getAccessToken).not.toHaveBeenCalled();
     expect(response.config.headers.Authorization).toBeUndefined();
+  });
+
+  it("does not overwrite an existing authorization header", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("access-token");
+    setupAxiosInterceptor(getAccessToken);
+
+    const response = await runRequest({
+      nachetAuthRequired: true,
+      headers: { authorization: "Bearer explicit-token" },
+    });
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(getAuthorizationHeader(response.config)).toBe(
+      "Bearer explicit-token",
+    );
   });
 
   it("fails closed when a protected request cannot get a token", async () => {

--- a/frontend/src/logging/ErrorLogger.ts
+++ b/frontend/src/logging/ErrorLogger.ts
@@ -70,29 +70,32 @@ class ErrorLogger {
         "X-Correlation-ID": this.getCorrelationId(),
       };
 
-      // Try to get access token if token provider is available
-      if (this.tokenProvider) {
-        try {
-          const token = await this.tokenProvider();
-          if (token) {
-            headers["Authorization"] = `Bearer ${token}`;
-          }
-        } catch (tokenError) {
-          // Backend logging is protected when the auth bridge is active.
-          // Keep console fallback rather than posting an unauthenticated log.
-          console.warn(
-            "Skipping backend log submission because log auth failed:",
-            tokenError,
-          );
-          return;
-        }
+      if (!this.tokenProvider) {
+        console.warn(
+          "Skipping backend log submission because log auth is not initialized.",
+        );
+        return;
+      }
 
-        if (!headers.Authorization) {
-          console.warn(
-            "Skipping backend log submission because no auth token is available.",
-          );
-          return;
+      try {
+        const token = await this.tokenProvider();
+        if (token) {
+          headers["Authorization"] = `Bearer ${token}`;
         }
+      } catch (tokenError) {
+        // Keep console fallback rather than posting an unauthenticated log.
+        console.warn(
+          "Skipping backend log submission because log auth failed:",
+          tokenError,
+        );
+        return;
+      }
+
+      if (!headers.Authorization) {
+        console.warn(
+          "Skipping backend log submission because no auth token is available.",
+        );
+        return;
       }
 
       await axios.post(this.apiEndpoint, logData, {

--- a/frontend/src/logging/ErrorLogger.ts
+++ b/frontend/src/logging/ErrorLogger.ts
@@ -14,6 +14,22 @@ interface LogEntry {
 
 type TokenProvider = () => Promise<string | null>;
 
+const formatRejectionReason = (reason: unknown): string => {
+  if (reason instanceof Error) {
+    return reason.message;
+  }
+
+  if (typeof reason === "string") {
+    return reason;
+  }
+
+  try {
+    return JSON.stringify(reason) ?? String(reason);
+  } catch {
+    return String(reason);
+  }
+};
+
 class ErrorLogger {
   private apiEndpoint: string;
   private sessionId: string;
@@ -183,11 +199,16 @@ class ErrorLogger {
   // Log unhandled promise rejections
   public setupGlobalHandlers(): void {
     window.addEventListener("unhandledrejection", (event) => {
-      this.logError(
-        `Unhandled Promise Rejection: ${event.reason}`,
-        event.reason instanceof Error
-          ? event.reason
-          : new Error(String(event.reason)),
+      const rejectionReason = event.reason;
+      const rejectionMessage = formatRejectionReason(rejectionReason);
+      const rejectionError =
+        rejectionReason instanceof Error
+          ? rejectionReason
+          : new Error(rejectionMessage);
+
+      void this.logError(
+        `Unhandled Promise Rejection: ${rejectionMessage}`,
+        rejectionError,
         { promise: event.promise },
       );
     });

--- a/frontend/src/logging/ErrorLogger.ts
+++ b/frontend/src/logging/ErrorLogger.ts
@@ -78,11 +78,20 @@ class ErrorLogger {
             headers["Authorization"] = `Bearer ${token}`;
           }
         } catch (tokenError) {
-          // Log token acquisition failure but continue without auth
+          // Backend logging is protected when the auth bridge is active.
+          // Keep console fallback rather than posting an unauthenticated log.
           console.warn(
-            "Failed to acquire token for logs endpoint:",
+            "Skipping backend log submission because log auth failed:",
             tokenError,
           );
+          return;
+        }
+
+        if (!headers.Authorization) {
+          console.warn(
+            "Skipping backend log submission because no auth token is available.",
+          );
+          return;
         }
       }
 

--- a/frontend/src/logging/ErrorLogger.ts
+++ b/frontend/src/logging/ErrorLogger.ts
@@ -12,7 +12,7 @@ interface LogEntry {
   extra?: Record<string, any>;
 }
 
-type TokenProvider = () => Promise<string | null>;
+type TokenProvider = () => Promise<string>;
 
 const formatRejectionReason = (reason: unknown): string => {
   if (reason instanceof Error) {
@@ -42,7 +42,7 @@ class ErrorLogger {
     this.tokenProvider = tokenProvider || null;
   }
 
-  public setTokenProvider(tokenProvider: TokenProvider): void {
+  public setTokenProvider(tokenProvider: TokenProvider | null): void {
     this.tokenProvider = tokenProvider;
   }
 

--- a/frontend/src/logging/tests/ErrorLogger.test.ts
+++ b/frontend/src/logging/tests/ErrorLogger.test.ts
@@ -14,6 +14,7 @@ describe("ErrorLogger (Singleton)", () => {
   beforeEach(() => {
     // Reset mocks
     vi.clearAllMocks();
+    errorLogger.setTokenProvider(vi.fn().mockResolvedValue("test-token"));
 
     // Mock axios.post
     (axios.post as any).mockResolvedValue({ data: { success: true } });
@@ -58,7 +59,7 @@ describe("ErrorLogger (Singleton)", () => {
       );
 
       // Reset token provider
-      errorLogger.setTokenProvider(null as any);
+      errorLogger.setTokenProvider(vi.fn().mockResolvedValue("test-token"));
     });
   });
 
@@ -199,7 +200,7 @@ describe("ErrorLogger (Singleton)", () => {
       expect(axios.post).not.toHaveBeenCalled();
 
       // Reset token provider
-      errorLogger.setTokenProvider(null as any);
+      errorLogger.setTokenProvider(vi.fn().mockResolvedValue("test-token"));
     });
 
     it("should skip backend logging if token provider returns null", async () => {
@@ -214,7 +215,18 @@ describe("ErrorLogger (Singleton)", () => {
       expect(axios.post).not.toHaveBeenCalled();
 
       // Reset token provider
+      errorLogger.setTokenProvider(vi.fn().mockResolvedValue("test-token"));
+    });
+
+    it("should skip backend logging if token provider is not initialized", async () => {
       errorLogger.setTokenProvider(null as any);
+
+      await errorLogger.logError("Test");
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Skipping backend log submission because log auth is not initialized.",
+      );
+      expect(axios.post).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/logging/tests/ErrorLogger.test.ts
+++ b/frontend/src/logging/tests/ErrorLogger.test.ts
@@ -9,6 +9,7 @@ describe("ErrorLogger (Singleton)", () => {
   let consoleErrorSpy: any;
   let consoleWarnSpy: any;
   let consoleInfoSpy: any;
+  const mockedAxiosPost = vi.mocked(axios.post);
   const originalEnv = import.meta.env.VITE_LOG_API_URL;
 
   beforeEach(() => {
@@ -17,7 +18,7 @@ describe("ErrorLogger (Singleton)", () => {
     errorLogger.setTokenProvider(vi.fn().mockResolvedValue("test-token"));
 
     // Mock axios.post
-    (axios.post as any).mockResolvedValue({ data: { success: true } });
+    mockedAxiosPost.mockResolvedValue({ data: { success: true } });
 
     // Spy on console methods
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -30,7 +31,7 @@ describe("ErrorLogger (Singleton)", () => {
     consoleWarnSpy.mockRestore();
     consoleInfoSpy.mockRestore();
     // Reset token provider
-    errorLogger.setTokenProvider(null as any);
+    errorLogger.setTokenProvider(null);
     import.meta.env.VITE_LOG_API_URL = originalEnv;
   });
 
@@ -175,7 +176,7 @@ describe("ErrorLogger (Singleton)", () => {
 
     it("should fallback to console if axios fails", async () => {
       const axiosError = new Error("Network error");
-      (axios.post as any).mockRejectedValueOnce(axiosError);
+      mockedAxiosPost.mockRejectedValueOnce(axiosError);
 
       await errorLogger.logError("Test error");
 
@@ -203,8 +204,8 @@ describe("ErrorLogger (Singleton)", () => {
       errorLogger.setTokenProvider(vi.fn().mockResolvedValue("test-token"));
     });
 
-    it("should skip backend logging if token provider returns null", async () => {
-      const tokenProvider = vi.fn().mockResolvedValue(null);
+    it("should skip backend logging if token provider returns an empty token", async () => {
+      const tokenProvider = vi.fn().mockResolvedValue("");
       errorLogger.setTokenProvider(tokenProvider);
 
       await errorLogger.logError("Test");
@@ -219,7 +220,7 @@ describe("ErrorLogger (Singleton)", () => {
     });
 
     it("should skip backend logging if token provider is not initialized", async () => {
-      errorLogger.setTokenProvider(null as any);
+      errorLogger.setTokenProvider(null);
 
       await errorLogger.logError("Test");
 

--- a/frontend/src/logging/tests/ErrorLogger.test.ts
+++ b/frontend/src/logging/tests/ErrorLogger.test.ts
@@ -186,45 +186,32 @@ describe("ErrorLogger (Singleton)", () => {
       );
     });
 
-    it("should continue without auth if token provider fails", async () => {
+    it("should skip backend logging if token provider fails", async () => {
       const tokenProvider = vi.fn().mockRejectedValue(new Error("Token error"));
       errorLogger.setTokenProvider(tokenProvider);
 
       await errorLogger.logError("Test");
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "Failed to acquire token for logs endpoint:",
+        "Skipping backend log submission because log auth failed:",
         expect.any(Error),
       );
-      expect(axios.post).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.not.objectContaining({
-            Authorization: expect.anything(),
-          }),
-        }),
-      );
+      expect(axios.post).not.toHaveBeenCalled();
 
       // Reset token provider
       errorLogger.setTokenProvider(null as any);
     });
 
-    it("should continue without auth if token provider returns null", async () => {
+    it("should skip backend logging if token provider returns null", async () => {
       const tokenProvider = vi.fn().mockResolvedValue(null);
       errorLogger.setTokenProvider(tokenProvider);
 
       await errorLogger.logError("Test");
 
-      expect(axios.post).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.not.objectContaining({
-            Authorization: expect.anything(),
-          }),
-        }),
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Skipping backend log submission because no auth token is available.",
       );
+      expect(axios.post).not.toHaveBeenCalled();
 
       // Reset token provider
       errorLogger.setTokenProvider(null as any);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,14 +11,8 @@ import { CacheProvider } from "@emotion/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { createEmotionCache } from "./common/emotionCache";
 import { ErrorBoundary } from "@components/body/index.ts";
-import { errorLogger } from "./logging";
 import { theme } from "./theme";
-import {
-  acquireAccessToken,
-  shouldTriggerRedirect,
-  resetAuthRedirectFlag,
-} from "./common/auth";
-import { initializeApi, resetRedirectFlag } from "./common/api";
+import { resetAuthRedirectFlag } from "./common/auth";
 import {
   getApiScopeClaim,
   getConfiguredAuthProvider,
@@ -113,7 +107,6 @@ const initializeMsalAndRender = async (): Promise<void> => {
       // Set the active account after successful redirect
       msalInstance.setActiveAccount(response.account);
       // Reset redirect flags to allow future redirects if needed
-      resetRedirectFlag(); // For axios interceptor
       resetAuthRedirectFlag(); // For auth.ts
     } else {
       // Check if we have any cached accounts
@@ -122,37 +115,6 @@ const initializeMsalAndRender = async (): Promise<void> => {
         msalInstance.setActiveAccount(accounts[0]);
       }
     }
-
-    // Initialize axios interceptor for authentication
-    const scopes = apiScopeClaim ? [apiScopeClaim] : [];
-    initializeApi(msalInstance, scopes);
-
-    // Set up token provider for error logger
-    errorLogger.setTokenProvider(async () => {
-      try {
-        const token = await acquireAccessToken(msalInstance, scopes);
-        return token;
-      } catch (error) {
-        // Check if error requires redirect
-        if (shouldTriggerRedirect(error)) {
-          console.error(
-            "Error logger: Token acquisition failed. Redirecting to login...",
-          );
-          // Trigger redirect authentication
-          const activeAccount = msalInstance.getActiveAccount();
-          const accounts = msalInstance.getAllAccounts();
-          if (activeAccount || accounts.length > 0) {
-            await msalInstance.acquireTokenRedirect({
-              scopes,
-              account: activeAccount || accounts[0],
-            });
-          }
-        }
-        // If token acquisition fails, return null (logs will be sent without auth)
-        console.warn("Failed to acquire token for error logger:", error);
-        return null;
-      }
-    });
 
     renderApp(msalInstance);
   } catch (error) {


### PR DESCRIPTION
Relates to #818  
Follows #836

## Summary

This PR connects the shared Nachet auth provider to frontend API requests.

The main change is that protected Nachet API calls can now get tokens through the active auth provider instead of being tied directly to MSAL. The bridge is still narrow: it only affects requests marked as protected Nachet API requests, keeps unrelated Axios traffic untouched, and retries a 401 once with a fresh token.

## What Changed

- Added an auth bridge inside `NachetAuthProvider` to initialize API token access from the shared auth interface.
- Updated the Axios interceptor to attach bearer tokens only to protected Nachet API requests.
- Scoped 401 retry behavior so only protected Nachet API requests can retry with a refreshed token.
- Added fail-closed behavior when protected API requests run before auth is initialized.
- Updated backend API helpers and logging so they respect the new protected-request boundary.
- Added tests for token attachment, retry behavior, auth initialization, bridge cleanup, and logging behavior.

## Notes

This PR does not migrate hooks/components away from direct MSAL usage yet. That is intentionally left for the next slice, so this review can stay focused on the API bridge behavior.

This PR also does not change backend token validation. Provider-neutral backend JWT/OIDC validation remains a separate follow-up.

## Validation

- `npm run test -- --run src/auth/tests/NachetAuthProvider.apiBridge.test.tsx src/common/tests/apiInterceptor.test.ts src/common/tests/api.test.ts src/logging/tests/ErrorLogger.test.ts`
- `npm run build`
- `git diff --check origin/main...HEAD`