### PR TITLE
Issue 818 auth callsite migration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.0.2",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,7 @@ const App = ({ basename, msalInstance, apiScopeClaim }: AppProps) => {
         msalInstance={msalInstance}
       >
         <Fragment>
-          <Navbar windowSize={windowSize} apiScopeClaim={apiScopeClaim} />
+          <Navbar />
           <Appbar windowSize={windowSize} />
           <Routes>
             <Route
@@ -72,7 +72,6 @@ const App = ({ basename, msalInstance, apiScopeClaim }: AppProps) => {
                   handleCreativeCommonsAgreement={
                     handleCreativeCommonsAgreement
                   }
-                  apiScopeClaim={apiScopeClaim}
                 />
               }
             />
@@ -87,7 +86,6 @@ const App = ({ basename, msalInstance, apiScopeClaim }: AppProps) => {
                   handleCreativeCommonsAgreement={
                     handleCreativeCommonsAgreement
                   }
-                  apiScopeClaim={apiScopeClaim}
                 />
               }
             />

--- a/frontend/src/auth/index.ts
+++ b/frontend/src/auth/index.ts
@@ -4,4 +4,5 @@ export type {
   AuthProviderKind,
   NachetAuthAccount,
   NachetAuthContextValue,
+  NachetAuthTokenOptions,
 } from "./NachetAuthContext";

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosHeaders } from "axios";
+import axios from "axios";
 import { AzureAPIError, ValueError } from "./error";
 import {
   ApiInferenceData,
@@ -71,16 +71,11 @@ const handleAxios = async <T>(request: {
 }): Promise<T> => {
   // Generate correlation ID for this request
   const correlationId = errorLogger.getCorrelationId();
-  const requestHasExplicitAuthHeader = hasAuthorizationHeader(request.headers);
   const requestRequiresAuth = request.authRequired ?? true;
   const requestCanUseAuthProvider =
     requestRequiresAuth && hasApiAccessTokenProvider();
 
-  if (
-    requestRequiresAuth &&
-    !requestHasExplicitAuthHeader &&
-    !requestCanUseAuthProvider
-  ) {
+  if (requestRequiresAuth && !requestCanUseAuthProvider) {
     throw new ValueError("Auth provider is not initialized for API requests");
   }
 
@@ -164,25 +159,6 @@ const handleAxios = async <T>(request: {
   return data;
 };
 
-// API helpers build plain header objects before Axios normalizes header names.
-const hasAuthorizationHeader = (headers: Record<string, string>): boolean => {
-  const authorizationHeader = AxiosHeaders.from(headers).get("Authorization");
-
-  return (
-    typeof authorizationHeader === "string" && authorizationHeader.trim() !== ""
-  );
-};
-
-// During the API auth migration, callers either pass an explicit token
-// or omit it so the Axios auth bridge can attach one.
-const getAuthHeaders = (accessToken?: string): Record<string, string> => {
-  if (accessToken === "") {
-    throw new ValueError("Access token is empty");
-  }
-
-  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
-};
-
 export const pingBackend = async ({
   backendUrl,
 }: {
@@ -210,23 +186,18 @@ export const pingBackend = async ({
 
 export const checkUserRegistration = async ({
   backendUrl,
-  accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string;
 }): Promise<{ isRegistered: boolean }> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/is-registered`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
   };
   const response = await handleAxios<unknown>(request);
@@ -239,23 +210,18 @@ export const checkUserRegistration = async ({
 
 export const readAzureStorageDir = async ({
   backendUrl,
-  accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ReadAzureStorageDirApi> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/get-directories`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     // data: {
     //   //   container_name: uuid,
@@ -271,11 +237,9 @@ export const readAzureStorageDir = async ({
 
 export const createAzureStorageDir = async ({
   backendUrl,
-  accessToken,
   folderName,
 }: {
   backendUrl: string;
-  accessToken?: string;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -284,15 +248,12 @@ export const createAzureStorageDir = async ({
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/create-dir`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {
       folderName: folderName,
@@ -312,11 +273,9 @@ export const createAzureStorageDir = async ({
  */
 export const deleteAzureStorageDir = async ({
   backendUrl,
-  accessToken,
   folderName,
 }: {
   backendUrl: string;
-  accessToken?: string;
   folderName: string;
 }): Promise<boolean> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -325,15 +284,12 @@ export const deleteAzureStorageDir = async ({
   if (folderName === "" || folderName == null) {
     throw new ValueError("Folder name is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/del`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {
       folderName: folderName,
@@ -352,11 +308,9 @@ export const deleteAzureStorageDir = async ({
  */
 export const deleteFolder = async ({
   backendUrl,
-  accessToken,
   folderId,
 }: {
   backendUrl: string;
-  accessToken?: string;
   folderId: string;
 }): Promise<{ id: string; message: string }> => {
   if (!backendUrl) {
@@ -365,15 +319,12 @@ export const deleteFolder = async ({
   if (!folderId) {
     throw new ValueError("Folder ID is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "delete",
     url: `${backendUrl}/folders/${folderId}`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
   };
 
@@ -397,14 +348,12 @@ export const inferenceRequest = async ({
   selectedModel,
   imageObject,
   curDir,
-  accessToken,
   folderId,
 }: {
   backendUrl: string;
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken?: string;
   folderId: string;
 }): Promise<ImageSubmissionResponse> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -419,8 +368,6 @@ export const inferenceRequest = async ({
   if (curDir === "" || curDir == null) {
     throw new ValueError("Directory is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   // Build payload object with all required and optional fields
   const payload = {
     pipelineId: selectedModel,
@@ -458,7 +405,6 @@ export const inferenceRequest = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: validatedPayload,
   };
@@ -475,14 +421,12 @@ export const inferenceDirectRequest = async ({
   selectedModel,
   imageObject,
   curDir,
-  accessToken,
   folderId,
 }: {
   backendUrl: string;
   selectedModel: string;
   imageObject: Images;
   curDir: string;
-  accessToken?: string;
   folderId: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
@@ -497,8 +441,6 @@ export const inferenceDirectRequest = async ({
   if (curDir === "" || curDir == null) {
     throw new ValueError("Directory is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   // Build payload object with all required and optional fields
   const payload = {
     pipelineId: selectedModel,
@@ -536,7 +478,6 @@ export const inferenceDirectRequest = async ({
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: validatedPayload,
   };
@@ -550,23 +491,18 @@ export const inferenceDirectRequest = async ({
 
 export const fetchModelMetadata = async ({
   backendUrl,
-  accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ModelMetadata[]> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/model-endpoints-metadata`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {},
   };
@@ -580,23 +516,18 @@ export const fetchModelMetadata = async ({
 
 export const fetchDevices = async ({
   backendUrl,
-  accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ApiDevicesResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/devices`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {},
   };
@@ -611,11 +542,9 @@ export const fetchDevices = async ({
 export const getWorkflowStatus = async ({
   backendUrl,
   workflowId,
-  accessToken,
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken?: string;
 }): Promise<WorkflowStatusResponse> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -623,15 +552,12 @@ export const getWorkflowStatus = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/status`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {},
   };
@@ -646,11 +572,9 @@ export const getWorkflowStatus = async ({
 export const getWorkflowResults = async ({
   backendUrl,
   workflowId,
-  accessToken,
 }: {
   backendUrl: string;
   workflowId: string;
-  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
@@ -658,15 +582,12 @@ export const getWorkflowResults = async ({
   if (workflowId === "" || workflowId == null) {
     throw new ValueError("Workflow ID is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/workflow/${workflowId}/results`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {},
   };
@@ -681,24 +602,19 @@ export const getWorkflowResults = async ({
 export const sendFeedbackNewBox = async ({
   feedbackData,
   backendUrl,
-  accessToken,
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/feedback-new-box`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: feedbackData,
   };
@@ -713,24 +629,19 @@ export const sendFeedbackNewBox = async ({
 export const sendPositiveFeedback = async ({
   feedbackData,
   backendUrl,
-  accessToken,
 }: {
   feedbackData: FeedbackDataPositive;
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/feedback-positive`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: feedbackData,
   };
@@ -745,24 +656,19 @@ export const sendPositiveFeedback = async ({
 export const sendNegativeFeedback = async ({
   feedbackData,
   backendUrl,
-  accessToken,
 }: {
   feedbackData: FeedbackDataNegative;
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ApiInferenceData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/feedback-negative`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: feedbackData,
   };
@@ -801,23 +707,18 @@ export const sendNegativeFeedback = async ({
 
 export const requestClassList = async ({
   backendUrl,
-  accessToken,
 }: {
   backendUrl: string;
-  accessToken?: string;
 }): Promise<ApiSpeciesData> => {
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "get",
     url: `${backendUrl}/seeds`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {},
   };
@@ -831,12 +732,10 @@ export const requestClassList = async ({
 
 export const batchUploadInit = async ({
   backendUrl,
-  accessToken,
   folderId,
   fileCount,
 }: {
   backendUrl: string;
-  accessToken?: string;
   folderId: string;
   fileCount: number;
 }): Promise<{
@@ -851,15 +750,12 @@ export const batchUploadInit = async ({
   if (fileCount === 0 || fileCount == null) {
     throw new ValueError("Number of pictures is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/new-batch-import`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {
       folderId: folderId,
@@ -877,11 +773,9 @@ export const batchUploadInit = async ({
 export const batchUploadImage = async ({
   backendUrl,
   data,
-  accessToken,
 }: {
   backendUrl: string;
   data: BatchUploadMetadata;
-  accessToken?: string;
 }): Promise<BatchUploadImageResponse> => {
   const {
     sessionId,
@@ -927,15 +821,12 @@ export const batchUploadImage = async ({
   if (magnification === 0 || magnification == null) {
     throw new ValueError("Magnification is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/upload-picture`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {
       sessionId: sessionId,
@@ -970,7 +861,6 @@ export const batchUploadImage = async ({
  * Authorization: Users can only create folders for themselves
  *
  * @param backendUrl - Backend API base URL
- * @param accessToken - Optional compatibility bearer token. App callers normally use the shared auth provider.
  * @param normalizedPath - Relative path from user's root (e.g., "avena-fatua" or "mycology/avena-fatua")
  * @param description - Optional folder description
  * @returns Promise resolving to CreateOrGetFolderResponse with folderId
@@ -987,12 +877,10 @@ export const batchUploadImage = async ({
  */
 export const createOrGetFolder = async ({
   backendUrl,
-  accessToken,
   normalizedPath,
   description = "",
 }: {
   backendUrl: string;
-  accessToken?: string;
   normalizedPath: string;
   description?: string;
 }): Promise<CreateOrGetFolderResponse> => {
@@ -1011,15 +899,12 @@ export const createOrGetFolder = async ({
       `Invalid normalized path: ${pathValidation.error.issues[0].message}`,
     );
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/folders`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {
       normalizedPath: normalizedPath,
@@ -1044,7 +929,6 @@ export const createOrGetFolder = async ({
  * Restrictions: Cannot update default folders for active users
  *
  * @param backendUrl - Backend API base URL
- * @param accessToken - Optional compatibility bearer token. App callers normally use the shared auth provider.
  * @param folderId - UUID of the folder to update
  * @param name - Optional new folder name (just the name, not full path)
  * @param description - Optional new description
@@ -1063,13 +947,11 @@ export const createOrGetFolder = async ({
  */
 export const updateFolder = async ({
   backendUrl,
-  accessToken,
   folderId,
   name,
   description,
 }: {
   backendUrl: string;
-  accessToken?: string;
   folderId: string;
   name?: string;
   description?: string;
@@ -1106,15 +988,12 @@ export const updateFolder = async ({
       );
     }
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "put",
     url: `${backendUrl}/folders/${folderId}`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: {
       ...(name && { name }),
@@ -1132,11 +1011,9 @@ export const updateFolder = async ({
 
 export const sendLogToBackend = async ({
   backendUrl,
-  accessToken,
   logData,
 }: {
   backendUrl: string;
-  accessToken?: string;
   logData: {
     level: "ERROR" | "WARNING" | "INFO" | "DEBUG";
     message: string;
@@ -1151,15 +1028,12 @@ export const sendLogToBackend = async ({
   if (backendUrl === "" || backendUrl == null) {
     throw new ValueError("Backend URL is null or empty");
   }
-  const authHeaders = getAuthHeaders(accessToken);
-
   const request = {
     method: "post",
     url: `${backendUrl}/logs`,
     headers: {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
-      ...authHeaders,
     },
     data: logData,
   };

--- a/frontend/src/common/api.ts
+++ b/frontend/src/common/api.ts
@@ -44,7 +44,7 @@ import {
   clearAxiosInterceptors,
   hasApiAccessTokenProvider,
 } from "./apiInterceptor";
-import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
+import type { NachetAuthTokenOptions } from "@auth";
 
 type GetApiAccessToken = (options?: NachetAuthTokenOptions) => Promise<string>;
 

--- a/frontend/src/common/auth.ts
+++ b/frontend/src/common/auth.ts
@@ -3,7 +3,7 @@ import {
   InteractionRequiredAuthError,
   BrowserAuthError,
 } from "@azure/msal-browser";
-import type { NachetAuthTokenOptions } from "../auth/NachetAuthContext";
+import type { NachetAuthTokenOptions } from "@auth";
 
 // Track if we're currently in a redirect flow to prevent loops
 let isRedirecting = false;

--- a/frontend/src/common/tests/api.test.ts
+++ b/frontend/src/common/tests/api.test.ts
@@ -1,4 +1,12 @@
 import { describe, it, vi, beforeEach, expect } from "vitest";
+
+const mockHasApiAccessTokenProvider = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock("../apiInterceptor", () => ({
+  setupAxiosInterceptor: vi.fn(),
+  clearAxiosInterceptors: vi.fn(),
+  hasApiAccessTokenProvider: mockHasApiAccessTokenProvider,
+}));
 import {
   createAzureStorageDir,
   deleteAzureStorageDir,
@@ -16,7 +24,7 @@ import {
 import axios from "axios";
 import { AzureAPIError, ValueError } from "../error";
 
-// mock axios while keeping AxiosHeaders available for api.ts header checks
+// mock axios
 vi.mock("axios", async () => {
   const actual = await vi.importActual<typeof import("axios")>("axios");
 
@@ -42,10 +50,13 @@ vi.mock("../../logging", () => ({
 
 beforeEach(() => {
   mockedAxios.mockClear();
+  mockHasApiAccessTokenProvider.mockReturnValue(true);
 });
 
 describe("protected API auth initialization", () => {
   it("should fail closed before sending protected requests without auth initialization", async () => {
+    mockHasApiAccessTokenProvider.mockReturnValue(false);
+
     await expect(
       fetchDevices({ backendUrl: "http://localhost:8080" }),
     ).rejects.toThrow(
@@ -75,9 +86,7 @@ describe("readAzureStorageDir", () => {
       data: mockData,
     });
     const backendUrl = "http://localhost:8080";
-    const accessToken = "valid-access-token";
-
-    const result = await readAzureStorageDir({ backendUrl, accessToken });
+    const result = await readAzureStorageDir({ backendUrl });
     expect(result).toEqual(mockData);
     expect(mockedAxios).toHaveBeenCalledWith({
       method: "get",
@@ -85,37 +94,26 @@ describe("readAzureStorageDir", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer ${accessToken}`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
   it("should throw ValueError for empty backend URL", async () => {
-    await expect(
-      readAzureStorageDir({ backendUrl: "", accessToken: "valid-token" }),
-    ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
+    await expect(readAzureStorageDir({ backendUrl: "" })).rejects.toThrow(
+      new ValueError("Backend URL is null or empty"),
+    );
   });
 
   it("should throw ValueError for null backend URL", async () => {
     await expect(
       readAzureStorageDir({
         backendUrl: null as any,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
-  });
-
-  it("should throw ValueError for empty access token", async () => {
-    await expect(
-      readAzureStorageDir({
-        backendUrl: "http://localhost:8080",
-        accessToken: "",
-      }),
-    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should throw error has response", async () => {
@@ -128,11 +126,9 @@ describe("readAzureStorageDir", () => {
       },
     });
     const backendUrl = "backendUrl";
-    const accessToken = "valid-token";
-
-    await expect(
-      readAzureStorageDir({ backendUrl, accessToken }),
-    ).rejects.toEqual(new AzureAPIError("error"));
+    await expect(readAzureStorageDir({ backendUrl })).rejects.toEqual(
+      new AzureAPIError("error"),
+    );
     expect(console.error).toHaveBeenCalled();
     console.error = consoleError;
   });
@@ -144,11 +140,9 @@ describe("readAzureStorageDir", () => {
       request: "error",
     });
     const backendUrl = "backendUrl";
-    const accessToken = "valid-token";
-
-    await expect(
-      readAzureStorageDir({ backendUrl, accessToken }),
-    ).rejects.toEqual(new AzureAPIError("Network request failed"));
+    await expect(readAzureStorageDir({ backendUrl })).rejects.toEqual(
+      new AzureAPIError("Network request failed"),
+    );
     expect(console.error).toHaveBeenCalled();
     console.error = consoleError;
   });
@@ -161,11 +155,9 @@ describe("readAzureStorageDir", () => {
       config: "error config",
     });
     const backendUrl = "http://localhost:8080";
-    const accessToken = "valid-token";
-
-    await expect(
-      readAzureStorageDir({ backendUrl, accessToken }),
-    ).rejects.toEqual(new AzureAPIError("Network error"));
+    await expect(readAzureStorageDir({ backendUrl })).rejects.toEqual(
+      new AzureAPIError("Network error"),
+    );
     expect(console.error).toHaveBeenCalledWith("Error", "Network error");
     console.error = consoleError;
   });
@@ -176,11 +168,9 @@ describe("readAzureStorageDir", () => {
       data: "created",
     });
     const backendUrl = "http://localhost:8080";
-    const accessToken = "valid-token";
-
-    await expect(
-      readAzureStorageDir({ backendUrl, accessToken }),
-    ).rejects.toThrow(AzureAPIError);
+    await expect(readAzureStorageDir({ backendUrl })).rejects.toThrow(
+      AzureAPIError,
+    );
   });
 
   it("should throw error has config", async () => {
@@ -190,11 +180,9 @@ describe("readAzureStorageDir", () => {
       config: "error",
     });
     const backendUrl = "backendUrl";
-    const accessToken = "valid-token";
-
-    await expect(
-      readAzureStorageDir({ backendUrl, accessToken }),
-    ).rejects.toEqual(new AzureAPIError("Unknown error"));
+    await expect(readAzureStorageDir({ backendUrl })).rejects.toEqual(
+      new AzureAPIError("Unknown error"),
+    );
     expect(console.error).toHaveBeenCalled();
     console.error = consoleError;
   });
@@ -208,17 +196,15 @@ describe("createAzureStorageDir", () => {
       data: { folderName: "test-folder" },
     });
     const backendUrl = "http://localhost:8080";
-    const accessToken = "valid-token";
     const folderName = "test-folder";
 
-    await createAzureStorageDir({ backendUrl, accessToken, folderName });
+    await createAzureStorageDir({ backendUrl, folderName });
     expect(mockedAxios).toHaveBeenCalledWith({
       method: "post",
       url: `${backendUrl}/create-dir`,
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer ${accessToken}`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
@@ -226,7 +212,7 @@ describe("createAzureStorageDir", () => {
         folderName: folderName,
       },
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -234,27 +220,15 @@ describe("createAzureStorageDir", () => {
     await expect(
       createAzureStorageDir({
         backendUrl: "",
-        accessToken: "valid-token",
         folderName: "folder",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
-  });
-
-  it("should throw ValueError for empty access token", async () => {
-    await expect(
-      createAzureStorageDir({
-        backendUrl: "http://localhost:8080",
-        accessToken: "",
-        folderName: "folder",
-      }),
-    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should throw ValueError for empty folder name", async () => {
     await expect(
       createAzureStorageDir({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
         folderName: "",
       }),
     ).rejects.toThrow(new ValueError("Folder name is null or empty"));
@@ -273,7 +247,6 @@ describe("createAzureStorageDir", () => {
     await expect(
       createAzureStorageDir({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
         folderName: "folder",
       }),
     ).rejects.toThrow(new AzureAPIError("Permission denied"));
@@ -289,17 +262,15 @@ describe("deleteAzureStorageDir", () => {
       data: { folderName: "test-folder" },
     });
     const backendUrl = "http://localhost:8080";
-    const accessToken = "valid-token";
     const folderName = "test-folder";
 
-    await deleteAzureStorageDir({ backendUrl, accessToken, folderName });
+    await deleteAzureStorageDir({ backendUrl, folderName });
     expect(mockedAxios).toHaveBeenCalledWith({
       method: "post",
       url: `${backendUrl}/del`,
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer ${accessToken}`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
@@ -307,7 +278,7 @@ describe("deleteAzureStorageDir", () => {
         folderName: folderName,
       },
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -315,27 +286,15 @@ describe("deleteAzureStorageDir", () => {
     await expect(
       deleteAzureStorageDir({
         backendUrl: "",
-        accessToken: "valid-token",
         folderName: "folder",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
-  });
-
-  it("should throw ValueError for empty access token", async () => {
-    await expect(
-      deleteAzureStorageDir({
-        backendUrl: "http://localhost:8080",
-        accessToken: "",
-        folderName: "folder",
-      }),
-    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should throw ValueError for empty folder name", async () => {
     await expect(
       deleteAzureStorageDir({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
         folderName: "",
       }),
     ).rejects.toThrow(new ValueError("Folder name is null or empty"));
@@ -354,7 +313,6 @@ describe("deleteAzureStorageDir", () => {
     await expect(
       deleteAzureStorageDir({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
         folderName: "nonexistent",
       }),
     ).rejects.toThrow(new AzureAPIError("Directory not found"));
@@ -401,7 +359,6 @@ describe("inferenceRequest", () => {
       selectedModel,
       imageObject: mockImageObject,
       curDir,
-      accessToken: "valid-token",
       folderId: folderId,
     });
 
@@ -412,7 +369,6 @@ describe("inferenceRequest", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
@@ -431,7 +387,7 @@ describe("inferenceRequest", () => {
         magnification: mockImageObject.magnification,
       },
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -442,7 +398,6 @@ describe("inferenceRequest", () => {
         selectedModel: "model",
         imageObject: mockImageObject,
         curDir: "dir",
-        accessToken: "token",
         folderId: "folder-id",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
@@ -455,7 +410,6 @@ describe("inferenceRequest", () => {
         selectedModel: "",
         imageObject: mockImageObject,
         curDir: "dir",
-        accessToken: "token",
         folderId: "folder-id",
       }),
     ).rejects.toThrow(new ValueError("Model is null or empty"));
@@ -469,7 +423,6 @@ describe("inferenceRequest", () => {
         selectedModel: "model",
         imageObject: emptyImageObject,
         curDir: "dir",
-        accessToken: "token",
         folderId: "folder-id",
       }),
     ).rejects.toThrow(new ValueError("Image is null or empty"));
@@ -482,23 +435,9 @@ describe("inferenceRequest", () => {
         selectedModel: "model",
         imageObject: mockImageObject,
         curDir: "",
-        accessToken: "token",
         folderId: "folder-id",
       }),
     ).rejects.toThrow(new ValueError("Directory is null or empty"));
-  });
-
-  it("should throw ValueError for empty access token", async () => {
-    await expect(
-      inferenceRequest({
-        backendUrl: "http://localhost:8080",
-        selectedModel: "model",
-        imageObject: mockImageObject,
-        curDir: "dir",
-        accessToken: "",
-        folderId: "folder-id",
-      }),
-    ).rejects.toThrow(new ValueError("Access token is empty"));
   });
 
   it("should handle inference service errors", async () => {
@@ -517,7 +456,6 @@ describe("inferenceRequest", () => {
         selectedModel: "invalid-model",
         imageObject: mockImageObject,
         curDir: "dir",
-        accessToken: "token",
         folderId: "52345678-1234-1234-8234-123456789012",
       }),
     ).rejects.toThrow(new AzureAPIError("Model not available"));
@@ -540,7 +478,6 @@ describe("inferenceRequest", () => {
         selectedModel: "model",
         imageObject: mockImageObject,
         curDir: "dir",
-        accessToken: "token",
         folderId: "62345678-1234-1234-8234-123456789012",
       }),
     ).rejects.toThrow(new AzureAPIError("Invalid image format"));
@@ -560,7 +497,6 @@ describe("inferenceRequest", () => {
         selectedModel: "model",
         imageObject: mockImageObject,
         curDir: "dir",
-        accessToken: "token",
         folderId: "72345678-1234-1234-8234-123456789012",
       }),
     ).rejects.toThrow(new AzureAPIError("Network request failed"));
@@ -578,7 +514,6 @@ describe("handleAxios error scenarios", () => {
     await expect(
       fetchModelMetadata({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(AzureAPIError);
   });
@@ -611,7 +546,6 @@ describe("fetchModelMetadata", () => {
     const backendUrl = "http://localhost:8080";
     const result = await fetchModelMetadata({
       backendUrl,
-      accessToken: "valid-token",
     });
 
     expect(result).toEqual(mockMetadata);
@@ -621,27 +555,25 @@ describe("fetchModelMetadata", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
       data: {},
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
   it("should throw ValueError for empty backend URL", async () => {
-    await expect(
-      fetchModelMetadata({ backendUrl: "", accessToken: "valid-token" }),
-    ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
+    await expect(fetchModelMetadata({ backendUrl: "" })).rejects.toThrow(
+      new ValueError("Backend URL is null or empty"),
+    );
   });
 
   it("should throw ValueError for null backend URL", async () => {
     await expect(
       fetchModelMetadata({
         backendUrl: null as any,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
   });
@@ -659,7 +591,6 @@ describe("fetchModelMetadata", () => {
     await expect(
       fetchModelMetadata({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new AzureAPIError("Service temporarily unavailable"));
     console.error = consoleError;
@@ -674,7 +605,6 @@ describe("fetchModelMetadata", () => {
 
     const result = await fetchModelMetadata({
       backendUrl: "http://localhost:8080",
-      accessToken: "valid-token",
     });
     expect(result).toEqual([]);
   });
@@ -709,7 +639,6 @@ describe("requestClassList", () => {
     const backendUrl = "http://localhost:8080";
     const result = await requestClassList({
       backendUrl,
-      accessToken: "valid-token",
     });
 
     expect(result).toEqual(mockSpeciesData);
@@ -719,20 +648,19 @@ describe("requestClassList", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
       data: {},
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
   it("should throw ValueError for empty backend URL", async () => {
-    await expect(
-      requestClassList({ backendUrl: "", accessToken: "valid-token" }),
-    ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
+    await expect(requestClassList({ backendUrl: "" })).rejects.toThrow(
+      new ValueError("Backend URL is null or empty"),
+    );
   });
 });
 
@@ -751,7 +679,6 @@ describe("batchUploadInit", () => {
 
     const result = await batchUploadInit({
       backendUrl,
-      accessToken: "valid-token",
       folderId,
       fileCount: nbPictures,
     });
@@ -763,7 +690,6 @@ describe("batchUploadInit", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
@@ -772,7 +698,7 @@ describe("batchUploadInit", () => {
         fileCount: nbPictures,
       },
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -780,7 +706,6 @@ describe("batchUploadInit", () => {
     await expect(
       batchUploadInit({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
         folderId: "folder-uuid",
         fileCount: 0,
       }),
@@ -791,7 +716,6 @@ describe("batchUploadInit", () => {
     await expect(
       batchUploadInit({
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
         folderId: "",
         fileCount: 5,
       }),
@@ -826,7 +750,6 @@ describe("batchUploadImage", () => {
     const result = await batchUploadImage({
       backendUrl,
       data: mockBatchUploadData,
-      accessToken: "valid-token",
     });
 
     expect(result.pictureId).toBe("picture-uuid-789");
@@ -837,7 +760,6 @@ describe("batchUploadImage", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
@@ -853,7 +775,7 @@ describe("batchUploadImage", () => {
         image: mockBatchUploadData.imageDataUrl,
       },
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -862,7 +784,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "",
         data: mockBatchUploadData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
   });
@@ -873,7 +794,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Session ID is null or empty"));
   });
@@ -884,7 +804,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Image is null or empty"));
   });
@@ -895,7 +814,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Seed ID is null or empty"));
   });
@@ -906,7 +824,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Magnification is null or empty"));
   });
@@ -917,7 +834,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Tray code is null or empty"));
   });
@@ -928,7 +844,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Sample ID Prefix is null or empty"));
   });
@@ -939,7 +854,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Device brand is null or empty"));
   });
@@ -950,7 +864,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Device model is null or empty"));
   });
@@ -961,7 +874,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: invalidData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Device lens is null or empty"));
   });
@@ -980,7 +892,6 @@ describe("batchUploadImage", () => {
       batchUploadImage({
         backendUrl: "http://localhost:8080",
         data: mockBatchUploadData,
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new AzureAPIError("Upload failed - file too large"));
     console.error = consoleError;
@@ -1014,7 +925,6 @@ describe("sendPositiveFeedback", () => {
     const result = await sendPositiveFeedback({
       feedbackData: mockPositiveFeedbackData,
       backendUrl,
-      accessToken: "valid-token",
     });
 
     expect(result).toEqual(mockResponse);
@@ -1024,13 +934,12 @@ describe("sendPositiveFeedback", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
       data: mockPositiveFeedbackData,
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -1039,7 +948,6 @@ describe("sendPositiveFeedback", () => {
       sendPositiveFeedback({
         feedbackData: mockPositiveFeedbackData,
         backendUrl: "",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
   });
@@ -1058,7 +966,6 @@ describe("sendPositiveFeedback", () => {
       sendPositiveFeedback({
         feedbackData: mockPositiveFeedbackData,
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new AzureAPIError("Inference not found"));
     console.error = consoleError;
@@ -1104,7 +1011,6 @@ describe("sendNegativeFeedback", () => {
     const result = await sendNegativeFeedback({
       feedbackData: mockNegativeFeedbackData,
       backendUrl,
-      accessToken: "valid-token",
     });
 
     expect(result).toEqual(mockResponse);
@@ -1114,13 +1020,12 @@ describe("sendNegativeFeedback", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
       data: mockNegativeFeedbackData,
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -1129,7 +1034,6 @@ describe("sendNegativeFeedback", () => {
       sendNegativeFeedback({
         feedbackData: mockNegativeFeedbackData,
         backendUrl: "",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
   });
@@ -1187,7 +1091,6 @@ describe("sendFeedbackNewBox", () => {
     const result = await sendFeedbackNewBox({
       feedbackData: mockNewBoxFeedbackData,
       backendUrl,
-      accessToken: "valid-token",
     });
 
     expect(result).toEqual(mockResponse);
@@ -1197,13 +1100,12 @@ describe("sendFeedbackNewBox", () => {
       headers: {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer valid-token`,
         "X-Correlation-ID": "test-correlation-id",
         "X-Session-ID": "test-session-id",
       },
       data: mockNewBoxFeedbackData,
       withCredentials: true,
-      useNachetAuthProvider: false,
+      useNachetAuthProvider: true,
     });
   });
 
@@ -1212,7 +1114,6 @@ describe("sendFeedbackNewBox", () => {
       sendFeedbackNewBox({
         feedbackData: mockNewBoxFeedbackData,
         backendUrl: "",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new ValueError("Backend URL is null or empty"));
   });
@@ -1231,7 +1132,6 @@ describe("sendFeedbackNewBox", () => {
       sendFeedbackNewBox({
         feedbackData: mockNewBoxFeedbackData,
         backendUrl: "http://localhost:8080",
-        accessToken: "valid-token",
       }),
     ).rejects.toThrow(new AzureAPIError("Invalid box coordinates"));
     console.error = consoleError;

--- a/frontend/src/components/body/auth_popup/AuthPopup.tsx
+++ b/frontend/src/components/body/auth_popup/AuthPopup.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Dialog,
   DialogContent,
@@ -7,35 +6,22 @@ import {
   CircularProgress,
   Typography,
 } from "@mui/material";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { colours } from "../../../styles/colours";
 import { useTranslation } from "react-i18next";
+import { useNachetAuth } from "../../../auth";
 
 interface AuthPopupProps {
   open: boolean;
   onClose: () => void;
-  apiScopeClaim: string;
 }
 
-const AuthPopup: React.FC<AuthPopupProps> = ({
-  open,
-  onClose,
-  apiScopeClaim,
-}) => {
+const AuthPopup = ({ open, onClose }: AuthPopupProps) => {
   const { t } = useTranslation("popups");
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading, login } = useNachetAuth();
 
   const handleSignIn = async (): Promise<void> => {
     try {
-      if (inProgress !== InteractionStatus.None) {
-        console.warn("Interaction already in progress, please wait");
-        return;
-      }
-      await instance.loginRedirect({
-        scopes: [apiScopeClaim ?? ""],
-      });
+      await login();
     } catch (error) {
       console.error("Login failed:", error);
     }
@@ -45,8 +31,6 @@ const AuthPopup: React.FC<AuthPopupProps> = ({
   if (isAuthenticated) {
     return null;
   }
-
-  const isLoading = inProgress !== InteractionStatus.None;
 
   return (
     <Dialog

--- a/frontend/src/components/body/auth_popup/AuthPopup.tsx
+++ b/frontend/src/components/body/auth_popup/AuthPopup.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { colours } from "../../../styles/colours";
 import { useTranslation } from "react-i18next";
-import { useNachetAuth } from "../../../auth";
+import { useNachetAuth } from "@auth";
 
 interface AuthPopupProps {
   open: boolean;

--- a/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
+++ b/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
@@ -26,7 +26,7 @@ import { useModalStore } from "@stores/useModalStore";
 import { BatchUploadPopupView } from "./BatchUploadPopupView";
 import { useTranslation } from "react-i18next";
 import { useNotificationStore } from "@stores/useNotificationStore";
-import { useNachetAuth } from "../../../auth";
+import { useNachetAuth } from "@auth";
 
 interface BatchUploadPopupContainerProps {
   backendUrl: string;

--- a/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
+++ b/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
@@ -538,9 +538,6 @@ export const BatchUploadPopupContainer = (
       folderId: createdFolderId,
       fileCount,
     })
-      .then((response) => {
-        return { sessionId: response.sessionId };
-      })
       .then(({ sessionId }) => {
         // Create session in Zustand store
         createSession(sessionId, fileCount);

--- a/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
+++ b/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
@@ -8,9 +8,6 @@ import {
   useZodFieldValidation,
   ERROR_KEY_MAPPINGS,
 } from "@hooks";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
-import { acquireAccessToken } from "@common/auth";
 import { getSeedIdByTaxonomy } from "../../../utils/seedLookup";
 import {
   folderNameSchema,
@@ -29,19 +26,19 @@ import { useModalStore } from "@stores/useModalStore";
 import { BatchUploadPopupView } from "./BatchUploadPopupView";
 import { useTranslation } from "react-i18next";
 import { useNotificationStore } from "@stores/useNotificationStore";
+import { useNachetAuth } from "../../../auth";
 
 interface BatchUploadPopupContainerProps {
   backendUrl: string;
   containerName: string;
   uuid: string;
-  apiScopeClaim: string;
   setReadAzureStorage: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const BatchUploadPopupContainer = (
   props: BatchUploadPopupContainerProps,
 ) => {
-  const { backendUrl, apiScopeClaim, setReadAzureStorage } = props;
+  const { backendUrl, setReadAzureStorage } = props;
   const { closeBatchUploadPopup } = useModalStore();
   const { t } = useTranslation("validation");
   const { t: tErrors } = useTranslation("errors");
@@ -137,10 +134,9 @@ export const BatchUploadPopupContainer = (
     ERROR_KEY_MAPPINGS.description,
   );
 
-  const { speciesData } = useSpeciesData(backendUrl, apiScopeClaim);
-  const { devicesData } = useDeviceData(backendUrl, apiScopeClaim);
-  const { instance: msalInstance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { speciesData } = useSpeciesData(backendUrl);
+  const { devicesData } = useDeviceData(backendUrl);
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   // Folder creation state
   const [createdFolderId, setCreatedFolderId] = useState<string>("");
@@ -183,7 +179,7 @@ export const BatchUploadPopupContainer = (
       return;
     }
 
-    if (inProgress !== InteractionStatus.None || !isAuthenticated) {
+    if (authLoading || !isAuthenticated) {
       console.warn("Authentication in progress or user not authenticated");
       return;
     }
@@ -210,12 +206,8 @@ export const BatchUploadPopupContainer = (
     setFolderDescriptionError("");
 
     try {
-      const accessToken = await acquireAccessToken(msalInstance, [
-        apiScopeClaim,
-      ]);
       const result = await createOrGetFolder({
         backendUrl,
-        accessToken,
         normalizedPath: normalizedFolderName,
         description: descriptionValidationResult.data,
       });
@@ -504,7 +496,7 @@ export const BatchUploadPopupContainer = (
       return;
     }
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(tErrors("auth.inProgress"), 8000);
       return;
     }
@@ -541,29 +533,21 @@ export const BatchUploadPopupContainer = (
     }
 
     // Initialize batch upload session
-    acquireAccessToken(msalInstance, [apiScopeClaim])
-      .then((accessToken) => {
-        return batchUploadInit({
-          backendUrl,
-          accessToken,
-          folderId: createdFolderId,
-          fileCount,
-        }).then((response) => ({
-          accessToken,
-          sessionId: response.sessionId,
-        }));
+    batchUploadInit({
+      backendUrl,
+      folderId: createdFolderId,
+      fileCount,
+    })
+      .then((response) => {
+        return { sessionId: response.sessionId };
       })
       .then(({ sessionId }) => {
         // Create session in Zustand store
         createSession(sessionId, fileCount);
 
-        const scopes = apiScopeClaim ? [apiScopeClaim] : [];
-
         // Configure queue manager
         queueManagerRef.current.configure({
           backendUrl,
-          msalInstance,
-          scopes,
           uploadStore: {
             addUpload,
             updateUploadStatus,

--- a/frontend/src/components/body/directory_popup/DirectoryPopup.tsx
+++ b/frontend/src/components/body/directory_popup/DirectoryPopup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState, type Dispatch, type FC, type SetStateAction } from "react";
 import {
   Box,
   Dialog,
@@ -9,9 +9,6 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import { colours } from "@styles/colours";
 import { useBackendUrl } from "@hooks";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
-import { acquireAccessToken } from "@common/auth";
 import { createOrGetFolder, updateFolder, deleteFolder } from "@common/api";
 import { normalizedPathSchema, descriptionSchema } from "@common/validation";
 import { getZodErrorKey } from "@common/zodErrorMap";
@@ -25,10 +22,10 @@ import { PopupActionButtons } from "@components/common";
 import { useDirectoryModalStore } from "@stores/useDirectoryModalStore";
 import { useFolderStore } from "@stores/useFolderStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
+import { useNachetAuth } from "../../../auth";
 
 interface params {
-  setReadAzureStorage: React.Dispatch<React.SetStateAction<boolean>>;
-  apiScopeClaim: string;
+  setReadAzureStorage: Dispatch<SetStateAction<boolean>>;
   mode: "create" | "edit" | "delete";
   initialData?: {
     folderId: string;
@@ -37,10 +34,10 @@ interface params {
   };
 }
 
-const DirectoryPopup: React.FC<params> = (props) => {
+const DirectoryPopup: FC<params> = (props) => {
   const { t } = useTranslation("popups");
   const { t: tValidation } = useTranslation("validation");
-  const { setReadAzureStorage, apiScopeClaim, mode, initialData } = props;
+  const { setReadAzureStorage, mode, initialData } = props;
   const { closeCreateDirectory, closeEditDirectory, closeDeleteDirectory } =
     useDirectoryModalStore();
   const { setCurDir } = useFolderStore();
@@ -57,8 +54,7 @@ const DirectoryPopup: React.FC<params> = (props) => {
   );
   const [validationError, setValidationError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
-  const { instance: msalInstance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
   const { addError, addWarning } = useNotificationStore();
 
   // Zod validation hook for auto-normalization on blur
@@ -80,7 +76,7 @@ const DirectoryPopup: React.FC<params> = (props) => {
       return;
     }
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       const warningKey =
         mode === "delete"
           ? "deleteDirectory.errors.authInProgress"
@@ -96,13 +92,11 @@ const DirectoryPopup: React.FC<params> = (props) => {
         return;
       }
 
-      acquireAccessToken(msalInstance, [apiScopeClaim])
-        .then(async (accessToken) => {
-          await deleteFolder({
-            backendUrl: backendURL,
-            accessToken,
-            folderId: initialData.folderId,
-          });
+      deleteFolder({
+        backendUrl: backendURL,
+        folderId: initialData.folderId,
+      })
+        .then(() => {
           console.log(`Folder deleted: ${initialData.folderId}`);
           closeDeleteDirectory();
           setCurDir(null);
@@ -157,13 +151,12 @@ const DirectoryPopup: React.FC<params> = (props) => {
 
     const sanitizedDescription = descriptionValidationResult.data;
 
-    acquireAccessToken(msalInstance, [apiScopeClaim])
-      .then(async (accessToken) => {
+    Promise.resolve()
+      .then(async () => {
         if (mode === "create") {
           // Create directory at root level using new API
           const result = await createOrGetFolder({
             backendUrl: backendURL,
-            accessToken,
             normalizedPath,
             description: sanitizedDescription,
           });
@@ -175,7 +168,6 @@ const DirectoryPopup: React.FC<params> = (props) => {
           }
           const result = await updateFolder({
             backendUrl: backendURL,
-            accessToken,
             folderId: initialData.folderId,
             name: normalizedPath,
             description: sanitizedDescription,

--- a/frontend/src/components/body/directory_popup/DirectoryPopup.tsx
+++ b/frontend/src/components/body/directory_popup/DirectoryPopup.tsx
@@ -22,7 +22,7 @@ import { PopupActionButtons } from "@components/common";
 import { useDirectoryModalStore } from "@stores/useDirectoryModalStore";
 import { useFolderStore } from "@stores/useFolderStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
-import { useNachetAuth } from "../../../auth";
+import { useNachetAuth } from "@auth";
 
 interface params {
   setReadAzureStorage: Dispatch<SetStateAction<boolean>>;

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -19,7 +19,7 @@ import { useNotificationStore } from "@stores/useNotificationStore";
 import { useInferenceResultsStore } from "@stores/useInferenceResultsStore";
 import { MicroscopeFeedControlsView } from "./MicroscopeFeedControlsView";
 import { MicroscopeFeedWorkspaceView } from "./MicroscopeFeedWorkspaceView";
-import { useNachetAuth } from "../../../auth";
+import { useNachetAuth } from "@auth";
 
 interface MicroscopeFeedProps {
   webcamRef: React.RefObject<Webcam | null>;

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeed.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeed.tsx
@@ -13,15 +13,13 @@ import {
 } from "@common/types";
 import { sendNegativeFeedback, sendPositiveFeedback } from "@common";
 import { useSpeciesData } from "@hooks";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
-import { acquireAccessToken } from "@common/auth";
 import { getUnscaledCoordinates } from "@common/imageutils";
 import { useImageStore } from "@stores/useImageStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
 import { useInferenceResultsStore } from "@stores/useInferenceResultsStore";
 import { MicroscopeFeedControlsView } from "./MicroscopeFeedControlsView";
 import { MicroscopeFeedWorkspaceView } from "./MicroscopeFeedWorkspaceView";
+import { useNachetAuth } from "../../../auth";
 
 interface MicroscopeFeedProps {
   webcamRef: React.RefObject<Webcam | null>;
@@ -40,7 +38,6 @@ interface MicroscopeFeedProps {
   toggleShowInference: (state: boolean) => void;
   backendUrl: string;
   uuid: string;
-  apiScopeClaim: string;
 }
 
 const MicroscopeFeed = (props: MicroscopeFeedProps) => {
@@ -58,7 +55,6 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     toggleShowInference,
     backendUrl,
     uuid,
-    apiScopeClaim,
   } = props;
 
   const { t } = useTranslation("main");
@@ -94,12 +90,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
   const [apiResultDismissed, setApiResultDismissed] = useState<boolean>(true);
   const [boxDragEnabled, setBoxDragEnabled] = useState<boolean>(true);
 
-  const { instance: msalInstance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const { speciesData, isLoading: classListLoading } = useSpeciesData(
-    backendUrl,
-    apiScopeClaim,
-  );
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
+  const { speciesData, isLoading: classListLoading } =
+    useSpeciesData(backendUrl);
 
   const classList: SpeciesData[] = useMemo(() => {
     if (!speciesData?.seeds) return [];
@@ -165,7 +158,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     }
     console.log("Submitting positive feedback for key: ", index);
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(t("microscopeFeed.errors.authInProgress"), 8000);
       return;
     }
@@ -180,13 +173,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     setApiResultDismissed(false);
 
     try {
-      const accessToken = await acquireAccessToken(msalInstance, [
-        apiScopeClaim,
-      ]);
       await sendPositiveFeedback({
         feedbackData: feedbackDataPositive,
         backendUrl,
-        accessToken,
       });
       console.log("Positive Feedback submitted successfully");
       // TODO: Update active inference result with feedback response
@@ -212,7 +201,7 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
       return;
     }
 
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       setApiError(t("microscopeFeed.errors.authInProgress"));
       setApiResultDismissed(false);
       return;
@@ -226,13 +215,9 @@ const MicroscopeFeed = (props: MicroscopeFeedProps) => {
     setApiResultDismissed(false);
 
     try {
-      const accessToken = await acquireAccessToken(msalInstance, [
-        apiScopeClaim,
-      ]);
       await sendNegativeFeedback({
         feedbackData: feedbackDataNegative,
         backendUrl,
-        accessToken,
       });
       console.log("Negative Feedback submitted successfully");
       // TODO: Update active inference result with feedback response

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
@@ -20,7 +20,7 @@ import { useModalStore } from "@stores/useModalStore";
 import { useWebcamStore } from "@stores/useWebcamStore";
 import { useModelStore } from "@stores/useModelStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
-import { useNachetAuth } from "../../../auth";
+import { useNachetAuth } from "@auth";
 
 export interface MicroscopeFeedControlsViewProps {
   isWebcamActive: boolean;

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
@@ -14,13 +14,13 @@ import InfoIcon from "@mui/icons-material/Info";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import { colours } from "@styles/colours";
-import { useAccount } from "@azure/msal-react";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { useImageStore } from "@stores/useImageStore";
 import { useModalStore } from "@stores/useModalStore";
 import { useWebcamStore } from "@stores/useWebcamStore";
 import { useModelStore } from "@stores/useModelStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
+import { useNachetAuth } from "../../../auth";
 
 export interface MicroscopeFeedControlsViewProps {
   isWebcamActive: boolean;
@@ -94,7 +94,7 @@ export const MicroscopeFeedControlsView = (
   const { getMissingMetadataCount } = useDeviceStore();
   const { images: imageCache } = useImageStore();
   const { selectedModel, metadata } = useModelStore();
-  const accountInfo = useAccount();
+  const { activeAccount } = useNachetAuth();
 
   // Modal store actions
   const {
@@ -129,19 +129,9 @@ export const MicroscopeFeedControlsView = (
     padding: 0,
   };
 
-  // Derive isGuest from accountInfo
-  // acct === 0 means member account, acct !== 0 or undefined means guest account
-  // Defensive: treat missing/undefined acct as guest (hide D button)
   const isGuest = useMemo(() => {
-    const idTokenClaims = accountInfo?.idTokenClaims as
-      | { acct?: number }
-      | undefined;
-    const acctClaim = idTokenClaims?.acct;
-
-    // Only acct === 0 means member (show D button)
-    // Everything else (undefined, null, non-zero) means guest (hide D button)
-    return acctClaim !== 0;
-  }, [accountInfo]);
+    return activeAccount?.isGuest ?? true;
+  }, [activeAccount]);
 
   // Find the model name from metadata based on selectedModel (pipelineId)
   const selectedModelName = useMemo(() => {

--- a/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
+++ b/frontend/src/components/body/microscope_feed/MicroscopeFeedControlsView.tsx
@@ -129,9 +129,7 @@ export const MicroscopeFeedControlsView = (
     padding: 0,
   };
 
-  const isGuest = useMemo(() => {
-    return activeAccount?.isGuest ?? true;
-  }, [activeAccount]);
+  const isGuest = activeAccount?.isGuest ?? true;
 
   // Find the model name from metadata based on selectedModel (pipelineId)
   const selectedModelName = useMemo(() => {

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -6,7 +6,7 @@ import useBackendUrl from "@hooks/useBackendUrl";
 import { pingBackend } from "@common/api";
 import { colours } from "../../styles/colours";
 import { useTranslation } from "react-i18next";
-import { useNachetAuth } from "../../auth";
+import { useNachetAuth } from "@auth";
 
 const Footer: React.FC = () => {
   const { activeAccount } = useNachetAuth();

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useAccount } from "@azure/msal-react";
 import { environment } from "../../environments/environment";
 import { Box, Link } from "@mui/material";
 import CanadaLogo from "../../assets/Canada_logo.png";
@@ -7,24 +6,18 @@ import useBackendUrl from "@hooks/useBackendUrl";
 import { pingBackend } from "@common/api";
 import { colours } from "../../styles/colours";
 import { useTranslation } from "react-i18next";
+import { useNachetAuth } from "../../auth";
 
 const Footer: React.FC = () => {
-  const accountInfo = useAccount();
+  const { activeAccount } = useNachetAuth();
   const backendUrl = useBackendUrl();
   const { t } = useTranslation("footer");
   const [backendConnected, setBackendConnected] = useState<boolean | null>(
     null,
   );
 
-  // Derive isGuest from accountInfo
-  // acct === 0 means member account, acct !== 0 means guest account
-  const isGuest = (() => {
-    const idTokenClaims = accountInfo?.idTokenClaims as
-      | { acct?: number }
-      | undefined;
-    const acctClaim = idTokenClaims?.acct;
-    return acctClaim !== 0;
-  })();
+  const isGuest = activeAccount?.isGuest ?? true;
+  const userOid = activeAccount?.userId ?? "";
 
   // Check backend connectivity for guest users
   useEffect(() => {
@@ -138,7 +131,7 @@ const Footer: React.FC = () => {
             zIndex: 0,
           }}
         >
-          {t("oid", { oid: accountInfo?.idTokenClaims?.oid || "" })}
+          {t("oid", { oid: userOid })}
         </Box>
         <Box
           component="img"

--- a/frontend/src/components/header/navbar/Navbar.tsx
+++ b/frontend/src/components/header/navbar/Navbar.tsx
@@ -3,7 +3,7 @@ import { Button, IconButton, Box } from "@mui/material";
 import { colours } from "../../../styles/colours";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import { useTranslation } from "react-i18next";
-import { useNachetAuth } from "../../../auth";
+import { useNachetAuth } from "@auth";
 
 const Navbar = () => {
   const { accounts, isAuthenticated, login, logout } = useNachetAuth();

--- a/frontend/src/components/header/navbar/Navbar.tsx
+++ b/frontend/src/components/header/navbar/Navbar.tsx
@@ -1,43 +1,24 @@
-import React from "react";
 import CFIALogo from "../../../assets/CFIA_blackfont.png";
 import { Button, IconButton, Box } from "@mui/material";
 import { colours } from "../../../styles/colours";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useTranslation } from "react-i18next";
+import { useNachetAuth } from "../../../auth";
 
-interface params {
-  windowSize: {
-    width: number;
-    height: number;
-  };
-  apiScopeClaim: string;
-}
-
-const Navbar: React.FC<params> = (props) => {
-  const { instance, inProgress, accounts } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const { apiScopeClaim } = props;
+const Navbar = () => {
+  const { accounts, isAuthenticated, login, logout } = useNachetAuth();
   const { t } = useTranslation("header");
-  const logout = async (): Promise<void> => {
+  const handleLogout = async (): Promise<void> => {
     try {
-      await instance.logoutRedirect();
+      await logout();
     } catch (error) {
       console.error("Logout failed:", error);
       throw error;
     }
   };
-  const login = async (): Promise<void> => {
+  const handleLogin = async (): Promise<void> => {
     try {
-      if (inProgress !== InteractionStatus.None) {
-        console.warn("Interaction already in progress, please wait");
-        return;
-      }
-      await instance.loginRedirect({
-        // scopes: ["openid", "profile", "email"],
-        scopes: [apiScopeClaim ?? ""],
-      });
+      await login();
     } catch (error) {
       console.error("Login failed:", error);
       throw error;
@@ -115,7 +96,7 @@ const Navbar: React.FC<params> = (props) => {
               variant="outlined"
               onClick={async () => {
                 try {
-                  await login();
+                  await handleLogin();
                 } catch (error) {
                   console.error("Login failed:", error);
                 }
@@ -131,7 +112,7 @@ const Navbar: React.FC<params> = (props) => {
                 sx={{ padding: 0, marginTop: "0.27vh", marginRight: "0.4vh" }}
                 onClick={async () => {
                   try {
-                    await logout();
+                    await handleLogout();
                   } catch (error) {
                     console.error("Logout failed:", error);
                   }

--- a/frontend/src/hooks/tests/useDeviceData.test.tsx
+++ b/frontend/src/hooks/tests/useDeviceData.test.tsx
@@ -3,12 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useDeviceData } from "../useDeviceData";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { fetchDevices } from "@common/api";
-import { useNachetAuth } from "../../auth";
+import { useNachetAuth } from "@auth";
 
 // Mock dependencies
 vi.mock("@stores/useDeviceStore");
 vi.mock("@common/api");
-vi.mock("../../auth");
+vi.mock("@auth");
 
 describe("useDeviceData", () => {
   let mockSetDevicesData: any;

--- a/frontend/src/hooks/tests/useDeviceData.test.tsx
+++ b/frontend/src/hooks/tests/useDeviceData.test.tsx
@@ -3,21 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useDeviceData } from "../useDeviceData";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { fetchDevices } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
+import { useNachetAuth } from "../../auth";
 
 // Mock dependencies
 vi.mock("@stores/useDeviceStore");
 vi.mock("@common/api");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
+vi.mock("../../auth");
 
 describe("useDeviceData", () => {
   let mockSetDevicesData: any;
   let mockSetLoading: any;
   let mockSetError: any;
-  let mockMsalInstance: any;
   const mockDevicesData = {
     devices: [
       { id: "device-1", name: "Device 1" },
@@ -31,7 +27,6 @@ describe("useDeviceData", () => {
     mockSetDevicesData = vi.fn();
     mockSetLoading = vi.fn();
     mockSetError = vi.fn();
-    mockMsalInstance = {} as any;
 
     // Mock the store
     (useDeviceStore as any).mockReturnValue({
@@ -43,17 +38,10 @@ describe("useDeviceData", () => {
       setError: mockSetError,
     });
 
-    // Mock useMsal
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.None,
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
-
-    // Mock useIsAuthenticated
-    (useIsAuthenticated as any).mockReturnValue(true);
-
-    // Mock auth
-    (acquireAccessToken as any).mockResolvedValue("test-token");
 
     // Mock fetchDevices
     (fetchDevices as any).mockResolvedValue(mockDevicesData);
@@ -63,22 +51,15 @@ describe("useDeviceData", () => {
   });
 
   it("should fetch and set device data when authenticated", async () => {
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetLoading).toHaveBeenCalledWith(true);
     });
 
     await waitFor(() => {
-      expect(acquireAccessToken).toHaveBeenCalledWith(mockMsalInstance, [
-        "test-scope",
-      ]);
-    });
-
-    await waitFor(() => {
       expect(fetchDevices).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -92,15 +73,18 @@ describe("useDeviceData", () => {
   });
 
   it("should not fetch when backendUrl is empty", () => {
-    renderHook(() => useDeviceData("", "test-scope"));
+    renderHook(() => useDeviceData(""));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
 
   it("should not fetch when not authenticated", () => {
-    (useIsAuthenticated as any).mockReturnValue(false);
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
@@ -115,18 +99,18 @@ describe("useDeviceData", () => {
       setError: mockSetError,
     });
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.Login,
+  it("should not fetch while auth is loading", () => {
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
     });
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     expect(fetchDevices).not.toHaveBeenCalled();
   });
@@ -135,7 +119,7 @@ describe("useDeviceData", () => {
     const mockError = new Error("Failed to fetch devices");
     (fetchDevices as any).mockRejectedValue(mockError);
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Failed to fetch devices");
@@ -156,7 +140,7 @@ describe("useDeviceData", () => {
   it("should handle non-Error rejection", async () => {
     (fetchDevices as any).mockRejectedValue("String error");
 
-    renderHook(() => useDeviceData("http://test-backend.com", "test-scope"));
+    renderHook(() => useDeviceData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Unknown error occurred");
@@ -178,7 +162,7 @@ describe("useDeviceData", () => {
     });
 
     const { result } = renderHook(() =>
-      useDeviceData("http://test-backend.com", "test-scope"),
+      useDeviceData("http://test-backend.com"),
     );
 
     expect(result.current.devicesData).toEqual(mockDevicesData);

--- a/frontend/src/hooks/tests/useFolderData.test.tsx
+++ b/frontend/src/hooks/tests/useFolderData.test.tsx
@@ -3,12 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useFolderData } from "../useFolderData";
 import { useFolderStore, FolderData } from "@stores/useFolderStore";
 import { readAzureStorageDir } from "@common/api";
-import { useNachetAuth } from "../../auth";
+import { useNachetAuth } from "@auth";
 
 // Mock dependencies
 vi.mock("@stores/useFolderStore");
 vi.mock("@common/api");
-vi.mock("../../auth");
+vi.mock("@auth");
 
 describe("useFolderData", () => {
   let mockSetFolderData: any;

--- a/frontend/src/hooks/tests/useFolderData.test.tsx
+++ b/frontend/src/hooks/tests/useFolderData.test.tsx
@@ -3,21 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useFolderData } from "../useFolderData";
 import { useFolderStore, FolderData } from "@stores/useFolderStore";
 import { readAzureStorageDir } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
+import { useNachetAuth } from "../../auth";
 
 // Mock dependencies
 vi.mock("@stores/useFolderStore");
 vi.mock("@common/api");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
+vi.mock("../../auth");
 
 describe("useFolderData", () => {
   let mockSetFolderData: any;
   let mockSetLoading: any;
   let mockSetError: any;
-  let mockMsalInstance: any;
   const mockApiResponse = {
     directories: [
       {
@@ -60,7 +56,6 @@ describe("useFolderData", () => {
     mockSetFolderData = vi.fn();
     mockSetLoading = vi.fn();
     mockSetError = vi.fn();
-    mockMsalInstance = {} as any;
 
     (useFolderStore as any).mockReturnValue({
       folderData: null,
@@ -71,20 +66,17 @@ describe("useFolderData", () => {
       setError: mockSetError,
     });
 
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.None,
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
-
-    (useIsAuthenticated as any).mockReturnValue(true);
-    (acquireAccessToken as any).mockResolvedValue("test-token");
     (readAzureStorageDir as any).mockResolvedValue(mockApiResponse);
 
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   it("should fetch and transform folder data when authenticated", async () => {
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetLoading).toHaveBeenCalledWith(true);
@@ -94,7 +86,6 @@ describe("useFolderData", () => {
     await waitFor(() => {
       expect(readAzureStorageDir).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -122,7 +113,7 @@ describe("useFolderData", () => {
       apiResponseWithoutDescription,
     );
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetFolderData).toHaveBeenCalledWith({
@@ -140,13 +131,16 @@ describe("useFolderData", () => {
   });
 
   it("should not fetch when backendUrl is empty", () => {
-    renderHook(() => useFolderData("", "test-scope"));
+    renderHook(() => useFolderData(""));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
   it("should not fetch when not authenticated", () => {
-    (useIsAuthenticated as any).mockReturnValue(false);
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    renderHook(() => useFolderData("http://test-backend.com"));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
@@ -160,17 +154,17 @@ describe("useFolderData", () => {
       setError: mockSetError,
     });
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.Login,
+  it("should not fetch while auth is loading", () => {
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
     });
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
     expect(readAzureStorageDir).not.toHaveBeenCalled();
   });
 
@@ -178,7 +172,7 @@ describe("useFolderData", () => {
     const mockError = new Error("Failed to fetch folders");
     (readAzureStorageDir as any).mockRejectedValue(mockError);
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Failed to fetch folders");
@@ -190,7 +184,7 @@ describe("useFolderData", () => {
   it("should handle non-Error rejection", async () => {
     (readAzureStorageDir as any).mockRejectedValue("String error");
 
-    renderHook(() => useFolderData("http://test-backend.com", "test-scope"));
+    renderHook(() => useFolderData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Unknown error occurred");
@@ -211,7 +205,7 @@ describe("useFolderData", () => {
     });
 
     const { result } = renderHook(() =>
-      useFolderData("http://test-backend.com", "test-scope"),
+      useFolderData("http://test-backend.com"),
     );
 
     expect(result.current.folderData).toEqual(mockFolderData);

--- a/frontend/src/hooks/tests/useModelMetadata.test.tsx
+++ b/frontend/src/hooks/tests/useModelMetadata.test.tsx
@@ -3,21 +3,15 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useModelMetadata } from "../useModelMetadata";
 import { useModelStore } from "@stores/useModelStore";
 import { fetchModelMetadata } from "@common";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 
 // Mock dependencies
 vi.mock("@stores/useModelStore");
 vi.mock("@common");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
 
 describe("useModelMetadata", () => {
   let mockSetMetadata: any;
   let mockSetSelectedModel: any;
   let mockSetLoading: any;
-  let mockMsalInstance: any;
   const mockMetadata = [
     { pipelineId: "pipeline-1", name: "Model 1", default: false },
     { pipelineId: "pipeline-2", name: "Model 2", default: true },
@@ -30,7 +24,6 @@ describe("useModelMetadata", () => {
     mockSetMetadata = vi.fn();
     mockSetSelectedModel = vi.fn();
     mockSetLoading = vi.fn();
-    mockMsalInstance = {} as any;
 
     // Mock the store
     (useModelStore as any).mockReturnValue({
@@ -40,14 +33,6 @@ describe("useModelMetadata", () => {
       setSelectedModel: mockSetSelectedModel,
       setLoading: mockSetLoading,
     });
-
-    // Mock useMsal
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-    });
-
-    // Mock auth
-    (acquireAccessToken as any).mockResolvedValue("test-token");
 
     // Mock fetchModelMetadata
     (fetchModelMetadata as any).mockResolvedValue(mockMetadata);
@@ -61,9 +46,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -72,15 +56,8 @@ describe("useModelMetadata", () => {
     });
 
     await waitFor(() => {
-      expect(acquireAccessToken).toHaveBeenCalledWith(mockMsalInstance, [
-        "test-scope",
-      ]);
-    });
-
-    await waitFor(() => {
       expect(fetchModelMetadata).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -101,22 +78,20 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: false,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
     expect(fetchModelMetadata).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
+  it("should not fetch while auth is loading", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.Login,
+        authLoading: true,
       }),
     );
 
@@ -134,9 +109,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -155,9 +129,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -185,9 +158,8 @@ describe("useModelMetadata", () => {
     renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -215,9 +187,8 @@ describe("useModelMetadata", () => {
     const { result } = renderHook(() =>
       useModelMetadata({
         backendUrl: "http://test-backend.com",
-        apiScopeClaim: "test-scope",
         isAuthenticated: true,
-        inProgress: InteractionStatus.None,
+        authLoading: false,
       }),
     );
 
@@ -230,9 +201,8 @@ describe("useModelMetadata", () => {
       ({ backendUrl }) =>
         useModelMetadata({
           backendUrl,
-          apiScopeClaim: "test-scope",
           isAuthenticated: true,
-          inProgress: InteractionStatus.None,
+          authLoading: false,
         }),
       {
         initialProps: { backendUrl: "http://test-backend-1.com" },

--- a/frontend/src/hooks/tests/useSpeciesData.test.tsx
+++ b/frontend/src/hooks/tests/useSpeciesData.test.tsx
@@ -3,21 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useSpeciesData } from "../useSpeciesData";
 import { useSpeciesStore } from "@stores/useSpeciesStore";
 import { requestClassList } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
+import { useNachetAuth } from "../../auth";
 
 // Mock dependencies
 vi.mock("@stores/useSpeciesStore");
 vi.mock("@common/api");
-vi.mock("@common/auth");
-vi.mock("@azure/msal-react");
+vi.mock("../../auth");
 
 describe("useSpeciesData", () => {
   let mockSetSpeciesData: any;
   let mockSetLoading: any;
   let mockSetError: any;
-  let mockMsalInstance: any;
   const mockSpeciesData = [
     { id: 1, name: "Species 1" },
     { id: 2, name: "Species 2" },
@@ -29,7 +25,6 @@ describe("useSpeciesData", () => {
     mockSetSpeciesData = vi.fn();
     mockSetLoading = vi.fn();
     mockSetError = vi.fn();
-    mockMsalInstance = {} as any;
 
     (useSpeciesStore as any).mockReturnValue({
       speciesData: null,
@@ -40,20 +35,17 @@ describe("useSpeciesData", () => {
       setError: mockSetError,
     });
 
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.None,
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
     });
-
-    (useIsAuthenticated as any).mockReturnValue(true);
-    (acquireAccessToken as any).mockResolvedValue("test-token");
     (requestClassList as any).mockResolvedValue(mockSpeciesData);
 
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   it("should fetch and set species data when authenticated", async () => {
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetLoading).toHaveBeenCalledWith(true);
@@ -63,7 +55,6 @@ describe("useSpeciesData", () => {
     await waitFor(() => {
       expect(requestClassList).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
       });
     });
 
@@ -74,13 +65,16 @@ describe("useSpeciesData", () => {
   });
 
   it("should not fetch when backendUrl is empty", () => {
-    renderHook(() => useSpeciesData("", "test-scope"));
+    renderHook(() => useSpeciesData(""));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
   it("should not fetch when not authenticated", () => {
-    (useIsAuthenticated as any).mockReturnValue(false);
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    renderHook(() => useSpeciesData("http://test-backend.com"));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
@@ -94,17 +88,17 @@ describe("useSpeciesData", () => {
       setError: mockSetError,
     });
 
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when interaction is in progress", () => {
-    (useMsal as any).mockReturnValue({
-      instance: mockMsalInstance,
-      inProgress: InteractionStatus.Login,
+  it("should not fetch while auth is loading", () => {
+    (useNachetAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
     });
 
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
     expect(requestClassList).not.toHaveBeenCalled();
   });
 
@@ -112,7 +106,7 @@ describe("useSpeciesData", () => {
     const mockError = new Error("Failed to fetch species");
     (requestClassList as any).mockRejectedValue(mockError);
 
-    renderHook(() => useSpeciesData("http://test-backend.com", "test-scope"));
+    renderHook(() => useSpeciesData("http://test-backend.com"));
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Failed to fetch species");
@@ -132,7 +126,7 @@ describe("useSpeciesData", () => {
     });
 
     const { result } = renderHook(() =>
-      useSpeciesData("http://test-backend.com", "test-scope"),
+      useSpeciesData("http://test-backend.com"),
     );
 
     expect(result.current.speciesData).toEqual(mockSpeciesData);

--- a/frontend/src/hooks/tests/useSpeciesData.test.tsx
+++ b/frontend/src/hooks/tests/useSpeciesData.test.tsx
@@ -3,12 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useSpeciesData } from "../useSpeciesData";
 import { useSpeciesStore } from "@stores/useSpeciesStore";
 import { requestClassList } from "@common/api";
-import { useNachetAuth } from "../../auth";
+import { useNachetAuth } from "@auth";
 
 // Mock dependencies
 vi.mock("@stores/useSpeciesStore");
 vi.mock("@common/api");
-vi.mock("../../auth");
+vi.mock("@auth");
 
 describe("useSpeciesData", () => {
   let mockSetSpeciesData: any;

--- a/frontend/src/hooks/tests/useWorkflowPolling.test.ts
+++ b/frontend/src/hooks/tests/useWorkflowPolling.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import { useWorkflowPolling } from "../useWorkflowPolling";
 import { useWorkflowStore } from "@stores/useWorkflowStore";
 import * as commonApi from "@common/index";
+import { useNachetAuth } from "../../auth";
 import { errorLogger } from "../../logging";
 import type { ApiInferenceData, WorkflowStatusResponse } from "@common/types";
 
@@ -18,10 +19,11 @@ vi.mock("../../logging", () => ({
   },
 }));
 
+vi.mock("../../auth");
+
 describe("useWorkflowPolling", () => {
   const mockWorkflowId = "workflow-123";
   const mockBackendUrl = "http://localhost:8080";
-  const mockAccessToken = "mock-token";
   const mockOnComplete = vi.fn();
   const mockOnError = vi.fn();
 
@@ -97,6 +99,11 @@ describe("useWorkflowPolling", () => {
     useWorkflowStore.setState({
       workflows: new Map(),
     });
+
+    vi.mocked(useNachetAuth).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    } as ReturnType<typeof useNachetAuth>);
   });
 
   afterEach(() => {
@@ -110,7 +117,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: false,
           onComplete: mockOnComplete,
         }),
@@ -127,7 +133,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: "",
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -143,7 +148,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: "",
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -154,12 +158,16 @@ describe("useWorkflowPolling", () => {
       expect(commonApi.getWorkflowStatus).not.toHaveBeenCalled();
     });
 
-    it("should not start polling when accessToken is empty", () => {
+    it("should not start polling when the user is not authenticated", () => {
+      vi.mocked(useNachetAuth).mockReturnValue({
+        isAuthenticated: false,
+        isLoading: false,
+      } as ReturnType<typeof useNachetAuth>);
+
       renderHook(() =>
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: "",
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -181,7 +189,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -205,7 +212,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -244,7 +250,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -282,7 +287,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -293,13 +297,11 @@ describe("useWorkflowPolling", () => {
       expect(commonApi.getWorkflowStatus).toHaveBeenCalledWith({
         backendUrl: mockBackendUrl,
         workflowId: mockWorkflowId,
-        accessToken: mockAccessToken,
       });
 
       expect(commonApi.getWorkflowResults).toHaveBeenCalledWith({
         backendUrl: mockBackendUrl,
         workflowId: mockWorkflowId,
-        accessToken: mockAccessToken,
       });
 
       expect(mockOnComplete).toHaveBeenCalledWith(mockInferenceResults);
@@ -328,7 +330,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -355,7 +356,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -391,7 +391,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -426,7 +425,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -461,7 +459,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -496,7 +493,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -531,7 +527,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -566,7 +561,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -591,7 +585,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -616,7 +609,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -652,7 +644,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -676,7 +667,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -700,7 +690,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -739,7 +728,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -767,7 +755,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           onError: mockOnError,
@@ -787,7 +774,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
           // No onError provided
@@ -813,7 +799,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -836,7 +821,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -857,7 +841,6 @@ describe("useWorkflowPolling", () => {
           useWorkflowPolling({
             workflowId: mockWorkflowId,
             backendUrl: mockBackendUrl,
-            accessToken: mockAccessToken,
             enabled,
             onComplete: mockOnComplete,
           }),
@@ -894,7 +877,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),
@@ -921,7 +903,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: false,
           onComplete: mockOnComplete,
         }),
@@ -939,7 +920,6 @@ describe("useWorkflowPolling", () => {
         useWorkflowPolling({
           workflowId: mockWorkflowId,
           backendUrl: mockBackendUrl,
-          accessToken: mockAccessToken,
           enabled: true,
           onComplete: mockOnComplete,
         }),

--- a/frontend/src/hooks/tests/useWorkflowPolling.test.ts
+++ b/frontend/src/hooks/tests/useWorkflowPolling.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from "@testing-library/react";
 import { useWorkflowPolling } from "../useWorkflowPolling";
 import { useWorkflowStore } from "@stores/useWorkflowStore";
 import * as commonApi from "@common/index";
-import { useNachetAuth } from "../../auth";
+import { useNachetAuth } from "@auth";
 import { errorLogger } from "../../logging";
 import type { ApiInferenceData, WorkflowStatusResponse } from "@common/types";
 
@@ -19,7 +19,7 @@ vi.mock("../../logging", () => ({
   },
 }));
 
-vi.mock("../../auth");
+vi.mock("@auth");
 
 describe("useWorkflowPolling", () => {
   const mockWorkflowId = "workflow-123";

--- a/frontend/src/hooks/useDeviceData.ts
+++ b/frontend/src/hooks/useDeviceData.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { fetchDevices } from "@common/api";
-import { useNachetAuth } from "../auth";
+import { useNachetAuth } from "@auth";
 
 export const useDeviceData = (backendUrl: string) => {
   const {

--- a/frontend/src/hooks/useDeviceData.ts
+++ b/frontend/src/hooks/useDeviceData.ts
@@ -1,11 +1,9 @@
 import { useEffect } from "react";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { fetchDevices } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../auth";
 
-export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
+export const useDeviceData = (backendUrl: string) => {
   const {
     devicesData,
     isLoading,
@@ -14,8 +12,7 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
     setLoading,
     setError,
   } = useDeviceStore();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   useEffect(() => {
     const fetchDeviceData = async () => {
@@ -31,7 +28,7 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
         return; // Already have data, don't fetch again
       }
 
-      if (inProgress !== InteractionStatus.None) {
+      if (authLoading) {
         return; // Wait for interaction to complete
       }
 
@@ -39,8 +36,7 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
       setError(null);
 
       try {
-        const accessToken = await acquireAccessToken(instance, [apiScopeClaim]);
-        const response = await fetchDevices({ backendUrl, accessToken });
+        const response = await fetchDevices({ backendUrl });
         setDevicesData(response);
       } catch (err) {
         const errorMessage =
@@ -54,10 +50,8 @@ export const useDeviceData = (backendUrl: string, apiScopeClaim: string) => {
 
     fetchDeviceData();
   }, [
-    apiScopeClaim,
+    authLoading,
     backendUrl,
-    instance,
-    inProgress,
     isAuthenticated,
     setError,
     setLoading,

--- a/frontend/src/hooks/useFolderData.ts
+++ b/frontend/src/hooks/useFolderData.ts
@@ -8,7 +8,7 @@
 import { useEffect } from "react";
 import { useFolderStore, FolderData } from "@stores/useFolderStore";
 import { readAzureStorageDir } from "@common/api";
-import { useNachetAuth } from "../auth";
+import { useNachetAuth } from "@auth";
 
 export const useFolderData = (backendUrl: string) => {
   const { folderData, isLoading, error, setFolderData, setLoading, setError } =

--- a/frontend/src/hooks/useFolderData.ts
+++ b/frontend/src/hooks/useFolderData.ts
@@ -6,17 +6,14 @@
  */
 
 import { useEffect } from "react";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useFolderStore, FolderData } from "@stores/useFolderStore";
 import { readAzureStorageDir } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../auth";
 
-export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
+export const useFolderData = (backendUrl: string) => {
   const { folderData, isLoading, error, setFolderData, setLoading, setError } =
     useFolderStore();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   useEffect(() => {
     const fetchFolderData = async () => {
@@ -32,7 +29,7 @@ export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
         return; // Already have data, don't fetch again
       }
 
-      if (inProgress !== InteractionStatus.None) {
+      if (authLoading) {
         return; // Wait for interaction to complete
       }
 
@@ -40,8 +37,7 @@ export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
       setError(null);
 
       try {
-        const accessToken = await acquireAccessToken(instance, [apiScopeClaim]);
-        const response = await readAzureStorageDir({ backendUrl, accessToken });
+        const response = await readAzureStorageDir({ backendUrl });
 
         // Transform API response to match store format
         const directories: FolderData[] = response.directories.map((item) => ({
@@ -66,10 +62,8 @@ export const useFolderData = (backendUrl: string, apiScopeClaim: string) => {
 
     fetchFolderData();
   }, [
-    apiScopeClaim,
+    authLoading,
     backendUrl,
-    instance,
-    inProgress,
     isAuthenticated,
     setError,
     setLoading,

--- a/frontend/src/hooks/useModelMetadata.ts
+++ b/frontend/src/hooks/useModelMetadata.ts
@@ -8,41 +8,31 @@
 import { useEffect } from "react";
 import { useModelStore } from "@stores/useModelStore";
 import { fetchModelMetadata } from "@common";
-import { acquireAccessToken } from "@common/auth";
-import { useMsal } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 
 interface UseModelMetadataParams {
   backendUrl: string;
-  apiScopeClaim: string;
   isAuthenticated: boolean;
-  inProgress: InteractionStatus;
+  authLoading: boolean;
 }
 
 export const useModelMetadata = ({
   backendUrl,
-  apiScopeClaim,
   isAuthenticated,
-  inProgress,
+  authLoading,
 }: UseModelMetadataParams) => {
-  const { instance: msalInstance } = useMsal();
   const { metadata, selectedModel, setMetadata, setSelectedModel, setLoading } =
     useModelStore();
 
   useEffect(() => {
     // Only load metadata if user is authenticated and no interaction is in progress
-    if (!isAuthenticated || inProgress !== InteractionStatus.None) {
+    if (!isAuthenticated || authLoading) {
       return;
     }
 
     const loadModelMetadata = async () => {
       try {
         setLoading(true);
-        const accessToken = await acquireAccessToken(msalInstance, [
-          apiScopeClaim,
-        ]);
-
-        const metadata = await fetchModelMetadata({ backendUrl, accessToken });
+        const metadata = await fetchModelMetadata({ backendUrl });
         setMetadata(metadata);
 
         // Find the default model from the metadata
@@ -63,11 +53,9 @@ export const useModelMetadata = ({
 
     void loadModelMetadata();
   }, [
+    authLoading,
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
     isAuthenticated,
-    inProgress,
     setMetadata,
     setSelectedModel,
     setLoading,

--- a/frontend/src/hooks/useSpeciesData.ts
+++ b/frontend/src/hooks/useSpeciesData.ts
@@ -1,11 +1,9 @@
 import { useEffect } from "react";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { InteractionStatus } from "@azure/msal-browser";
 import { useSpeciesStore } from "@stores/useSpeciesStore";
 import { requestClassList } from "@common/api";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../auth";
 
-export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
+export const useSpeciesData = (backendUrl: string) => {
   const {
     speciesData,
     isLoading,
@@ -14,8 +12,7 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
     setLoading,
     setError,
   } = useSpeciesStore();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
 
   useEffect(() => {
     const fetchSpeciesData = async () => {
@@ -31,7 +28,7 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
         return; // Already have data, don't fetch again
       }
 
-      if (inProgress !== InteractionStatus.None) {
+      if (authLoading) {
         return; // Wait for interaction to complete
       }
 
@@ -39,8 +36,7 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
       setError(null);
 
       try {
-        const accessToken = await acquireAccessToken(instance, [apiScopeClaim]);
-        const response = await requestClassList({ backendUrl, accessToken });
+        const response = await requestClassList({ backendUrl });
         setSpeciesData(response);
       } catch (err) {
         const errorMessage =
@@ -54,10 +50,8 @@ export const useSpeciesData = (backendUrl: string, apiScopeClaim: string) => {
 
     fetchSpeciesData();
   }, [
-    apiScopeClaim,
+    authLoading,
     backendUrl,
-    instance,
-    inProgress,
     isAuthenticated,
     setError,
     setLoading,

--- a/frontend/src/hooks/useSpeciesData.ts
+++ b/frontend/src/hooks/useSpeciesData.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useSpeciesStore } from "@stores/useSpeciesStore";
 import { requestClassList } from "@common/api";
-import { useNachetAuth } from "../auth";
+import { useNachetAuth } from "@auth";
 
 export const useSpeciesData = (backendUrl: string) => {
   const {

--- a/frontend/src/hooks/useWorkflowPolling.ts
+++ b/frontend/src/hooks/useWorkflowPolling.ts
@@ -3,7 +3,7 @@ import { getWorkflowStatus, getWorkflowResults } from "@common/index";
 import { useWorkflowStore } from "@stores/useWorkflowStore";
 import { ApiInferenceData, WorkflowStatus } from "@common/types";
 import { errorLogger } from "../logging";
-import { useNachetAuth } from "../auth";
+import { useNachetAuth } from "@auth";
 
 const POLLING_INTERVAL_MS = 10000; // 10 seconds
 const INITIAL_DELAY_MS = 20000; // 20 seconds - wait before first poll

--- a/frontend/src/hooks/useWorkflowPolling.ts
+++ b/frontend/src/hooks/useWorkflowPolling.ts
@@ -190,13 +190,11 @@ export const useWorkflowPolling = ({
   ]);
 
   useEffect(() => {
-    if (
-      !enabled ||
-      !workflowId ||
-      !backendUrl ||
-      !isAuthenticated ||
-      authLoading
-    ) {
+    const isWorkflowReady =
+      enabled && Boolean(workflowId) && Boolean(backendUrl);
+    const isAuthReady = isAuthenticated && !authLoading;
+
+    if (!isWorkflowReady || !isAuthReady) {
       return;
     }
 

--- a/frontend/src/hooks/useWorkflowPolling.ts
+++ b/frontend/src/hooks/useWorkflowPolling.ts
@@ -3,6 +3,7 @@ import { getWorkflowStatus, getWorkflowResults } from "@common/index";
 import { useWorkflowStore } from "@stores/useWorkflowStore";
 import { ApiInferenceData, WorkflowStatus } from "@common/types";
 import { errorLogger } from "../logging";
+import { useNachetAuth } from "../auth";
 
 const POLLING_INTERVAL_MS = 10000; // 10 seconds
 const INITIAL_DELAY_MS = 20000; // 20 seconds - wait before first poll
@@ -18,7 +19,6 @@ const isTerminalState = (status: string): status is TerminalState => {
 interface UseWorkflowPollingParams {
   workflowId: string;
   backendUrl: string;
-  accessToken: string;
   enabled: boolean;
   onComplete: (results: ApiInferenceData) => void;
   onError?: (error: Error) => void;
@@ -28,7 +28,6 @@ interface UseWorkflowPollingParams {
  * Custom hook for polling workflow status and fetching results when complete
  * @param workflowId - The workflow ID to poll
  * @param backendUrl - Backend API URL
- * @param accessToken - Authentication token
  * @param enabled - Whether polling is enabled
  * @param onComplete - Callback when workflow completes successfully
  * @param onError - Optional callback when workflow fails
@@ -36,11 +35,11 @@ interface UseWorkflowPollingParams {
 export const useWorkflowPolling = ({
   workflowId,
   backendUrl,
-  accessToken,
   enabled,
   onComplete,
   onError,
 }: UseWorkflowPollingParams) => {
+  const { isAuthenticated, isLoading: authLoading } = useNachetAuth();
   const updateWorkflowStatus = useWorkflowStore(
     (state) => state.updateWorkflowStatus,
   );
@@ -74,7 +73,6 @@ export const useWorkflowPolling = ({
       const statusResponse = await getWorkflowStatus({
         backendUrl,
         workflowId,
-        accessToken,
       });
 
       console.log(
@@ -114,7 +112,6 @@ export const useWorkflowPolling = ({
           const results = await getWorkflowResults({
             backendUrl,
             workflowId,
-            accessToken,
           });
 
           console.log(
@@ -185,7 +182,6 @@ export const useWorkflowPolling = ({
   }, [
     workflowId,
     backendUrl,
-    accessToken,
     updateWorkflowStatus,
     removeWorkflow,
     onComplete,
@@ -194,7 +190,13 @@ export const useWorkflowPolling = ({
   ]);
 
   useEffect(() => {
-    if (!enabled || !workflowId || !backendUrl || !accessToken) {
+    if (
+      !enabled ||
+      !workflowId ||
+      !backendUrl ||
+      !isAuthenticated ||
+      authLoading
+    ) {
       return;
     }
 
@@ -217,7 +219,14 @@ export const useWorkflowPolling = ({
         pollingIntervalRef.current = null;
       }
     };
-  }, [enabled, workflowId, backendUrl, accessToken, pollWorkflowStatus]);
+  }, [
+    enabled,
+    workflowId,
+    backendUrl,
+    isAuthenticated,
+    authLoading,
+    pollWorkflowStatus,
+  ]);
 
   return {
     isPolling: enabled && pollingIntervalRef.current !== null,

--- a/frontend/src/root/body/body.test.tsx
+++ b/frontend/src/root/body/body.test.tsx
@@ -2,6 +2,19 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Body from "./body";
 
+vi.mock("../../auth", () => ({
+  useNachetAuth: () => ({
+    isAuthenticated: false,
+    isLoading: false,
+    activeAccount: null,
+    accounts: [],
+    login: vi.fn(),
+    logout: vi.fn(),
+    getAccessToken: vi.fn(),
+    provider: "msal",
+  }),
+}));
+
 // Mock the hooks
 vi.mock("@hooks", () => ({
   useBackendUrl: () => "http://localhost:8080",
@@ -195,7 +208,6 @@ const mockProps = {
   signedIn: false,
   setUuid: vi.fn(),
   user: null,
-  apiScopeClaim: "test-api-scope-claim",
 };
 
 const mockAddEventListener = vi.fn();

--- a/frontend/src/root/body/body.test.tsx
+++ b/frontend/src/root/body/body.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Body from "./body";
 
-vi.mock("../../auth", () => ({
+vi.mock("@auth", () => ({
   useNachetAuth: () => ({
     isAuthenticated: false,
     isLoading: false,

--- a/frontend/src/root/body/body.tsx
+++ b/frontend/src/root/body/body.tsx
@@ -39,9 +39,7 @@ import { useModelStore } from "@stores/useModelStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
 import { useInferenceResultsStore } from "@stores/useInferenceResultsStore";
 import { WorkflowQueueManager } from "../../services/WorkflowQueueManager";
-import { InteractionStatus } from "@azure/msal-browser";
-import { useMsal, useIsAuthenticated, useAccount } from "@azure/msal-react";
-import { acquireAccessToken } from "@common/auth";
+import { useNachetAuth } from "../../auth";
 import {
   getLabelOccurrence,
   loadToCanvas,
@@ -65,7 +63,6 @@ interface params {
   creativeCommonsPopupOpen: boolean;
   setCreativeCommonsPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handleCreativeCommonsAgreement: (agree: boolean) => void;
-  apiScopeClaim: string;
 }
 
 const Body: React.FC<params> = (props) => {
@@ -160,22 +157,23 @@ const Body: React.FC<params> = (props) => {
 
   const decodedTiff = useDecoderTiff(imageTiff);
   const backendUrl = useBackendUrl();
-  const apiScopeClaim = props.apiScopeClaim;
-  const { instance: msalInstance, inProgress, accounts } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const accountInfo = useAccount();
+  const {
+    accounts,
+    activeAccount,
+    isAuthenticated,
+    isLoading: authLoading,
+  } = useNachetAuth();
 
   // Webcam devices hook
   useWebcamDevices();
-  const uuid = accountInfo?.idTokenClaims?.oid ?? "";
-  const { devicesData } = useDeviceData(backendUrl, apiScopeClaim);
+  const uuid = activeAccount?.userId ?? "";
+  const { devicesData } = useDeviceData(backendUrl);
 
   // Model metadata hook
   useModelMetadata({
     backendUrl,
-    apiScopeClaim,
     isAuthenticated,
-    inProgress,
+    authLoading,
   });
 
   // Model store
@@ -204,15 +202,8 @@ const Body: React.FC<params> = (props) => {
 
   // Derive authPopupOpen from authentication state
   const authPopupOpen = useMemo(() => {
-    return !isAuthenticated && inProgress === InteractionStatus.None;
-  }, [isAuthenticated, inProgress]);
-
-  // Set active account if available
-  useEffect(() => {
-    if (accounts.length > 0 && !msalInstance.getActiveAccount()) {
-      msalInstance.setActiveAccount(accounts[0]);
-    }
-  }, [accounts, msalInstance]);
+    return !isAuthenticated && !authLoading;
+  }, [authLoading, isAuthenticated]);
 
   const captureFeed = (): void => {
     // takes screenshot of webcam feed and loads it to cache when capture button is pressed
@@ -234,7 +225,7 @@ const Body: React.FC<params> = (props) => {
       addError(t("auth.signInRequired"), "auth");
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(t("auth.inProgress"), 8000);
       return;
     }
@@ -252,17 +243,13 @@ const Body: React.FC<params> = (props) => {
       const folderName = curDir.folderName;
 
       setIsLoading(true);
-      acquireAccessToken(msalInstance, [apiScopeClaim])
-        .then((accessToken) => {
-          return inferenceDirectRequest({
-            backendUrl,
-            selectedModel,
-            imageObject,
-            curDir: folderName,
-            accessToken,
-            folderId: folderId,
-          });
-        })
+      inferenceDirectRequest({
+        backendUrl,
+        selectedModel,
+        imageObject,
+        curDir: folderName,
+        folderId: folderId,
+      })
         .then((response) => {
           setReadAzureStorage(!readAzureStorage);
           // TODO: Handle direct inference results with new inference store
@@ -288,7 +275,7 @@ const Body: React.FC<params> = (props) => {
       addError(t("auth.signInRequired"), "auth");
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       addWarning(t("auth.inProgress"), 8000);
       return;
     }
@@ -335,12 +322,8 @@ const Body: React.FC<params> = (props) => {
       return;
     }
 
-    const scopes = apiScopeClaim ? [apiScopeClaim] : [];
-
     queueManagerRef.current.configure({
       backendUrl,
-      msalInstance,
-      scopes,
       pipelineId,
       pipelineName,
       curDir,
@@ -430,8 +413,6 @@ const Body: React.FC<params> = (props) => {
     });
   }, [
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
     pipelineId,
     pipelineName,
     curDir,
@@ -507,7 +488,7 @@ const Body: React.FC<params> = (props) => {
     if (!isAuthenticated) {
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       return;
     }
     if (backendUrl == null || backendUrl === "") {
@@ -523,12 +504,8 @@ const Body: React.FC<params> = (props) => {
 
     const checkRegistration = async () => {
       try {
-        const accessToken = await acquireAccessToken(msalInstance, [
-          apiScopeClaim,
-        ]);
         const response = await checkUserRegistration({
           backendUrl,
-          accessToken,
         });
 
         if (!response.isRegistered) {
@@ -550,10 +527,8 @@ const Body: React.FC<params> = (props) => {
   }, [
     uuid,
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
+    authLoading,
     isAuthenticated,
-    inProgress,
     registrationCheckComplete,
     t,
     addError,
@@ -563,7 +538,7 @@ const Body: React.FC<params> = (props) => {
     if (!isAuthenticated) {
       return;
     }
-    if (inProgress !== InteractionStatus.None) {
+    if (authLoading) {
       return;
     }
     if (backendUrl == null || backendUrl === "") {
@@ -579,10 +554,7 @@ const Body: React.FC<params> = (props) => {
 
     const loadAzureStorageDir = async () => {
       try {
-        const accessToken = await acquireAccessToken(msalInstance, [
-          apiScopeClaim,
-        ]);
-        const response = await readAzureStorageDir({ backendUrl, accessToken });
+        const response = await readAzureStorageDir({ backendUrl });
         const directories: AzureStorageDirectoryItem[] = [];
         const folders = response.directories;
         folders.forEach((item: AzureStorageDirectoryItemApi) => {
@@ -609,10 +581,8 @@ const Body: React.FC<params> = (props) => {
   }, [
     uuid,
     backendUrl,
-    msalInstance,
-    apiScopeClaim,
+    authLoading,
     isAuthenticated,
-    inProgress,
     registrationCheckComplete,
     readAzureStorage,
     t,
@@ -671,7 +641,6 @@ const Body: React.FC<params> = (props) => {
             onClose={() => {
               /* Auth popup closes automatically when user is authenticated */
             }}
-            apiScopeClaim={apiScopeClaim}
           />
         )}
         {registrationModalOpen && (
@@ -685,21 +654,18 @@ const Body: React.FC<params> = (props) => {
             backendUrl={backendUrl}
             uuid={uuid}
             containerName={uuid}
-            apiScopeClaim={apiScopeClaim}
             setReadAzureStorage={setReadAzureStorage}
           />
         )}
         {createDirectoryOpen && (
           <DirectoryPopup
             setReadAzureStorage={setReadAzureStorage}
-            apiScopeClaim={apiScopeClaim}
             mode="create"
           />
         )}
         {editDirectoryOpen && editingFolder && (
           <DirectoryPopup
             setReadAzureStorage={setReadAzureStorage}
-            apiScopeClaim={apiScopeClaim}
             mode="edit"
             initialData={{
               folderId: editingFolder.folderId,
@@ -711,7 +677,6 @@ const Body: React.FC<params> = (props) => {
         {delDirectoryOpen && curDir && (
           <DirectoryPopup
             setReadAzureStorage={setReadAzureStorage}
-            apiScopeClaim={apiScopeClaim}
             mode="delete"
             initialData={{
               folderId: curDir.folderId,
@@ -799,7 +764,6 @@ const Body: React.FC<params> = (props) => {
               onFreeformBoxChange={handleFreeformBoxChange}
               backendUrl={backendUrl}
               uuid={uuid}
-              apiScopeClaim={apiScopeClaim}
             />
           </Box>
           <Box

--- a/frontend/src/root/body/body.tsx
+++ b/frontend/src/root/body/body.tsx
@@ -39,7 +39,7 @@ import { useModelStore } from "@stores/useModelStore";
 import { useNotificationStore } from "@stores/useNotificationStore";
 import { useInferenceResultsStore } from "@stores/useInferenceResultsStore";
 import { WorkflowQueueManager } from "../../services/WorkflowQueueManager";
-import { useNachetAuth } from "../../auth";
+import { useNachetAuth } from "@auth";
 import {
   getLabelOccurrence,
   loadToCanvas,

--- a/frontend/src/services/BatchUploadQueueManager.ts
+++ b/frontend/src/services/BatchUploadQueueManager.ts
@@ -2,8 +2,6 @@ import { getWorkflowStatus } from "@common";
 import { batchUploadImage } from "@common/api";
 import type { BatchUploadMetadata, WorkflowStatus } from "@common/types";
 import { errorLogger } from "../logging";
-import { acquireAccessToken } from "../common/auth";
-import type { IPublicClientApplication } from "@azure/msal-browser";
 
 interface QueueItem {
   file: File;
@@ -34,8 +32,6 @@ interface UploadStore {
 
 interface BatchUploadQueueManagerConfig {
   backendUrl: string;
-  msalInstance: IPublicClientApplication;
-  scopes: string[];
   uploadStore: UploadStore;
   onComplete: (workflowId: string, file: File, results: unknown) => void;
   onError: (workflowId: string, file: File, error: Error) => void;
@@ -130,19 +126,12 @@ export class BatchUploadQueueManager {
     const item = this.queue.shift()!;
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       // Convert file to base64 data URL
       const imageDataUrl = await this.fileToDataUrl(item.file);
 
       // Submit to backend
       const response = await batchUploadImage({
         backendUrl: this.config.backendUrl,
-        accessToken,
         data: {
           ...item.metadata,
           imageDataUrl,
@@ -283,16 +272,9 @@ export class BatchUploadQueueManager {
     }
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       const statusResponse = await getWorkflowStatus({
         backendUrl: this.config.backendUrl,
         workflowId,
-        accessToken,
       });
 
       // Update upload status in store

--- a/frontend/src/services/WorkflowQueueManager.ts
+++ b/frontend/src/services/WorkflowQueueManager.ts
@@ -5,8 +5,6 @@ import {
 } from "@common";
 import type { Images, ApiInferenceData } from "@common/types";
 import { errorLogger } from "../logging";
-import { acquireAccessToken } from "../common/auth";
-import type { IPublicClientApplication } from "@azure/msal-browser";
 
 interface QueueItem {
   imageIndex: number;
@@ -47,8 +45,6 @@ interface WorkflowStore {
 
 interface WorkflowQueueManagerConfig {
   backendUrl: string;
-  msalInstance: IPublicClientApplication;
-  scopes: string[];
   pipelineId: string;
   pipelineName: string;
   curDir: { folderId: string; folderName: string };
@@ -184,19 +180,12 @@ export class WorkflowQueueManager {
         return;
       }
 
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       // Submit to backend using the pipeline info from queue item
       const response = await inferenceRequest({
         backendUrl: this.config.backendUrl,
         selectedModel: item.pipelineId,
         imageObject: image as Images,
         curDir: this.config.curDir.folderName,
-        accessToken,
         folderId: this.config.curDir.folderId,
       });
 
@@ -316,16 +305,9 @@ export class WorkflowQueueManager {
     }
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       const statusResponse = await getWorkflowStatus({
         backendUrl: this.config.backendUrl,
         workflowId,
-        accessToken,
       });
 
       // Update workflow status in store
@@ -367,17 +349,10 @@ export class WorkflowQueueManager {
     this.stopPolling();
 
     try {
-      // Acquire fresh access token
-      const accessToken = await acquireAccessToken(
-        this.config.msalInstance,
-        this.config.scopes,
-      );
-
       // Fetch results
       const results = await getWorkflowResults({
         backendUrl: this.config.backendUrl,
         workflowId,
-        accessToken,
       });
 
       // Clear current workflow BEFORE calling callback

--- a/frontend/src/services/tests/BatchUploadQueueManager.test.ts
+++ b/frontend/src/services/tests/BatchUploadQueueManager.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { BatchUploadQueueManager } from "../BatchUploadQueueManager";
 import * as api from "@common/api";
-import * as auth from "@common/auth";
 import { errorLogger } from "../../logging";
 
 // Mock dependencies
 vi.mock("@common/api");
-vi.mock("@common/auth");
 vi.mock("../../logging");
 
 describe("BatchUploadQueueManager", () => {
@@ -14,7 +12,6 @@ describe("BatchUploadQueueManager", () => {
   let mockUploadStore: any;
   let mockOnComplete: any;
   let mockOnError: any;
-  let mockMsalInstance: any;
   let mockConfig: any;
 
   beforeEach(() => {
@@ -32,19 +29,13 @@ describe("BatchUploadQueueManager", () => {
 
     mockOnComplete = vi.fn();
     mockOnError = vi.fn();
-    mockMsalInstance = {} as any;
 
     mockConfig = {
       backendUrl: "http://test-backend.com",
-      msalInstance: mockMsalInstance,
-      scopes: ["test-scope"],
       uploadStore: mockUploadStore,
       onComplete: mockOnComplete,
       onError: mockOnError,
     };
-
-    // Mock auth
-    (auth.acquireAccessToken as any).mockResolvedValue("test-token");
 
     // Mock FileReader for file conversion
     global.FileReader = class {
@@ -166,7 +157,6 @@ describe("BatchUploadQueueManager", () => {
 
       expect(api.batchUploadImage).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
-        accessToken: "test-token",
         data: expect.objectContaining({
           ...metadata,
           imageDataUrl: "data:image/jpeg;base64,testdata",

--- a/frontend/src/services/tests/WorkflowQueueManager.test.ts
+++ b/frontend/src/services/tests/WorkflowQueueManager.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { WorkflowQueueManager } from "../WorkflowQueueManager";
 import * as api from "@common/api";
-import * as auth from "@common/auth";
 import { errorLogger } from "../../logging";
 
 // Mock dependencies
 vi.mock("@common/api");
-vi.mock("@common/auth");
 vi.mock("../../logging");
 
 describe("WorkflowQueueManager", () => {
@@ -14,7 +12,6 @@ describe("WorkflowQueueManager", () => {
   let mockWorkflowStore: any;
   let mockOnComplete: any;
   let mockOnError: any;
-  let mockMsalInstance: any;
   let mockConfig: any;
 
   beforeEach(() => {
@@ -31,12 +28,9 @@ describe("WorkflowQueueManager", () => {
 
     mockOnComplete = vi.fn();
     mockOnError = vi.fn();
-    mockMsalInstance = {} as any;
 
     mockConfig = {
       backendUrl: "http://test-backend.com",
-      msalInstance: mockMsalInstance,
-      scopes: ["test-scope"],
       pipelineId: "pipeline-1",
       pipelineName: "Test Pipeline",
       curDir: { folderId: "folder-1", folderName: "Test Folder" },
@@ -46,9 +40,6 @@ describe("WorkflowQueueManager", () => {
       onComplete: mockOnComplete,
       onError: mockOnError,
     };
-
-    // Mock auth
-    (auth.acquireAccessToken as any).mockResolvedValue("test-token");
   });
 
   afterEach(() => {
@@ -153,7 +144,6 @@ describe("WorkflowQueueManager", () => {
         selectedModel: "pipeline-1",
         imageObject: mockImage,
         curDir: "Test Folder",
-        accessToken: "test-token",
         folderId: "folder-1",
       });
       expect(mockWorkflowStore.removeWorkflow).toHaveBeenCalled();
@@ -276,7 +266,6 @@ describe("WorkflowQueueManager", () => {
       expect(api.getWorkflowResults).toHaveBeenCalledWith({
         backendUrl: "http://test-backend.com",
         workflowId: "workflow-1",
-        accessToken: "test-token",
       });
 
       expect(mockOnComplete).toHaveBeenCalledWith(

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -50,6 +50,12 @@
       "@stores": [
         "src/stores"
       ],
+      "@auth/*": [
+        "src/auth/*"
+      ],
+      "@auth": [
+        "src/auth"
+      ],
       "oidc-client-ts": [
         "submodules/oidc-client-ts/dist/types/oidc-client-ts.d.ts"
       ],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
       "@styles/*": path.resolve(__dirname, "./src/styles/*"),
       "@stores": path.resolve(__dirname, "./src/stores"),
       "@stores/*": path.resolve(__dirname, "./src/stores/*"),
+      "@auth": path.resolve(__dirname, "./src/auth"),
+      "@auth/*": path.resolve(__dirname, "./src/auth/*"),
       "oidc-client-ts": path.resolve(
         __dirname,
         "./submodules/oidc-client-ts/dist/esm/oidc-client-ts.js",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -34,6 +34,8 @@ export default defineConfig({
       "@styles/*": path.resolve(__dirname, "./src/styles/*"),
       "@stores": path.resolve(__dirname, "./src/stores"),
       "@stores/*": path.resolve(__dirname, "./src/stores/*"),
+      "@auth": path.resolve(__dirname, "./src/auth"),
+      "@auth/*": path.resolve(__dirname, "./src/auth/*"),
       "oidc-client-ts": path.resolve(
         __dirname,
         "./submodules/oidc-client-ts/dist/esm/oidc-client-ts.js",


### PR DESCRIPTION
Relates to #818  
Follow-up to #841

## Summary

This PR finishes the frontend auth call-site migration.

Hooks, components, services, and tests now use the shared Nachet auth provider instead of calling MSAL directly or passing access tokens manually. API helpers now rely on the API auth bridge for bearer-token attachment, which keeps auth behavior centralized and provider-neutral.

## Validation

- `npm run test -- --run`
- `npm run build`
- `git diff --check`