### PR TITLE
Issue 852 versions workflow ensure version ts matches package

### DIFF
--- a/.github/workflows/reusable-frontend-versions.yml
+++ b/.github/workflows/reusable-frontend-versions.yml
@@ -55,37 +55,37 @@ jobs:
           echo "version=$PR_VERSION" >> $GITHUB_OUTPUT
 
       - name: Verify src/_versions.ts matches package.json
-          run: |
-            PACKAGE_VERSION=$(jq -r '.version' package.json)
+        run: |
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
 
-            if [ -z "$PACKAGE_VERSION" ] || [ "$PACKAGE_VERSION" = "null" ]; then
-              echo "Error: Could not extract version from package.json"
-              exit 1
-            fi
+          if [ -z "$PACKAGE_VERSION" ] || [ "$PACKAGE_VERSION" = "null" ]; then
+            echo "Error: Could not extract version from package.json"
+            exit 1
+          fi
 
-            if [ ! -f "src/_versions.ts" ]; then
-              echo "Error: src/_versions.ts not found in ${{ inputs.working-directory }}"
-              exit 1
-            fi
+          if [ ! -f "src/_versions.ts" ]; then
+            echo "Error: src/_versions.ts not found in ${{ inputs.working-directory }}"
+            exit 1
+          fi
 
-            FILE_VERSION=$(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' src/_versions.ts | head -n 1)
+          FILE_VERSION=$(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' src/_versions.ts | head -n 1)
 
-            if [ -z "$FILE_VERSION" ]; then
-              echo "Error: Could not extract APP_VERSION from src/_versions.ts"
-              exit 1
-            fi
+          if [ -z "$FILE_VERSION" ]; then
+            echo "Error: Could not extract APP_VERSION from src/_versions.ts"
+            exit 1
+          fi
 
-            echo "package.json version: $PACKAGE_VERSION"
-            echo "src/_versions.ts APP_VERSION: $FILE_VERSION"
+          echo "package.json version: $PACKAGE_VERSION"
+          echo "src/_versions.ts APP_VERSION: $FILE_VERSION"
 
-            if [ "$PACKAGE_VERSION" != "$FILE_VERSION" ]; then
-              echo "❌ Version mismatch detected!"
-              echo "${{ inputs.working-directory }}/package.json version ($PACKAGE_VERSION) does not match ${{ inputs.working-directory }}/src/_versions.ts APP_VERSION ($FILE_VERSION)."
-              echo "Please update src/_versions.ts to match package.json."
-              exit 1
-            fi
+          if [ "$PACKAGE_VERSION" != "$FILE_VERSION" ]; then
+            echo "❌ Version mismatch detected!"
+            echo "${{ inputs.working-directory }}/package.json version ($PACKAGE_VERSION) does not match ${{ inputs.working-directory }}/src/_versions.ts APP_VERSION ($FILE_VERSION)."
+            echo "Please update src/_versions.ts to match package.json."
+            exit 1
+          fi
 
-            echo "✅ src/_versions.ts matches package.json"
+          echo "✅ src/_versions.ts matches package.json"
 
       - name: Get latest version
         if: ${{ !inputs.skip-version-check }}

--- a/.github/workflows/reusable-frontend-versions.yml
+++ b/.github/workflows/reusable-frontend-versions.yml
@@ -54,6 +54,39 @@ jobs:
           echo "PR version: $PR_VERSION"
           echo "version=$PR_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Verify src/_versions.ts matches package.json
+          run: |
+            PACKAGE_VERSION=$(jq -r '.version' package.json)
+
+            if [ -z "$PACKAGE_VERSION" ] || [ "$PACKAGE_VERSION" = "null" ]; then
+              echo "Error: Could not extract version from package.json"
+              exit 1
+            fi
+
+            if [ ! -f "src/_versions.ts" ]; then
+              echo "Error: src/_versions.ts not found in ${{ inputs.working-directory }}"
+              exit 1
+            fi
+
+            FILE_VERSION=$(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' src/_versions.ts | head -n 1)
+
+            if [ -z "$FILE_VERSION" ]; then
+              echo "Error: Could not extract APP_VERSION from src/_versions.ts"
+              exit 1
+            fi
+
+            echo "package.json version: $PACKAGE_VERSION"
+            echo "src/_versions.ts APP_VERSION: $FILE_VERSION"
+
+            if [ "$PACKAGE_VERSION" != "$FILE_VERSION" ]; then
+              echo "❌ Version mismatch detected!"
+              echo "${{ inputs.working-directory }}/package.json version ($PACKAGE_VERSION) does not match ${{ inputs.working-directory }}/src/_versions.ts APP_VERSION ($FILE_VERSION)."
+              echo "Please update src/_versions.ts to match package.json."
+              exit 1
+            fi
+
+            echo "✅ src/_versions.ts matches package.json"
+
       - name: Get latest version
         if: ${{ !inputs.skip-version-check }}
         id: get_latest_version

--- a/nachet-mini/package-lock.json
+++ b/nachet-mini/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-mini",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-mini",
-      "version": "0.10.13",
+      "version": "0.10.14",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/nachet-mini/package.json
+++ b/nachet-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-mini",
   "private": true,
-  "version": "0.10.13",
+  "version": "0.10.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/nachet-mini/src/_versions.ts
+++ b/nachet-mini/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
   gitTag?: string;
 }
 export const versions: TsAppVersion = {
-  version: "0.10.11",
+  version: "0.10.14",
   name: "nachet-mini",
-  versionDate: "2026-06-25T15:31:10.000Z",
+  versionDate: "2026-07-13T15:31:10.000Z",
 };
 export default versions;


### PR DESCRIPTION
closes #852

Currently there is no workflow enforcement to make sure the frontend displayed version is in sync with the package version . This is critical for nachet mini to ensure active user sessions are warned of an update.