### PR TITLE
Issue #755: Deconvolute the renovate version bumping by splitting into distinct workflow files

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -1,7 +1,7 @@
 ---
 name: backend lint
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: read
 
@@ -26,6 +26,7 @@ on:
       - "backend/**"
       - "backend/pyproject.toml"
       - ".github/workflows/backend-*"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -33,7 +34,7 @@ defaults:
 
 jobs:
   nachet-pyproject-version-bump:
-    # if: github.event.pull_request.merged != true
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
     name: nachet-backend-pyproject-version-bump
     uses: ai-cfia/github-workflows/.github/workflows/workflow-version-bump-python-mono.yml@main
     secrets: inherit
@@ -42,54 +43,12 @@ jobs:
       package-name: "nachet-backend"
       working-directory: backend
 
-  bump-version-renovate:
-    needs: [nachet-pyproject-version-bump]
-    # Failure of nachet-pyproject-version-bump indicates that version in pyproject.toml has not been updated.
-    if: ${{ !cancelled() && (github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') && needs.nachet-pyproject-version-bump.result == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-          
-      - name: Install uv
-        uses: astral-sh/setup-uv@5c62c5926145985eec91f09e2e0a75f40daed929
-        with:
-          version: "latest"
-
-      - name: Bump version for Renovate PRs
-        run: |
-          uv version --bump patch
-
-      - name: Update lock file for Renovate PRs
-        run: uv lock
-
-      - name: Commit & push changes
-        uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
-        with:
-          message: "chore: bump backend version for Renovate PRs"
-          add: "."
-          pull: "--rebase --autostash"
-          author_name: "github-actions[bot]"
-          author_email: "github-actions[bot]@users.noreply.github.com"
-
   backend-lint:
     name: backend-lint-test-python
     uses: ai-cfia/github-workflows/.github/workflows/workflow-lint-python-mono.yml@main
     secrets: inherit
     with:
       working-directory: backend
-  # bytebase-sql-review:
-  #   uses: ai-cfia/github-workflows/.github/workflows/workflow-bytebase-sql-review.yml@main
-  #   secrets: inherit
 
   mkd-check:
     name: workflow-markdown-check
@@ -125,7 +84,6 @@ jobs:
 
       - name: Check if uv.lock is up to date
         run: |
-          # Generate a new lock file and compare with existing
           uv lock --check
         working-directory: backend
 

--- a/.github/workflows/backend-renovate-bump.yml
+++ b/.github/workflows/backend-renovate-bump.yml
@@ -2,8 +2,8 @@
 name: Backend Renovate
 
 permissions:
-  actions: write
-  contents: write
+  actions: read
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -28,11 +28,11 @@ defaults:
 jobs:
   bump-version:
     name: Bump version
-    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Slumberdac' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ (github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      contents: write
+      actions: read
+      contents: read
       pull-requests: read
     steps:
       - name: Checkout PR branch
@@ -96,6 +96,8 @@ jobs:
 
       - name: Commit & push changes
         if: steps.check.outputs.changed == 'true'
+        permissions:
+          contents: write
         uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
         with:
           message: "chore: bump backend version for Renovate PRs"

--- a/.github/workflows/backend-renovate-bump.yml
+++ b/.github/workflows/backend-renovate-bump.yml
@@ -1,0 +1,111 @@
+---
+name: Backend Renovate
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "backend/pyproject.toml"
+      - ".github/workflows/backend-*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  bump-version:
+    name: Bump version
+    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Slumberdac' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5c62c5926145985eec91f09e2e0a75f40daed929
+        with:
+          version: "latest"
+
+      - name: Bump version for Renovate PRs
+        id: bump
+        run: |
+          latest_version=""
+          tags=$(git tag --list "nachet-backend-v*" --sort=-creatordate | head -n 10)
+
+          for tag in $tags; do
+            version=$(echo "$tag" | grep -oP '(?<=nachet-backend-v)[0-9]+\.[0-9]+\.[0-9]+')
+            if [ -n "$version" ]; then
+              latest_version="$version"
+              break
+            fi
+          done
+
+          if [ -z "$latest_version" ]; then
+            latest_version="0.0.0"
+          fi
+
+          current=$(uv version --short)
+          desired=$(echo "$latest_version" | awk -F. -v OFS=. '{ $NF++; print }')
+
+          echo "Latest released: $latest_version"
+          echo "Current in pyproject.toml: $current"
+          echo "Desired: $desired"
+
+          if [ "$(printf '%s\n' "$current" "$latest_version" | sort -V | tail -1)" = "$current" ] && [ "$current" != "$latest_version" ]; then
+            echo "bumped=false" >> $GITHUB_OUTPUT
+            echo "Version already bumped, skipping."
+          else
+            uv version "$desired"
+            echo "bumped=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update lock file
+        if: steps.bump.outputs.bumped == 'true'
+        run: uv lock
+
+      - name: Check if bump is needed
+        id: check
+        if: steps.bump.outputs.bumped == 'true'
+        run: git diff --exit-code || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit & push changes
+        if: steps.check.outputs.changed == 'true'
+        uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
+        with:
+          message: "chore: bump backend version for Renovate PRs"
+          add: "."
+          pull: "--rebase --autostash"
+          author_name: "github-actions[bot]"
+          author_email: "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run backend checks
+        run: |
+          gh workflow run backend-lint.yml --ref "${{ github.head_ref }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -1,6 +1,8 @@
+---
 name: Frontend Lint
+
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: write
 
@@ -23,6 +25,7 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-*.yml"
+  workflow_dispatch:
 
 env:
   IS_MONOREPO: true
@@ -36,58 +39,16 @@ defaults:
 
 jobs:
   versions:
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: frontend
       package-name: nachet-frontend
       skip-version-check: false
 
-  bump-version-renovate:
-    needs: [versions]
-    if: ${{ !cancelled() && (github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') && needs.versions.result == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ needs.versions.outputs.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install specific npm version
-        run: npm install -g npm@${{ needs.versions.outputs.npm-version }}
-
-      - name: Increment version for Renovate PRs
-        run: |
-          echo "current version: ${{ needs.versions.outputs.app-version }}"
-          npm version "$(jq -r '.version' package.json | awk -F. -v OFS=. '{ $NF++; print }')" --no-git-tag-version
-          echo "new version: $(jq -r '.version' package.json)"
-
-      - name: Update lock file for Renovate PRs
-        run: |
-          npm install --package-lock-only
-          npm audit fix --package-lock-only || true
-
-      - name: Commit & push changes
-        uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
-        with:
-          message: "chore: bump frontend version for Renovate PRs"
-          add: "."
-          pull: "--rebase --autostash"
-          author_name: "github-actions[bot]"
-          author_email: "github-actions[bot]@users.noreply.github.com"
-
-
   check-package-lock:
-    needs: [versions, bump-version-renovate]
-    if: ${{ !cancelled() && (needs.versions.result == 'success' || needs.bump-version-renovate.result == 'success') }}
+    needs: [versions]
+    if: ${{ !cancelled() && needs.versions.result == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -110,13 +71,9 @@ jobs:
         run: |
           echo "🔍 Checking if package-lock.json needs updating..."
 
-          # Create a backup of the current package-lock.json
           cp package-lock.json package-lock.json.backup
-
-          # Run npm install to regenerate package-lock.json
           npm install --package-lock-only
 
-          # Compare the files
           if ! cmp -s package-lock.json package-lock.json.backup; then
             echo "❌ package-lock.json is out of date!"
             echo ""
@@ -183,8 +140,6 @@ jobs:
 
   trigger-release:
     name: Trigger release workflow
-    # This job triggers the publish workflow automatically when a PR is merged to main
-    # The publish workflow can also be triggered manually via workflow_dispatch
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/frontend-renovate-bump.yml
+++ b/.github/workflows/frontend-renovate-bump.yml
@@ -2,7 +2,8 @@
 name: Frontend Renovate
 
 permissions:
-  contents: read
+  actions: write
+  contents: write
   pull-requests: read
 
 concurrency:
@@ -26,7 +27,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Slumberdac'  || github.event.pull_request.user.login == 'github-actions[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: frontend
@@ -45,9 +46,9 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-renovate-bump.yml
+++ b/.github/workflows/frontend-renovate-bump.yml
@@ -1,8 +1,8 @@
-name: Nachet Mini Renovate
+---
+name: Frontend Renovate
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -12,8 +12,8 @@ concurrency:
 on:
   pull_request:
     paths:
-      - "nachet-mini/**"
-      - ".github/workflows/nachet-mini-*.yml"
+      - "frontend/**"
+      - ".github/workflows/frontend-*.yml"
       - ".github/workflows/reusable-frontend-versions.yml"
     types:
       - opened
@@ -22,15 +22,15 @@ on:
 
 defaults:
   run:
-    working-directory: nachet-mini
+    working-directory: frontend
 
 jobs:
   versions:
     if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Slumberdac'  || github.event.pull_request.user.login == 'github-actions[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
-      working-directory: nachet-mini
-      package-name: nachet-mini
+      working-directory: frontend
+      package-name: nachet-frontend
       skip-version-check: true
 
   bump-version:
@@ -38,6 +38,9 @@ jobs:
     needs: [versions]
     if: ${{ !cancelled() && needs.versions.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -51,7 +54,7 @@ jobs:
         with:
           node-version: ${{ needs.versions.outputs.node-version }}
           cache: "npm"
-          cache-dependency-path: nachet-mini/package-lock.json
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install specific npm version
         run: npm install -g npm@${{ needs.versions.outputs.npm-version }}
@@ -59,10 +62,10 @@ jobs:
       - name: Idempotently bump version
         run: |
           latest_version=""
-          tags=$(git tag --list "nachet-mini-v*" --sort=-creatordate | head -n 10)
+          tags=$(git tag --list "nachet-frontend-v*" --sort=-creatordate | head -n 10)
 
           for tag in $tags; do
-            version=$(echo "$tag" | grep -oP '(?<=nachet-mini-v)[0-9]+\.[0-9]+\.[0-9]+')
+            version=$(echo "$tag" | grep -oP '(?<=nachet-frontend-v)[0-9]+\.[0-9]+\.[0-9]+')
             if [ -n "$version" ]; then
               latest_version="$version"
               break
@@ -121,14 +124,15 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
         with:
-          message: "chore: bump nachet-mini version for Renovate PRs"
+          message: "chore: bump frontend version for Renovate PRs"
           add: "."
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run nachet-mini checks
+      - name: Run frontend checks
+        if: steps.check.outputs.changed == 'true'
         run: |
-          gh workflow run nachet-mini-lint.yml --ref "${{ github.head_ref }}"
+          gh workflow run frontend-lint.yml --ref "${{ github.head_ref }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nachet-mini-lint.yml
+++ b/.github/workflows/nachet-mini-lint.yml
@@ -1,6 +1,6 @@
 name: Nachet Mini Lint
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: write
 
@@ -37,7 +37,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'renovate[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: nachet-mini
@@ -69,13 +69,9 @@ jobs:
         run: |
           echo "🔍 Checking if package-lock.json needs updating..."
 
-          # Create a backup of the current package-lock.json
           cp package-lock.json package-lock.json.backup
-
-          # Run npm install to regenerate package-lock.json
           npm install --package-lock-only
 
-          # Compare the files
           if ! cmp -s package-lock.json package-lock.json.backup; then
             echo "❌ package-lock.json is out of date!"
             echo ""
@@ -100,7 +96,6 @@ jobs:
     secrets: inherit
 
   nachet-mini-browser-tests:
-    # TODO: make this reusable in the github workflows repo and use it in other frontend repos as well
     name: Nachet Mini Browser Tests
     needs: [versions, nachet-mini-lint-test]
     if: ${{ !cancelled() && needs.nachet-mini-lint-test.result == 'success' }}

--- a/.github/workflows/nachet-mini-renovate.yml
+++ b/.github/workflows/nachet-mini-renovate.yml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'Slumberdac'  || github.event.pull_request.user.login == 'github-actions[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: nachet-mini

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "2.9.16"
+version = "2.9.17"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "2.9.16"
+version = "2.9.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.11",
+      "version": "0.10.12",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.11",
+  "version": "0.10.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Repo settings change required

Before merging, update **Settings → Actions → General → Fork pull request workflows**
from "Require approval for all outside collaborators" to
**"Require approval for first-time contributors only"**

This allows Renovate's automated PRs to trigger workflows without manual approval each time.