### PR TITLE
Add backend OIDC token verifier foundation

### DIFF
--- a/backend/app/service/auth/oidc_token_verifier.py
+++ b/backend/app/service/auth/oidc_token_verifier.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import jwt
+from jwt.exceptions import (
+    DecodeError,
+    ExpiredSignatureError,
+    ImmatureSignatureError,
+    InvalidAudienceError,
+    InvalidIssuerError,
+    InvalidSignatureError,
+    InvalidTokenError,
+    MissingRequiredClaimError,
+)
+
+from app.service.auth.openid_config import AllowedPublicKeys
+
+DEFAULT_ALLOWED_ALGORITHMS = ("RS256",)
+REQUIRED_ACCESS_TOKEN_CLAIMS = ("exp", "aud", "iat", "nbf", "iss", "sub")
+
+
+class OidcTokenValidationError(ValueError):
+    """Raised when an OIDC access token cannot be trusted by Nachet."""
+
+
+@dataclass(frozen=True)
+class OidcProviderConfig:
+    issuer: str
+    audience: str
+    allowed_algorithms: tuple[str, ...] = DEFAULT_ALLOWED_ALGORITHMS
+    required_claims: tuple[str, ...] = REQUIRED_ACCESS_TOKEN_CLAIMS
+    leeway: int = 0
+
+
+class OidcTokenVerifier:
+    def __init__(self, config: OidcProviderConfig, jwks: dict[str, Any]) -> None:
+        self.config = config
+        self.signing_keys = self._load_signing_keys(jwks)
+
+    # The JWKS is the provider's public key set. We keep the usable signing keys
+    # and store them by `kid` so each token can name the key that should verify it.
+    def _load_signing_keys(self, jwks: dict[str, Any]) -> dict[str, AllowedPublicKeys]:
+        signing_keys: dict[str, AllowedPublicKeys] = {}
+        jwks_keys = jwks.get("keys", [])
+        for jwk in jwks_keys:
+            loaded_key = self._load_signing_key(jwk)
+            if loaded_key is None:
+                continue
+
+            key_id, key = loaded_key
+            signing_keys[key_id] = key
+
+        return signing_keys
+
+    # A JWK is still just input data until it passes these checks. We ignore keys
+    # that are not signing keys, have no `kid`, or use an algorithm we do not allow.
+    def _load_signing_key(
+        self,
+        jwk: dict[str, Any],
+    ) -> tuple[str, AllowedPublicKeys] | None:
+        if jwk.get("use") not in (None, "sig"):
+            return None
+
+        key_id = jwk.get("kid")
+        if not isinstance(key_id, str):
+            return None
+
+        algorithm = jwk.get("alg", self.config.allowed_algorithms[0])
+        if not isinstance(algorithm, str):
+            return None
+
+        if algorithm not in self.config.allowed_algorithms:
+            return None
+
+        return key_id, jwt.PyJWK(jwk, algorithm).key
+
+    # This is the verifier entry point. It chooses the key named by the token
+    # header, then returns claims only after the signature and claim checks pass.
+    def verify(self, access_token: str) -> dict[str, Any]:
+        if not access_token:
+            raise OidcTokenValidationError("Access token is empty")
+
+        header = self._get_token_header(access_token)
+        key = self._get_signing_key(header)
+        return self._decode_claims(access_token, key)
+
+    # We read the unverified header only to find metadata like `alg` and `kid`.
+    # Claims stay untrusted until `_decode_claims` verifies the signed token.
+    def _get_token_header(self, access_token: str) -> dict[str, Any]:
+        try:
+            return dict(jwt.get_unverified_header(access_token))
+        except DecodeError as error:
+            raise OidcTokenValidationError("Invalid token format") from error
+        except InvalidTokenError as error:
+            if "critical" in str(error).lower():
+                raise OidcTokenValidationError(
+                    "Unsupported critical token header"
+                ) from error
+            raise OidcTokenValidationError("Invalid token header") from error
+
+    # The token header can request an algorithm and key, but Nachet still decides
+    # whether that combination is allowed and available.
+    def _get_signing_key(self, header: dict[str, Any]) -> AllowedPublicKeys:
+        # `crit` marks required JWT header extensions. This verifier does not
+        # support header extensions, so those tokens are not accepted.
+        if header.get("crit"):
+            raise OidcTokenValidationError("Unsupported critical token header")
+
+        algorithm = header.get("alg")
+        if algorithm not in self.config.allowed_algorithms:
+            raise OidcTokenValidationError("Unsupported token algorithm")
+
+        key_id = header.get("kid")
+        if not isinstance(key_id, str):
+            raise OidcTokenValidationError("Token is missing a signing key id")
+
+        key = self.signing_keys.get(key_id)
+        if not key:
+            raise OidcTokenValidationError("No matching signing key found")
+
+        return key
+
+    # This is the trust check. PyJWT verifies the signature, issuer, audience,
+    # time claims, and required claims before the verifier returns anything.
+    def _decode_claims(
+        self,
+        access_token: str,
+        key: AllowedPublicKeys,
+    ) -> dict[str, Any]:
+        try:
+            return dict(
+                jwt.decode(
+                    access_token,
+                    key=key,
+                    algorithms=list(self.config.allowed_algorithms),
+                    audience=self.config.audience,
+                    issuer=self.config.issuer,
+                    leeway=self.config.leeway,
+                    options={
+                        "verify_signature": True,
+                        "verify_aud": True,
+                        "verify_iat": True,
+                        "verify_exp": True,
+                        "verify_nbf": True,
+                        "verify_iss": True,
+                        "require": list(self.config.required_claims),
+                    },
+                )
+            )
+        except ExpiredSignatureError as error:
+            raise OidcTokenValidationError("Token expired") from error
+        except ImmatureSignatureError as error:
+            raise OidcTokenValidationError("Token is not valid yet") from error
+        except InvalidAudienceError as error:
+            raise OidcTokenValidationError("Invalid audience") from error
+        except InvalidIssuerError as error:
+            raise OidcTokenValidationError("Invalid issuer") from error
+        except MissingRequiredClaimError as error:
+            raise OidcTokenValidationError("Missing required claim") from error
+        except InvalidSignatureError as error:
+            raise OidcTokenValidationError("Invalid signature") from error
+        except InvalidTokenError as error:
+            raise OidcTokenValidationError("Invalid token") from error

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "2.9.17"
+version = "2.9.18"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/tests/test_oidc_token_verifier.py
+++ b/backend/tests/test_oidc_token_verifier.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from app.service.auth.oidc_token_verifier import (
+    OidcProviderConfig,
+    OidcTokenValidationError,
+    OidcTokenVerifier,
+)
+
+
+ISSUER = "https://idp.example/realms/nachet"
+AUDIENCE = "nachet-api"
+KEY_ID = "test-signing-key"
+SIGNING_ALGORITHM = "RS256"
+
+
+def create_private_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def public_jwk_from_key(
+    private_key: rsa.RSAPrivateKey,
+    key_id: str = KEY_ID,
+) -> dict[str, Any]:
+    public_key = private_key.public_key()
+    public_jwk_json = RSAAlgorithm.to_jwk(public_key)
+    jwk = json.loads(public_jwk_json)
+    jwk["kid"] = key_id
+    jwk["use"] = "sig"
+    jwk["alg"] = SIGNING_ALGORITHM
+    return jwk
+
+
+def create_verifier(
+    jwk: dict[str, Any],
+    issuer: str = ISSUER,
+    audience: str = AUDIENCE,
+) -> OidcTokenVerifier:
+    return OidcTokenVerifier(
+        config=OidcProviderConfig(
+            issuer=issuer,
+            audience=audience,
+        ),
+        jwks={"keys": [jwk]},
+    )
+
+
+def create_claims(**overrides: Any) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    claims: dict[str, Any] = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": "user-subject",
+        "exp": now + timedelta(minutes=5),
+        "iat": now,
+        "nbf": now - timedelta(seconds=5),
+        "preferred_username": "seed.user@example.com",
+    }
+    claims.update(overrides)
+    return claims
+
+
+def sign_token(
+    private_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    key_id: str = KEY_ID,
+    headers: dict[str, Any] | None = None,
+) -> str:
+    token_headers = {"kid": key_id}
+    token_headers.update(headers or {})
+
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm=SIGNING_ALGORITHM,
+        headers=token_headers,
+    )
+
+
+# Creates a token with no `kid` header for the missing-key-id negative test.
+def sign_token_without_key_id(
+    private_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+) -> str:
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm=SIGNING_ALGORITHM,
+        headers={},
+    )
+
+
+def test_valid_token_returns_claims() -> None:
+    private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(private_key))
+    token = sign_token(private_key, create_claims())
+
+    claims = verifier.verify(token)
+
+    assert claims["iss"] == ISSUER
+    assert claims["aud"] == AUDIENCE
+    assert claims["sub"] == "user-subject"
+
+
+# `aud` can be a string or a list. The verifier accepts the token when Nachet's
+# API audience is one of the listed audiences.
+def test_audience_list_containing_expected_audience_returns_claims() -> None:
+    private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(private_key))
+    claims_with_audience_list = create_claims(aud=["other-api", AUDIENCE])
+    token = sign_token(private_key, claims_with_audience_list)
+
+    claims = verifier.verify(token)
+
+    assert claims["aud"] == ["other-api", AUDIENCE]
+
+
+@pytest.mark.parametrize(
+    ("claim_override", "expected_message"),
+    [
+        ({"iss": "https://wrong-issuer.example"}, "issuer"),
+        ({"aud": "wrong-audience"}, "audience"),
+        ({"exp": datetime.now(timezone.utc) - timedelta(minutes=1)}, "expired"),
+    ],
+)
+def test_invalid_standard_claims_fail_closed(
+    claim_override: dict[str, Any],
+    expected_message: str,
+) -> None:
+    private_key = create_private_key()
+    public_jwk = public_jwk_from_key(private_key)
+    verifier = create_verifier(public_jwk)
+    claims = create_claims(**claim_override)
+    token = sign_token(private_key, claims)
+
+    with pytest.raises(OidcTokenValidationError, match=expected_message):
+        verifier.verify(token)
+
+
+# `nbf` means "not before." A token can be properly signed and still be invalid
+# if its valid-from time is in the future.
+def test_not_before_in_future_fails_closed() -> None:
+    private_key = create_private_key()
+    public_jwk = public_jwk_from_key(private_key)
+    verifier = create_verifier(public_jwk)
+    future_not_before = datetime.now(timezone.utc) + timedelta(days=1)
+    claims = create_claims(nbf=future_not_before)
+    token = sign_token(private_key, claims)
+
+    with pytest.raises(OidcTokenValidationError, match="not valid yet"):
+        verifier.verify(token)
+
+
+# `alg: none` asks the backend to trust unsigned claims. The verifier treats it
+# as an unsupported algorithm.
+def test_unsigned_alg_none_token_fails_closed() -> None:
+    private_key = create_private_key()
+    public_jwk = public_jwk_from_key(private_key)
+    verifier = create_verifier(public_jwk)
+    unsigned_claims = create_claims()
+    unsigned_header = {"kid": KEY_ID}
+    token = jwt.encode(
+        unsigned_claims,
+        key="",
+        algorithm="none",
+        headers=unsigned_header,
+    )
+
+    token_header = jwt.get_unverified_header(token)
+    assert token_header["alg"] == "none"
+    with pytest.raises(OidcTokenValidationError, match="algorithm"):
+        verifier.verify(token)
+
+
+def test_bad_signature_fails_closed() -> None:
+    trusted_private_key = create_private_key()
+    attacker_private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(trusted_private_key))
+    token = sign_token(attacker_private_key, create_claims())
+
+    with pytest.raises(OidcTokenValidationError, match="signature"):
+        verifier.verify(token)
+
+
+def test_missing_signing_key_fails_closed() -> None:
+    private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(private_key, key_id="other-key"))
+    token = sign_token(private_key, create_claims(), key_id=KEY_ID)
+
+    with pytest.raises(OidcTokenValidationError, match="signing key"):
+        verifier.verify(token)
+
+
+# Without a `kid`, the verifier has no trusted key identifier to use.
+def test_missing_key_id_fails_closed() -> None:
+    private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(private_key))
+    token = sign_token_without_key_id(private_key, create_claims())
+
+    with pytest.raises(OidcTokenValidationError, match="signing key id"):
+        verifier.verify(token)
+
+
+# `crit` announces required JWT header extensions. This verifier supports no
+# header extensions, so tokens with `crit` are not accepted.
+def test_unsupported_critical_header_fails_closed() -> None:
+    private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(private_key))
+    token = sign_token(
+        private_key,
+        create_claims(),
+        headers={"crit": ["unknown-extension"], "unknown-extension": True},
+    )
+
+    with pytest.raises(OidcTokenValidationError, match="critical"):
+        verifier.verify(token)
+
+
+def test_missing_required_identity_claim_fails_closed() -> None:
+    private_key = create_private_key()
+    verifier = create_verifier(public_jwk_from_key(private_key))
+    claims = create_claims()
+    del claims["sub"]
+    token = sign_token(private_key, claims)
+
+    with pytest.raises(OidcTokenValidationError, match="required claim"):
+        verifier.verify(token)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "2.9.17"
+version = "2.9.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Relates to #818

## Summary

Adds a provider-neutral OIDC access-token verifier for the backend.

This is the first backend slice for the OIDC work. It validates signed JWT access tokens against a supplied provider config and JWKS, including issuer, audience, signature, expiry, `nbf`, allowed algorithm, signing key, and required claims.

This PR does not change FastAPI route behavior yet, and it does not fetch discovery/JWKS over HTTP. Those pieces are intentionally left for the next backend slices.

## Validation

From `backend/`:

- `uv run pytest tests/test_oidc_token_verifier.py -q`
- `uv run pyright app/service/auth/oidc_token_verifier.py tests/test_oidc_token_verifier.py`
- `uv run --with bandit bandit app/service/auth/oidc_token_verifier.py -q`
- `git diff --check`