### PR TITLE
Issue #873: Fix TruffleHog false positive in OIDC issuer test

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "3.0.0"
+version = "3.0.1"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/tests/test_oidc_backend_auth.py
+++ b/backend/tests/test_oidc_backend_auth.py
@@ -295,7 +295,7 @@ def test_oidc_authenticator_rejects_missing_ca_bundle_during_initialization(
 @pytest.mark.parametrize(
     "issuer",
     [
-        "https://user:password@idp.example/realms/nachet",
+        "https://user:password@idp.example/realms/nachet",  # trufflehog:ignore
         "https://idp.example/realms/nachet?tenant=one",
         "https://idp.example/realms/nachet#keys",
     ],

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "3.0.0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #873

TruffleHog was flagging the fake credential-bearing issuer used by an OIDC validation test. This adds a line-level ignore without changing the test or repository-wide scan rules.

Validated with the focused backend tests and TruffleHog 3.96.0.