### PR TITLE
Add backend OIDC discovery and JWKS loading

### DIFF
--- a/backend/app/service/auth/oidc_discovery.py
+++ b/backend/app/service/auth/oidc_discovery.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+import jwt
+from jwt.exceptions import InvalidTokenError
+
+from app.service.auth.oidc_token_verifier import (
+    DEFAULT_ALLOWED_ALGORITHMS,
+    REQUIRED_ACCESS_TOKEN_CLAIMS,
+    OidcProviderConfig,
+    OidcTokenVerifier,
+)
+
+
+DEFAULT_DISCOVERY_CACHE_TTL = timedelta(hours=24)
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 10.0
+# Unknown `kid` refreshes are rate-limited so invalid tokens cannot repeatedly
+# force JWKS reloads. A short cooldown still allows normal key rotation recovery.
+DEFAULT_UNKNOWN_KEY_REFRESH_COOLDOWN = timedelta(minutes=1)
+
+AllowedAlgorithms = tuple[str, ...]
+RequiredClaims = tuple[str, ...]
+HttpClientFactory = Callable[[], httpx.AsyncClient]
+CacheClock = Callable[[], datetime]
+
+
+class OidcDiscoveryError(RuntimeError):
+    """Raised when OIDC discovery or JWKS loading fails closed."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class OidcDiscoveryConfig:
+    issuer: str
+    audience: str
+    allowed_algorithms: AllowedAlgorithms = DEFAULT_ALLOWED_ALGORITHMS
+    required_claims: RequiredClaims = REQUIRED_ACCESS_TOKEN_CLAIMS
+    leeway: int = 0
+    cache_ttl: timedelta = DEFAULT_DISCOVERY_CACHE_TTL
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS
+    unknown_key_refresh_cooldown: timedelta = DEFAULT_UNKNOWN_KEY_REFRESH_COOLDOWN
+
+
+@dataclass(frozen=True)
+class CachedOidcVerifier:
+    verifier: OidcTokenVerifier
+    loaded_at: datetime
+
+
+class OidcDiscoveryClient:
+    def __init__(
+        self,
+        config: OidcDiscoveryConfig,
+        http_client_factory: HttpClientFactory | None = None,
+        cache_clock: CacheClock | None = None,
+    ) -> None:
+        self.config = config
+        self.discovery_url = self._build_discovery_url(self.config.issuer)
+        self._http_client_factory = (
+            http_client_factory
+            if http_client_factory is not None
+            else self._create_http_client
+        )
+        self._cache_clock = cache_clock if cache_clock is not None else _utc_now
+        self._cached_verifier: CachedOidcVerifier | None = None
+        self._last_unknown_key_refresh_at: datetime | None = None
+        self._refresh_lock = asyncio.Lock()
+
+    # Trim only for URL construction. The discovered issuer is still compared
+    # exactly against the configured issuer before the metadata is accepted.
+    def _build_discovery_url(self, issuer: str) -> str:
+        issuer_without_trailing_slash = issuer.rstrip("/")
+        return f"{issuer_without_trailing_slash}/.well-known/openid-configuration"
+
+    # Keep provider calls bounded so auth does not hang on a slow identity provider.
+    def _create_http_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self.config.request_timeout)
+
+    # Cache reads happen before and after taking the lock. That lets normal
+    # requests avoid locking while concurrent refreshes still collapse to one load.
+    async def get_verifier(self) -> OidcTokenVerifier:
+        cached_verifier = self._get_fresh_cached_verifier()
+        if cached_verifier is not None:
+            return cached_verifier.verifier
+
+        async with self._refresh_lock:
+            cached_verifier = self._get_fresh_cached_verifier()
+            if cached_verifier is not None:
+                return cached_verifier.verifier
+
+            return await self._refresh_verifier()
+
+    # A valid token may reference a new `kid` after provider key rotation. Refresh
+    # JWKS once, subject to the unknown-key cooldown, before the final validation.
+    async def verify(self, access_token: str) -> dict[str, Any]:
+        verifier = await self.get_verifier()
+        key_id = self._get_token_key_id(access_token)
+        if key_id is not None:
+            token_uses_unknown_key = not verifier.has_signing_key(key_id)
+            if token_uses_unknown_key:
+                verifier = await self._refresh_verifier_for_unknown_key(
+                    key_id,
+                    verifier,
+                )
+
+        return verifier.verify(access_token)
+
+    def _get_fresh_cached_verifier(self) -> CachedOidcVerifier | None:
+        cached_verifier = self._cached_verifier
+        if cached_verifier is None:
+            return None
+
+        if not self._is_cache_fresh(cached_verifier):
+            return None
+
+        return cached_verifier
+
+    def _is_cache_fresh(self, cached_verifier: CachedOidcVerifier) -> bool:
+        cache_age = self._cache_clock() - cached_verifier.loaded_at
+        return cache_age < self.config.cache_ttl
+
+    # Unknown-key refreshes share the main refresh lock. This preserves key
+    # rotation recovery without allowing a burst of bad tokens to stampede JWKS.
+    async def _refresh_verifier_for_unknown_key(
+        self,
+        key_id: str,
+        current_verifier: OidcTokenVerifier,
+    ) -> OidcTokenVerifier:
+        async with self._refresh_lock:
+            cached_verifier = self._cached_verifier
+            if cached_verifier and cached_verifier.verifier.has_signing_key(key_id):
+                return cached_verifier.verifier
+
+            if not self._can_refresh_for_unknown_key():
+                return current_verifier
+
+            self._last_unknown_key_refresh_at = self._cache_clock()
+            return await self._refresh_verifier()
+
+    # The cooldown applies process-wide for this client. It limits provider
+    # traffic caused by repeated unknown `kid` values.
+    def _can_refresh_for_unknown_key(self) -> bool:
+        cooldown = self.config.unknown_key_refresh_cooldown
+        if cooldown <= timedelta(0):
+            return True
+
+        last_refresh = self._last_unknown_key_refresh_at
+        if last_refresh is None:
+            return True
+
+        return self._cache_clock() - last_refresh >= cooldown
+
+    # Cache only after discovery and JWKS both pass shape and issuer validation.
+    async def _refresh_verifier(self) -> OidcTokenVerifier:
+        async with self._http_client_factory() as client:
+            discovery_metadata = await self._fetch_discovery_metadata(client)
+            jwks_uri = discovery_metadata["jwks_uri"]
+            jwks = await self._fetch_jwks(client, jwks_uri)
+
+        verifier = self._build_verifier(jwks)
+        self._cached_verifier = CachedOidcVerifier(
+            verifier=verifier,
+            loaded_at=self._cache_clock(),
+        )
+        return verifier
+
+    # Discovery supplies keys. Nachet still supplies the expected issuer, audience,
+    # algorithms, and required claims used by the verifier.
+    def _build_verifier(self, jwks: dict[str, Any]) -> OidcTokenVerifier:
+        verifier_config = OidcProviderConfig(
+            issuer=self.config.issuer,
+            audience=self.config.audience,
+            allowed_algorithms=self.config.allowed_algorithms,
+            required_claims=self.config.required_claims,
+            leeway=self.config.leeway,
+        )
+        return OidcTokenVerifier(config=verifier_config, jwks=jwks)
+
+    # Accept discovery metadata only from the configured issuer and only when it
+    # provides a JWKS endpoint.
+    async def _fetch_discovery_metadata(
+        self,
+        client: httpx.AsyncClient,
+    ) -> dict[str, str]:
+        metadata = await self._get_json(client, self.discovery_url, "discovery")
+        issuer = metadata.get("issuer")
+        if not isinstance(issuer, str) or issuer != self.config.issuer:
+            raise OidcDiscoveryError("OIDC discovery issuer does not match config")
+
+        jwks_uri = metadata.get("jwks_uri")
+        if not isinstance(jwks_uri, str) or not jwks_uri:
+            raise OidcDiscoveryError("OIDC discovery metadata is missing jwks_uri")
+
+        return {"issuer": issuer, "jwks_uri": jwks_uri}
+
+    # RFC 7517 defines a JWKS as a JSON object with a `keys` array.
+    async def _fetch_jwks(
+        self,
+        client: httpx.AsyncClient,
+        jwks_uri: str,
+    ) -> dict[str, Any]:
+        jwks = await self._get_json(client, jwks_uri, "JWKS")
+        if not isinstance(jwks.get("keys"), list):
+            raise OidcDiscoveryError("OIDC JWKS must contain a keys array")
+
+        return jwks
+
+    # Discovery and JWKS endpoints must return JSON objects. Transport failures,
+    # invalid JSON, or other JSON shapes fail closed.
+    async def _get_json(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        source_name: str,
+    ) -> dict[str, Any]:
+        try:
+            response = await client.get(url)
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as error:
+            raise OidcDiscoveryError(f"Unable to load OIDC {source_name}") from error
+
+        if not isinstance(payload, dict):
+            raise OidcDiscoveryError(f"OIDC {source_name} response must be an object")
+
+        return payload
+
+    # The unverified header is used only to decide whether refreshing JWKS may
+    # help. Claims and signatures are still validated by `OidcTokenVerifier`.
+    def _get_token_key_id(self, access_token: str) -> str | None:
+        try:
+            header = jwt.get_unverified_header(access_token)
+        except InvalidTokenError:
+            return None
+
+        key_id = header.get("kid")
+        return key_id if isinstance(key_id, str) else None

--- a/backend/app/service/auth/oidc_token_verifier.py
+++ b/backend/app/service/auth/oidc_token_verifier.py
@@ -39,6 +39,10 @@ class OidcTokenVerifier:
         self.config = config
         self.signing_keys = self._load_signing_keys(jwks)
 
+    # Discovery can check key availability without reaching into verifier internals.
+    def has_signing_key(self, key_id: str) -> bool:
+        return key_id in self.signing_keys
+
     # The JWKS is the provider's public key set. We keep the usable signing keys
     # and store them by `kid` so each token can name the key that should verify it.
     def _load_signing_keys(self, jwks: dict[str, Any]) -> dict[str, AllowedPublicKeys]:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "2.9.18"
+version = "2.9.19"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/tests/test_oidc_discovery.py
+++ b/backend/tests/test_oidc_discovery.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from app.service.auth.oidc_discovery import (
+    OidcDiscoveryClient,
+    OidcDiscoveryConfig,
+    OidcDiscoveryError,
+)
+from app.service.auth.oidc_token_verifier import OidcTokenValidationError
+
+
+ISSUER = "https://idp.example/realms/nachet"
+DISCOVERY_URL = f"{ISSUER}/.well-known/openid-configuration"
+JWKS_URI = f"{ISSUER}/protocol/openid-connect/certs"
+AUDIENCE = "nachet-api"
+KEY_ID = "test-signing-key"
+ROTATED_KEY_ID = "rotated-signing-key"
+SIGNING_ALGORITHM = "RS256"
+
+
+class MutableClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+@dataclass
+class MockOidcProvider:
+    issuer: str = ISSUER
+    jwks_uri: str = JWKS_URI
+    jwks: dict[str, Any] = field(default_factory=lambda: {"keys": []})
+    delay_seconds: float = 0
+    discovery_status: int = 200
+    jwks_status: int = 200
+    include_jwks_uri: bool = True
+    requests: list[str] = field(default_factory=list)
+
+    async def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(str(request.url))
+        if self.delay_seconds:
+            await asyncio.sleep(self.delay_seconds)
+
+        if str(request.url) == DISCOVERY_URL:
+            if self.discovery_status != 200:
+                return httpx.Response(self.discovery_status)
+
+            discovery_metadata = {"issuer": self.issuer}
+            if self.include_jwks_uri:
+                discovery_metadata["jwks_uri"] = self.jwks_uri
+
+            return httpx.Response(200, json=discovery_metadata)
+
+        if str(request.url) == self.jwks_uri:
+            if self.jwks_status != 200:
+                return httpx.Response(self.jwks_status)
+
+            return httpx.Response(200, json=self.jwks)
+
+        return httpx.Response(404, json={"error": "not found"})
+
+    def count_requests(self, url: str) -> int:
+        return self.requests.count(url)
+
+
+def create_private_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def public_jwk_from_key(
+    private_key: rsa.RSAPrivateKey,
+    key_id: str = KEY_ID,
+) -> dict[str, Any]:
+    public_key = private_key.public_key()
+    public_jwk_json = RSAAlgorithm.to_jwk(public_key)
+    jwk = json.loads(public_jwk_json)
+    jwk["kid"] = key_id
+    jwk["use"] = "sig"
+    jwk["alg"] = SIGNING_ALGORITHM
+    return jwk
+
+
+def jwks_from_key(
+    private_key: rsa.RSAPrivateKey,
+    key_id: str = KEY_ID,
+) -> dict[str, Any]:
+    return {"keys": [public_jwk_from_key(private_key, key_id=key_id)]}
+
+
+def create_claims(**overrides: Any) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    claims: dict[str, Any] = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": "user-subject",
+        "exp": now + timedelta(minutes=5),
+        "iat": now,
+        "nbf": now - timedelta(seconds=5),
+    }
+    claims.update(overrides)
+    return claims
+
+
+def sign_token(
+    private_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    key_id: str = KEY_ID,
+) -> str:
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm=SIGNING_ALGORITHM,
+        headers={"kid": key_id},
+    )
+
+
+def create_client(
+    provider: MockOidcProvider,
+    *,
+    issuer: str = ISSUER,
+    audience: str = AUDIENCE,
+    cache_ttl: timedelta = timedelta(hours=24),
+    unknown_key_refresh_cooldown: timedelta = timedelta(minutes=1),
+    clock: MutableClock | None = None,
+) -> OidcDiscoveryClient:
+    transport = httpx.MockTransport(provider.handle_request)
+    return OidcDiscoveryClient(
+        config=OidcDiscoveryConfig(
+            issuer=issuer,
+            audience=audience,
+            cache_ttl=cache_ttl,
+            unknown_key_refresh_cooldown=unknown_key_refresh_cooldown,
+        ),
+        http_client_factory=lambda: httpx.AsyncClient(transport=transport),
+        cache_clock=clock or MutableClock(datetime.now(timezone.utc)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetches_discovery_and_jwks_then_verifies_token() -> None:
+    private_key = create_private_key()
+    provider = MockOidcProvider(jwks=jwks_from_key(private_key))
+    client = create_client(provider)
+    token = sign_token(private_key, create_claims())
+
+    verifier = await client.get_verifier()
+    claims = verifier.verify(token)
+
+    assert claims["sub"] == "user-subject"
+    assert provider.count_requests(DISCOVERY_URL) == 1
+    assert provider.count_requests(JWKS_URI) == 1
+
+
+# Keycloak-style issuers often include a realm path. Discovery must preserve
+# that path and append only the well-known suffix.
+@pytest.mark.asyncio
+async def test_builds_discovery_url_for_path_based_issuer() -> None:
+    private_key = create_private_key()
+    provider = MockOidcProvider(jwks=jwks_from_key(private_key))
+    client = create_client(provider, issuer=ISSUER)
+
+    await client.get_verifier()
+
+    assert DISCOVERY_URL in provider.requests
+
+
+@pytest.mark.asyncio
+async def test_rejects_discovery_issuer_mismatch() -> None:
+    private_key = create_private_key()
+    provider = MockOidcProvider(
+        issuer="https://wrong-idp.example/realms/nachet",
+        jwks=jwks_from_key(private_key),
+    )
+    client = create_client(provider)
+
+    with pytest.raises(OidcDiscoveryError, match="issuer"):
+        await client.get_verifier()
+
+
+@pytest.mark.asyncio
+async def test_rejects_missing_jwks_uri() -> None:
+    provider = MockOidcProvider(include_jwks_uri=False)
+    client = create_client(provider)
+
+    with pytest.raises(OidcDiscoveryError, match="jwks_uri"):
+        await client.get_verifier()
+
+
+@pytest.mark.asyncio
+async def test_rejects_malformed_jwks_without_keys_array() -> None:
+    provider = MockOidcProvider(jwks={"keys": "not-an-array"})
+    client = create_client(provider)
+
+    with pytest.raises(OidcDiscoveryError, match="JWKS"):
+        await client.get_verifier()
+
+
+# Fresh cache entries should be reused so normal API requests do not refetch
+# provider metadata on every token validation.
+@pytest.mark.asyncio
+async def test_uses_cached_verifier_before_ttl_expires() -> None:
+    private_key = create_private_key()
+    clock = MutableClock(datetime(2026, 1, 1, tzinfo=timezone.utc))
+    provider = MockOidcProvider(jwks=jwks_from_key(private_key))
+    client = create_client(provider, cache_ttl=timedelta(hours=24), clock=clock)
+
+    first_verifier = await client.get_verifier()
+    clock.advance(timedelta(hours=23, minutes=59))
+    second_verifier = await client.get_verifier()
+
+    assert second_verifier is first_verifier
+    assert provider.count_requests(DISCOVERY_URL) == 1
+    assert provider.count_requests(JWKS_URI) == 1
+
+
+# Expired cache entries are replaced with fresh discovery and JWKS data.
+@pytest.mark.asyncio
+async def test_refreshes_verifier_after_ttl_expires() -> None:
+    first_private_key = create_private_key()
+    second_private_key = create_private_key()
+    clock = MutableClock(datetime(2026, 1, 1, tzinfo=timezone.utc))
+    provider = MockOidcProvider(jwks=jwks_from_key(first_private_key))
+    client = create_client(provider, cache_ttl=timedelta(hours=24), clock=clock)
+
+    first_verifier = await client.get_verifier()
+    provider.jwks = jwks_from_key(second_private_key)
+    clock.advance(timedelta(hours=24, seconds=1))
+    second_verifier = await client.get_verifier()
+
+    assert second_verifier is not first_verifier
+    assert provider.count_requests(DISCOVERY_URL) == 2
+    assert provider.count_requests(JWKS_URI) == 2
+
+
+# Key rotation can happen before the cache TTL expires. An unknown `kid` gets
+# one refresh attempt before final token validation.
+@pytest.mark.asyncio
+async def test_refreshes_jwks_once_when_token_kid_is_unknown() -> None:
+    old_private_key = create_private_key()
+    rotated_private_key = create_private_key()
+    provider = MockOidcProvider(jwks=jwks_from_key(old_private_key))
+    client = create_client(provider)
+    await client.get_verifier()
+    provider.jwks = jwks_from_key(rotated_private_key, key_id=ROTATED_KEY_ID)
+    token = sign_token(
+        rotated_private_key,
+        create_claims(),
+        key_id=ROTATED_KEY_ID,
+    )
+
+    claims = await client.verify(token)
+
+    assert claims["sub"] == "user-subject"
+    assert provider.count_requests(DISCOVERY_URL) == 2
+    assert provider.count_requests(JWKS_URI) == 2
+
+
+# Unknown `kid` values come from untrusted tokens. The cooldown keeps invalid
+# tokens from forcing repeated discovery/JWKS reloads.
+@pytest.mark.asyncio
+async def test_unknown_kid_refresh_is_rate_limited() -> None:
+    trusted_private_key = create_private_key()
+    first_attacker_private_key = create_private_key()
+    second_attacker_private_key = create_private_key()
+    third_attacker_private_key = create_private_key()
+    clock = MutableClock(datetime(2026, 1, 1, tzinfo=timezone.utc))
+    provider = MockOidcProvider(jwks=jwks_from_key(trusted_private_key))
+    client = create_client(provider, clock=clock)
+    await client.get_verifier()
+
+    first_fake_token = sign_token(
+        first_attacker_private_key,
+        create_claims(),
+        key_id="fake-key-1",
+    )
+    second_fake_token = sign_token(
+        second_attacker_private_key,
+        create_claims(),
+        key_id="fake-key-2",
+    )
+    third_fake_token = sign_token(
+        third_attacker_private_key,
+        create_claims(),
+        key_id="fake-key-3",
+    )
+
+    with pytest.raises(OidcTokenValidationError, match="signing key"):
+        await client.verify(first_fake_token)
+    with pytest.raises(OidcTokenValidationError, match="signing key"):
+        await client.verify(second_fake_token)
+
+    assert provider.count_requests(DISCOVERY_URL) == 2
+    assert provider.count_requests(JWKS_URI) == 2
+
+    clock.advance(timedelta(minutes=1, seconds=1))
+    with pytest.raises(OidcTokenValidationError, match="signing key"):
+        await client.verify(third_fake_token)
+
+    assert provider.count_requests(DISCOVERY_URL) == 3
+    assert provider.count_requests(JWKS_URI) == 3
+
+
+# ID tokens are meant for the frontend client, not the backend API. The audience
+# check rejects them before they can be used as API credentials.
+@pytest.mark.asyncio
+async def test_frontend_id_token_audience_fails_closed() -> None:
+    private_key = create_private_key()
+    provider = MockOidcProvider(jwks=jwks_from_key(private_key))
+    client = create_client(provider)
+    token_for_frontend = sign_token(
+        private_key,
+        create_claims(aud="nachet-frontend-client"),
+    )
+
+    with pytest.raises(OidcTokenValidationError, match="audience"):
+        await client.verify(token_for_frontend)
+
+
+@pytest.mark.asyncio
+async def test_fails_closed_when_discovery_fetch_fails_without_cache() -> None:
+    provider = MockOidcProvider(discovery_status=503)
+    client = create_client(provider)
+
+    with pytest.raises(OidcDiscoveryError, match="discovery"):
+        await client.get_verifier()
+
+
+# If the cache is expired and refresh fails, the client does not continue using
+# stale provider metadata.
+@pytest.mark.asyncio
+async def test_expired_cache_is_not_used_when_refresh_fails() -> None:
+    private_key = create_private_key()
+    clock = MutableClock(datetime(2026, 1, 1, tzinfo=timezone.utc))
+    provider = MockOidcProvider(jwks=jwks_from_key(private_key))
+    client = create_client(provider, cache_ttl=timedelta(hours=24), clock=clock)
+    await client.get_verifier()
+
+    provider.discovery_status = 503
+    clock.advance(timedelta(hours=24, seconds=1))
+
+    with pytest.raises(OidcDiscoveryError, match="discovery"):
+        await client.get_verifier()
+
+
+# Concurrent startup checks should share one provider refresh.
+@pytest.mark.asyncio
+async def test_concurrent_get_verifier_calls_share_one_refresh() -> None:
+    private_key = create_private_key()
+    provider = MockOidcProvider(
+        jwks=jwks_from_key(private_key),
+        delay_seconds=0.01,
+    )
+    client = create_client(provider)
+
+    first_verifier, second_verifier = await asyncio.gather(
+        client.get_verifier(),
+        client.get_verifier(),
+    )
+
+    assert second_verifier is first_verifier
+    assert provider.count_requests(DISCOVERY_URL) == 1
+    assert provider.count_requests(JWKS_URI) == 1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "2.9.18"
+version = "2.9.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Relates to #818

## Summary

Adds the backend OIDC discovery layer for provider-neutral token validation.

This PR loads OIDC discovery metadata, fetches JWKS, validates the discovered issuer and key-set shape, then builds the existing `OidcTokenVerifier`. It also caches the verifier and supports safe JWKS refresh for key rotation.

## What Changed

- Added `OidcDiscoveryClient` for discovery metadata and JWKS loading.
- Validates issuer, `jwks_uri`, and RFC 7517 `keys` array shape.
- Caches the verifier for 24 hours.
- Refreshes JWKS when a token references an unknown `kid`.
- Rate-limits unknown-`kid` refreshes to avoid repeated JWKS reloads from invalid tokens.
- Added tests for discovery, caching, refresh, fail-closed behavior, and concurrent refresh handling.

## Notes

This does not change FastAPI route behavior or replace the current Entra backend auth path. Route integration and provider config wiring are left for the next backend slice.

## Validation

- `uv run pytest tests/test_oidc_discovery.py -q`
- `uv run pytest tests/test_oidc_token_verifier.py tests/test_oidc_discovery.py -q`
- `uv run pyright app/service/auth/oidc_token_verifier.py app/service/auth/oidc_discovery.py tests/test_oidc_discovery.py`
- `uv run --with bandit bandit app/service/auth/oidc_token_verifier.py app/service/auth/oidc_discovery.py -q`
- `uv lock --check`
- `git diff --check`