### PR TITLE
860 add a none option to each metadata field

### DIFF
--- a/backend/app/db/data/data_seed_local.py
+++ b/backend/app/db/data/data_seed_local.py
@@ -69,8 +69,37 @@ async def seed_dev_data(sessionmanager: SessionManager) -> None:
         os.getenv("CFIA_ADMIN_ROLE_ID", "87654321-4321-4321-4321-210987654321")
     )
 
+    NIL = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
     # Add device brand (Tagarno), models, and lenses
     async with async_session.begin() as session:
+        # Null device brand, model, and lens for "none" selection
+        null_brand = DeviceBrand(
+            id=NIL,
+            name="None",
+            description="No device brand selected",
+            active=True,
+        )
+        session.add(null_brand)
+
+        null_model = DeviceModel(
+            id=NIL,
+            device_brand_id=NIL,
+            name="None",
+            description="No device model selected",
+            active=True,
+        )
+        session.add(null_model)
+
+        null_lens = DeviceLens(
+            id=NIL,
+            device_brand_id=NIL,
+            name="None",
+            description="No device lens selected",
+            active=True,
+        )
+        session.add(null_lens)
+
         # Tagarno brand
         tagarno_brand = DeviceBrand(
             id=uuid.UUID("7b6e7736-6fb7-4895-b6d5-c521621705b3"),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nachet-backend"
-version = "3.0.1"
+version = "3.0.2"
 description = "Canadian government (CFIA) AI-powered seed identification system backend"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "nachet-backend"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "3.0.4",
+  "version": "3.0.5",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "3.0.3",
+  "version": "3.0.4",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/src/_versions.ts
+++ b/frontend/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
     gitTag?: string;
 };
 export const versions: TsAppVersion = {
-    version: '3.0.4',
+    version: '3.0.5',
     name: 'nachet-frontend',
-    versionDate: '2026-07-27T11:45:00.000Z',
+    versionDate: '2026-07-28T16:45:00.000Z',
 };
 export default versions;

--- a/frontend/src/_versions.ts
+++ b/frontend/src/_versions.ts
@@ -9,8 +9,8 @@ export interface TsAppVersion {
     gitTag?: string;
 };
 export const versions: TsAppVersion = {
-    version: '3.0.3',
+    version: '3.0.4',
     name: 'nachet-frontend',
-    versionDate: '2026-07-14T19:30:00.000Z',
+    versionDate: '2026-07-27T11:45:00.000Z',
 };
 export default versions;

--- a/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
+++ b/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
@@ -94,7 +94,7 @@ export const BatchUploadPopupContainer = (
   const [deviceBrandId, setDeviceBrandId] = useState<string>("");
   const [deviceModelId, setDeviceModelId] = useState<string>("");
   const [deviceLensId, setDeviceLensId] = useState<string>("");
-  const [magnification, setMagnification] = useState<number>(0);
+  const [magnification, setMagnification] = useState<number>(1);
 
   // Track if user has manually edited folder name
   const folderNameManuallyEdited = useRef<boolean>(false);
@@ -333,7 +333,7 @@ export const BatchUploadPopupContainer = (
     setDeviceBrandId("");
     setDeviceModelId("");
     setDeviceLensId("");
-    setMagnification(0.1);
+    setMagnification(1);
     setFiles(null);
     setFileCount(0);
     folderNameManuallyEdited.current = false;

--- a/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
+++ b/frontend/src/components/body/batch_upload_popup/BatchUploadPopupContainer.tsx
@@ -333,7 +333,7 @@ export const BatchUploadPopupContainer = (
     setDeviceBrandId("");
     setDeviceModelId("");
     setDeviceLensId("");
-    setMagnification(0);
+    setMagnification(0.1);
     setFiles(null);
     setFileCount(0);
     folderNameManuallyEdited.current = false;

--- a/frontend/src/components/body/image_metadata_popup/ImageMetadataPopup.tsx
+++ b/frontend/src/components/body/image_metadata_popup/ImageMetadataPopup.tsx
@@ -56,7 +56,7 @@ const ImageMetadataPopup: React.FC<ImageMetadataPopupProps> = (props) => {
 
   // Initialize sample metadata state
   const [trayCode, setTrayCode] = useState<string>("");
-  const [magnification, setMagnification] = useState<number>(0);
+  const [magnification, setMagnification] = useState<number>(1);
   const [sampleDescription, setSampleDescription] = useState<string>("");
 
   // Load image-specific data when popup opens
@@ -78,7 +78,7 @@ const ImageMetadataPopup: React.FC<ImageMetadataPopupProps> = (props) => {
 
         // Load sample metadata
         setTrayCode(() => currentImage.trayCode || "");
-        setMagnification(() => currentImage.magnification || 0);
+        setMagnification(() => currentImage.magnification || 1);
         setSampleDescription(() => currentImage.imageDescription || "");
       }
     }

--- a/frontend/src/components/body/image_metadata_popup/ImageMetadataPopup.tsx
+++ b/frontend/src/components/body/image_metadata_popup/ImageMetadataPopup.tsx
@@ -121,9 +121,9 @@ const ImageMetadataPopup: React.FC<ImageMetadataPopupProps> = (props) => {
       const issue = imageNameResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setImageNameError(t("validation.imageName.empty"));
+        setImageNameError(t("deviceInfo.validation.imageName.empty"));
       } else if (issue.code === "too_big") {
-        setImageNameError(t("validation.imageName.tooLong"));
+        setImageNameError(t("deviceInfo.validation.imageName.tooLong"));
       } else {
         const errorKey = getZodErrorKey(imageNameResult.error);
         setImageNameError(t(errorKey));
@@ -191,9 +191,11 @@ const ImageMetadataPopup: React.FC<ImageMetadataPopupProps> = (props) => {
       const issue = sampleDescriptionResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setSampleDescriptionError(t("validation.description.empty"));
+        setSampleDescriptionError(t("deviceInfo.validation.description.empty"));
       } else if (issue.code === "too_big") {
-        setSampleDescriptionError(t("validation.description.tooLong"));
+        setSampleDescriptionError(
+          t("deviceInfo.validation.description.tooLong"),
+        );
       } else {
         const errorKey = getZodErrorKey(sampleDescriptionResult.error);
         setSampleDescriptionError(t(errorKey));

--- a/frontend/src/components/body/image_metadata_popup/ImageMetadataPopup.tsx
+++ b/frontend/src/components/body/image_metadata_popup/ImageMetadataPopup.tsx
@@ -121,9 +121,9 @@ const ImageMetadataPopup: React.FC<ImageMetadataPopupProps> = (props) => {
       const issue = imageNameResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setImageNameError(t("deviceInfo.validation.imageName.empty"));
+        setImageNameError(t("validation.imageName.empty"));
       } else if (issue.code === "too_big") {
-        setImageNameError(t("deviceInfo.validation.imageName.tooLong"));
+        setImageNameError(t("validation.imageName.tooLong"));
       } else {
         const errorKey = getZodErrorKey(imageNameResult.error);
         setImageNameError(t(errorKey));
@@ -191,11 +191,9 @@ const ImageMetadataPopup: React.FC<ImageMetadataPopupProps> = (props) => {
       const issue = sampleDescriptionResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setSampleDescriptionError(t("deviceInfo.validation.description.empty"));
+        setSampleDescriptionError(t("validation.description.empty"));
       } else if (issue.code === "too_big") {
-        setSampleDescriptionError(
-          t("deviceInfo.validation.description.tooLong"),
-        );
+        setSampleDescriptionError(t("validation.description.tooLong"));
       } else {
         const errorKey = getZodErrorKey(sampleDescriptionResult.error);
         setSampleDescriptionError(t(errorKey));

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -148,13 +148,9 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
       const issue = magnificationResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setMagnificationError(
-          t("deviceInfo.validation.magnification.tooSmall"),
-        );
+        setMagnificationError(t("validation.magnification.tooSmall"));
       } else if (issue.code === "too_big") {
-        setMagnificationError(
-          t("deviceInfo.validation.magnification.tooLarge"),
-        );
+        setMagnificationError(t("validation.magnification.tooLarge"));
       } else {
         const errorKey = getZodErrorKey(magnificationResult.error);
         setMagnificationError(t(errorKey));
@@ -170,9 +166,9 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
       const issue = sampleIdPrefixResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setSampleIdPrefixError(t("deviceInfo.validation.imageName.empty"));
+        setSampleIdPrefixError(t("validation.imageName.empty"));
       } else if (issue.code === "too_big") {
-        setSampleIdPrefixError(t("deviceInfo.validation.imageName.tooLong"));
+        setSampleIdPrefixError(t("validation.imageName.tooLong"));
       } else {
         const errorKey = getZodErrorKey(sampleIdPrefixResult.error);
         setSampleIdPrefixError(t(errorKey));
@@ -189,11 +185,9 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
       const issue = sampleDescriptionResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setSampleDescriptionError(t("deviceInfo.validation.description.empty"));
+        setSampleDescriptionError(t("validation.description.empty"));
       } else if (issue.code === "too_big") {
-        setSampleDescriptionError(
-          t("deviceInfo.validation.description.tooLong"),
-        );
+        setSampleDescriptionError(t("validation.description.tooLong"));
       } else {
         const errorKey = getZodErrorKey(sampleDescriptionResult.error);
         setSampleDescriptionError(t(errorKey));

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -68,7 +68,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
       // Load sample metadata
       setTrayCode(() => sampleMetadata.trayCode);
-      setMagnification(() => sampleMetadata.magnification);
+      setMagnification(() => Math.max(sampleMetadata.magnification, 0.1));
       setSampleIdPrefix(() => sampleMetadata.sampleIdPrefix);
       setSampleDescription(() => sampleMetadata.sampleDescription);
 

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -30,8 +30,7 @@ import {
   ERROR_KEY_MAPPINGS,
 } from "@hooks/useZodFieldValidation";
 
-const NONE_ID = "none";
-
+const NONE_ID = "00000000-0000-0000-0000-000000000000";
 interface SampleMetadataPopupProps {
   devicesData: ApiDevicesResponse | null;
 }
@@ -139,7 +138,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
     // Validate sample metadata using Zod with i18n
     const trayCodeResult = trayCodeSchema.safeParse(trayCode);
-    if (trayCode !== "none" && !trayCodeResult.success) {
+    if (!trayCodeResult.success) {
       setTrayCodeError(t("batchUpload.metadataSection.trayCodeRequired"));
       isValid = false;
     } else {

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -51,7 +51,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
   // Initialize sample metadata state
   const [trayCode, setTrayCode] = useState<string>("");
-  const [magnification, setMagnification] = useState<number>(0.1);
+  const [magnification, setMagnification] = useState<number>(1);
   const [sampleIdPrefix, setSampleIdPrefix] = useState<string>("");
   const [sampleDescription, setSampleDescription] = useState<string>("");
 
@@ -67,7 +67,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
       // Load sample metadata
       setTrayCode(() => sampleMetadata.trayCode);
-      setMagnification(() => Math.max(sampleMetadata.magnification, 0.1));
+      setMagnification(() => sampleMetadata.magnification);
       setSampleIdPrefix(() => sampleMetadata.sampleIdPrefix);
       setSampleDescription(() => sampleMetadata.sampleDescription);
 
@@ -109,7 +109,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
   const validateAndSave = (): boolean => {
     let isValid = true;
 
-    // Validate device selection using Zod with i18n.
+    // Validate device selection using Zod with i18n
     const brandResult = deviceIdValidationSchema.safeParse(selectedBrandId);
     if (!brandResult.success) {
       setBrandError(t("deviceInfo.errors.brandRequired"));
@@ -230,16 +230,21 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
   // Get the selected brand object for display
   const selectedBrand = useMemo(() => {
-    if (!selectedBrandId || !props.devicesData) return null;
+    if (!props.devicesData || !selectedBrandId) return null;
     return (
       props.devicesData.devices.find((brand) => brand.id === selectedBrandId) ||
       null
     );
   }, [props.devicesData, selectedBrandId]);
 
-  // Models/lenses of the selected brand, for the summary display
-  const availableModels = selectedBrand?.models || [];
-  const availableLenses = selectedBrand?.lenses || [];
+  // Get available models/lenses for display
+  const availableModels = useMemo(() => {
+    return selectedBrand?.models || [];
+  }, [selectedBrand]);
+
+  const availableLenses = useMemo(() => {
+    return selectedBrand?.lenses || [];
+  }, [selectedBrand]);
 
   return (
     <Dialog

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -150,9 +150,13 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
       const issue = magnificationResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setMagnificationError(t("validation.magnification.tooSmall"));
+        setMagnificationError(
+          t("deviceInfo.validation.magnification.tooSmall"),
+        );
       } else if (issue.code === "too_big") {
-        setMagnificationError(t("validation.magnification.tooLarge"));
+        setMagnificationError(
+          t("deviceInfo.validation.magnification.tooLarge"),
+        );
       } else {
         const errorKey = getZodErrorKey(magnificationResult.error);
         setMagnificationError(t(errorKey));

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { colours } from "../../../styles/colours";
-import { ApiDevicesResponse } from "@common/types";
+import { ApiDevicesResponse, ApiDeviceBrand } from "@common/types";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { useModalStore } from "@stores/useModalStore";
 import {
@@ -29,6 +29,8 @@ import {
   useZodFieldValidation,
   ERROR_KEY_MAPPINGS,
 } from "@hooks/useZodFieldValidation";
+
+const NONE_ID = "none";
 
 interface SampleMetadataPopupProps {
   devicesData: ApiDevicesResponse | null;
@@ -51,7 +53,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
   // Initialize sample metadata state
   const [trayCode, setTrayCode] = useState<string>("");
-  const [magnification, setMagnification] = useState<number>(0);
+  const [magnification, setMagnification] = useState<number>(0.1);
   const [sampleIdPrefix, setSampleIdPrefix] = useState<string>("");
   const [sampleDescription, setSampleDescription] = useState<string>("");
 
@@ -109,9 +111,10 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
   const validateAndSave = (): boolean => {
     let isValid = true;
 
-    // Validate device selection using Zod with i18n
+    // Validate device selection using Zod with i18n.
+    // "none" is an accepted answer (device unknown), so treat it as filled.
     const brandResult = deviceIdValidationSchema.safeParse(selectedBrandId);
-    if (!brandResult.success) {
+    if (selectedBrandId !== NONE_ID && !brandResult.success) {
       setBrandError(t("deviceInfo.errors.brandRequired"));
       isValid = false;
     } else {
@@ -119,7 +122,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     }
 
     const modelResult = deviceIdValidationSchema.safeParse(selectedModelId);
-    if (!modelResult.success) {
+    if (selectedModelId !== NONE_ID && !modelResult.success) {
       setModelError(t("deviceInfo.errors.modelRequired"));
       isValid = false;
     } else {
@@ -127,7 +130,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     }
 
     const lensResult = deviceIdValidationSchema.safeParse(selectedLensId);
-    if (!lensResult.success) {
+    if (selectedLensId !== NONE_ID && !lensResult.success) {
       setLensError(t("deviceInfo.errors.lensRequired"));
       isValid = false;
     } else {
@@ -136,7 +139,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
 
     // Validate sample metadata using Zod with i18n
     const trayCodeResult = trayCodeSchema.safeParse(trayCode);
-    if (!trayCodeResult.success) {
+    if (trayCode !== "none" && !trayCodeResult.success) {
       setTrayCodeError(t("batchUpload.metadataSection.trayCodeRequired"));
       isValid = false;
     } else {
@@ -166,9 +169,9 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
       const issue = sampleIdPrefixResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setSampleIdPrefixError(t("validation.imageName.empty"));
+        setSampleIdPrefixError(t("deviceInfo.validation.imageName.empty"));
       } else if (issue.code === "too_big") {
-        setSampleIdPrefixError(t("validation.imageName.tooLong"));
+        setSampleIdPrefixError(t("deviceInfo.validation.imageName.tooLong"));
       } else {
         const errorKey = getZodErrorKey(sampleIdPrefixResult.error);
         setSampleIdPrefixError(t(errorKey));
@@ -185,9 +188,11 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
       const issue = sampleDescriptionResult.error.issues[0];
       // Map Zod error codes to specific translation keys
       if (issue.code === "too_small") {
-        setSampleDescriptionError(t("validation.description.empty"));
+        setSampleDescriptionError(t("deviceInfo.validation.description.empty"));
       } else if (issue.code === "too_big") {
-        setSampleDescriptionError(t("validation.description.tooLong"));
+        setSampleDescriptionError(
+          t("deviceInfo.validation.description.tooLong"),
+        );
       } else {
         const errorKey = getZodErrorKey(sampleDescriptionResult.error);
         setSampleDescriptionError(t(errorKey));
@@ -228,23 +233,38 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     closeSampleMetadataPopup();
   };
 
+  // Synthetic "None" option used to resolve the display box when the
+  // user selects None (device unknown).
+  const noneOption: ApiDeviceBrand = useMemo(
+    () => ({
+      id: NONE_ID,
+      name: t("deviceInfo.none"),
+      description: "",
+      models: [],
+      lenses: [],
+    }),
+    [t],
+  );
+
   // Get the selected brand object for display
   const selectedBrand = useMemo(() => {
-    if (!props.devicesData || !selectedBrandId) return null;
+    if (!selectedBrandId) return null;
+    if (selectedBrandId === NONE_ID) return noneOption;
+    if (!props.devicesData) return null;
     return (
       props.devicesData.devices.find((brand) => brand.id === selectedBrandId) ||
       null
     );
-  }, [props.devicesData, selectedBrandId]);
+  }, [props.devicesData, selectedBrandId, noneOption]);
 
-  // Get available models/lenses for display
+  // Get available models/lenses for display, including the None option
   const availableModels = useMemo(() => {
-    return selectedBrand?.models || [];
-  }, [selectedBrand]);
+    return [...(selectedBrand?.models || []), noneOption];
+  }, [selectedBrand, noneOption]);
 
   const availableLenses = useMemo(() => {
-    return selectedBrand?.lenses || [];
-  }, [selectedBrand]);
+    return [...(selectedBrand?.lenses || []), noneOption];
+  }, [selectedBrand, noneOption]);
 
   return (
     <Dialog

--- a/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
+++ b/frontend/src/components/body/sample_metadata_popup/SampleMetadataPopup.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { colours } from "../../../styles/colours";
-import { ApiDevicesResponse, ApiDeviceBrand } from "@common/types";
+import { ApiDevicesResponse } from "@common/types";
 import { useDeviceStore } from "@stores/useDeviceStore";
 import { useModalStore } from "@stores/useModalStore";
 import {
@@ -30,7 +30,6 @@ import {
   ERROR_KEY_MAPPINGS,
 } from "@hooks/useZodFieldValidation";
 
-const NONE_ID = "00000000-0000-0000-0000-000000000000";
 interface SampleMetadataPopupProps {
   devicesData: ApiDevicesResponse | null;
 }
@@ -111,9 +110,8 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     let isValid = true;
 
     // Validate device selection using Zod with i18n.
-    // "none" is an accepted answer (device unknown), so treat it as filled.
     const brandResult = deviceIdValidationSchema.safeParse(selectedBrandId);
-    if (selectedBrandId !== NONE_ID && !brandResult.success) {
+    if (!brandResult.success) {
       setBrandError(t("deviceInfo.errors.brandRequired"));
       isValid = false;
     } else {
@@ -121,7 +119,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     }
 
     const modelResult = deviceIdValidationSchema.safeParse(selectedModelId);
-    if (selectedModelId !== NONE_ID && !modelResult.success) {
+    if (!modelResult.success) {
       setModelError(t("deviceInfo.errors.modelRequired"));
       isValid = false;
     } else {
@@ -129,7 +127,7 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     }
 
     const lensResult = deviceIdValidationSchema.safeParse(selectedLensId);
-    if (selectedLensId !== NONE_ID && !lensResult.success) {
+    if (!lensResult.success) {
       setLensError(t("deviceInfo.errors.lensRequired"));
       isValid = false;
     } else {
@@ -236,38 +234,18 @@ const SampleMetadataPopup: React.FC<SampleMetadataPopupProps> = (props) => {
     closeSampleMetadataPopup();
   };
 
-  // Synthetic "None" option used to resolve the display box when the
-  // user selects None (device unknown).
-  const noneOption: ApiDeviceBrand = useMemo(
-    () => ({
-      id: NONE_ID,
-      name: t("deviceInfo.none"),
-      description: "",
-      models: [],
-      lenses: [],
-    }),
-    [t],
-  );
-
   // Get the selected brand object for display
   const selectedBrand = useMemo(() => {
-    if (!selectedBrandId) return null;
-    if (selectedBrandId === NONE_ID) return noneOption;
-    if (!props.devicesData) return null;
+    if (!selectedBrandId || !props.devicesData) return null;
     return (
       props.devicesData.devices.find((brand) => brand.id === selectedBrandId) ||
       null
     );
-  }, [props.devicesData, selectedBrandId, noneOption]);
+  }, [props.devicesData, selectedBrandId]);
 
-  // Get available models/lenses for display, including the None option
-  const availableModels = useMemo(() => {
-    return [...(selectedBrand?.models || []), noneOption];
-  }, [selectedBrand, noneOption]);
-
-  const availableLenses = useMemo(() => {
-    return [...(selectedBrand?.lenses || []), noneOption];
-  }, [selectedBrand, noneOption]);
+  // Models/lenses of the selected brand, for the summary display
+  const availableModels = selectedBrand?.models || [];
+  const availableLenses = selectedBrand?.lenses || [];
 
   return (
     <Dialog

--- a/frontend/src/components/common/DeviceSelectionFields.tsx
+++ b/frontend/src/components/common/DeviceSelectionFields.tsx
@@ -3,6 +3,8 @@ import { Box, FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 import { ApiDevicesResponse } from "@common/types";
 import { useTranslation } from "react-i18next";
 
+const NONE_ID = "none";
+
 interface DeviceSelectionFieldsProps {
   selectedBrandId: string;
   selectedModelId: string;
@@ -31,6 +33,12 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
   lensError,
 }) => {
   const { t } = useTranslation("popups");
+
+  const noneOption = useMemo(
+    () => ({ id: NONE_ID, name: t("deviceInfo.none"), models: [], lenses: [] }),
+    [t],
+  );
+
   // Get the selected brand object
   const selectedBrand = useMemo(() => {
     if (!devicesData || !selectedBrandId) return null;
@@ -39,22 +47,36 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
     );
   }, [devicesData, selectedBrandId]);
 
-  // Filter models based on selected brand
-  const availableModels = useMemo(() => {
-    return selectedBrand?.models || [];
-  }, [selectedBrand]);
+  // Brand list with a trailing "None" option
+  const brandOptions = useMemo(() => {
+    if (!devicesData) return [noneOption];
+    return [...devicesData.devices, noneOption];
+  }, [devicesData, noneOption]);
 
-  // Filter lenses based on selected brand
+  // Filter models based on selected brand, plus a "None" option
+  const availableModels = useMemo(() => {
+    return [...(selectedBrand?.models || []), noneOption];
+  }, [selectedBrand, noneOption]);
+
+  // Filter lenses based on selected brand, plus a "None" option
   const availableLenses = useMemo(() => {
-    return selectedBrand?.lenses || [];
-  }, [selectedBrand]);
+    return [...(selectedBrand?.lenses || []), noneOption];
+  }, [selectedBrand, noneOption]);
 
   const handleBrandChange = (brandId: string) => {
     onBrandChange(brandId);
-    // Reset model and lens when brand changes
-    onModelChange("");
-    onLensChange("");
+    // If brand is None, cascade None down. Otherwise reset model and lens.
+    if (brandId === NONE_ID) {
+      onModelChange(NONE_ID);
+      onLensChange(NONE_ID);
+    } else {
+      onModelChange("");
+      onLensChange("");
+    }
   };
+
+  const subFieldsDisabled =
+    !selectedBrandId || selectedBrandId === NONE_ID || disabled;
 
   return (
     <Box
@@ -79,7 +101,7 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
           <MenuItem value="">
             <em>{t("deviceInfo.selectBrand")}</em>
           </MenuItem>
-          {devicesData?.devices.map((brand) => (
+          {brandOptions.map((brand) => (
             <MenuItem key={brand.id} value={brand.id}>
               {brand.name}
             </MenuItem>
@@ -111,7 +133,7 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
         {/* Model Dropdown */}
         <FormControl
           sx={{ width: "calc(50% - 5px)" }}
-          disabled={!selectedBrandId || disabled}
+          disabled={subFieldsDisabled}
           error={!!modelError}
         >
           <InputLabel id="device-model-label">
@@ -149,7 +171,7 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
         {/* Lens Dropdown */}
         <FormControl
           sx={{ width: "calc(50% - 5px)" }}
-          disabled={!selectedBrandId || disabled}
+          disabled={subFieldsDisabled}
           error={!!lensError}
         >
           <InputLabel id="device-lens-label">

--- a/frontend/src/components/common/DeviceSelectionFields.tsx
+++ b/frontend/src/components/common/DeviceSelectionFields.tsx
@@ -46,20 +46,29 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
     );
   }, [devicesData, selectedBrandId]);
 
-  // Brand list with a trailing "None" option
+  // Brand list with a trailing "None" option.
+  // Filter any backend-provided NIL entry so we don't duplicate the injected one.
   const brandOptions = useMemo(() => {
-    if (!devicesData) return [noneOption];
-    return [...devicesData.devices, noneOption];
+    const backendBrands = (devicesData?.devices || []).filter(
+      (brand) => brand.id !== NONE_ID,
+    );
+    return [...backendBrands, noneOption];
   }, [devicesData, noneOption]);
 
   // Filter models based on selected brand, plus a "None" option
   const availableModels = useMemo(() => {
-    return [...(selectedBrand?.models || []), noneOption];
+    const backendModels = (selectedBrand?.models || []).filter(
+      (model) => model.id !== NONE_ID,
+    );
+    return [...backendModels, noneOption];
   }, [selectedBrand, noneOption]);
 
   // Filter lenses based on selected brand, plus a "None" option
   const availableLenses = useMemo(() => {
-    return [...(selectedBrand?.lenses || []), noneOption];
+    const backendLenses = (selectedBrand?.lenses || []).filter(
+      (lens) => lens.id !== NONE_ID,
+    );
+    return [...backendLenses, noneOption];
   }, [selectedBrand, noneOption]);
 
   const handleBrandChange = (brandId: string) => {

--- a/frontend/src/components/common/DeviceSelectionFields.tsx
+++ b/frontend/src/components/common/DeviceSelectionFields.tsx
@@ -33,11 +33,6 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
 }) => {
   const { t } = useTranslation("popups");
 
-  const noneOption = useMemo(
-    () => ({ id: NONE_ID, name: t("deviceInfo.none"), models: [], lenses: [] }),
-    [t],
-  );
-
   // Get the selected brand object
   const selectedBrand = useMemo(() => {
     if (!devicesData || !selectedBrandId) return null;
@@ -46,30 +41,12 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
     );
   }, [devicesData, selectedBrandId]);
 
-  // Brand list with a trailing "None" option.
-  // Filter any backend-provided NIL entry so we don't duplicate the injected one.
-  const brandOptions = useMemo(() => {
-    const backendBrands = (devicesData?.devices || []).filter(
-      (brand) => brand.id !== NONE_ID,
-    );
-    return [...backendBrands, noneOption];
-  }, [devicesData, noneOption]);
+  // Brand list as provided by the backend (includes the "None" brand)
+  const brandOptions = devicesData?.devices || [];
 
-  // Filter models based on selected brand, plus a "None" option
-  const availableModels = useMemo(() => {
-    const backendModels = (selectedBrand?.models || []).filter(
-      (model) => model.id !== NONE_ID,
-    );
-    return [...backendModels, noneOption];
-  }, [selectedBrand, noneOption]);
-
-  // Filter lenses based on selected brand, plus a "None" option
-  const availableLenses = useMemo(() => {
-    const backendLenses = (selectedBrand?.lenses || []).filter(
-      (lens) => lens.id !== NONE_ID,
-    );
-    return [...backendLenses, noneOption];
-  }, [selectedBrand, noneOption]);
+  // Models and lenses belonging to the selected brand
+  const availableModels = selectedBrand?.models || [];
+  const availableLenses = selectedBrand?.lenses || [];
 
   const handleBrandChange = (brandId: string) => {
     onBrandChange(brandId);

--- a/frontend/src/components/common/DeviceSelectionFields.tsx
+++ b/frontend/src/components/common/DeviceSelectionFields.tsx
@@ -44,9 +44,15 @@ export const DeviceSelectionFields: React.FC<DeviceSelectionFieldsProps> = ({
   // Brand list as provided by the backend (includes the "None" brand)
   const brandOptions = devicesData?.devices || [];
 
-  // Models and lenses belonging to the selected brand
-  const availableModels = selectedBrand?.models || [];
-  const availableLenses = selectedBrand?.lenses || [];
+  // Filter models based on selected brand
+  const availableModels = useMemo(() => {
+    return selectedBrand?.models || [];
+  }, [selectedBrand]);
+
+  // Filter lenses based on selected brand
+  const availableLenses = useMemo(() => {
+    return selectedBrand?.lenses || [];
+  }, [selectedBrand]);
 
   const handleBrandChange = (brandId: string) => {
     onBrandChange(brandId);

--- a/frontend/src/components/common/DeviceSelectionFields.tsx
+++ b/frontend/src/components/common/DeviceSelectionFields.tsx
@@ -3,8 +3,7 @@ import { Box, FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 import { ApiDevicesResponse } from "@common/types";
 import { useTranslation } from "react-i18next";
 
-const NONE_ID = "none";
-
+const NONE_ID = "00000000-0000-0000-0000-000000000000";
 interface DeviceSelectionFieldsProps {
   selectedBrandId: string;
   selectedModelId: string;

--- a/frontend/src/components/common/SampleMetadataFields.tsx
+++ b/frontend/src/components/common/SampleMetadataFields.tsx
@@ -77,9 +77,6 @@ export const SampleMetadataFields = (props: SampleMetadataFieldsProps) => {
           <MenuItem value="">
             <em>{t("batchUpload.metadataSection.selectTrayCode")}</em>
           </MenuItem>
-          <MenuItem value="none">
-            {t("batchUpload.metadataSection.none")}
-          </MenuItem>
           <MenuItem value="A">A</MenuItem>
           <MenuItem value="B">B</MenuItem>
           <MenuItem value="C">C</MenuItem>

--- a/frontend/src/components/common/SampleMetadataFields.tsx
+++ b/frontend/src/components/common/SampleMetadataFields.tsx
@@ -77,6 +77,9 @@ export const SampleMetadataFields = (props: SampleMetadataFieldsProps) => {
           <MenuItem value="">
             <em>{t("batchUpload.metadataSection.selectTrayCode")}</em>
           </MenuItem>
+          <MenuItem value="none">
+            {t("batchUpload.metadataSection.none")}
+          </MenuItem>
           <MenuItem value="A">A</MenuItem>
           <MenuItem value="B">B</MenuItem>
           <MenuItem value="C">C</MenuItem>
@@ -95,7 +98,7 @@ export const SampleMetadataFields = (props: SampleMetadataFieldsProps) => {
           }
           slotProps={{
             htmlInput: {
-              min: 0.2,
+              min: 0.1,
               max: 1000,
               step: 0.1,
               style: { textAlign: "center" },

--- a/frontend/src/locales/en/popups.ts
+++ b/frontend/src/locales/en/popups.ts
@@ -65,38 +65,6 @@ const popups = {
       modelRequired: "Device model is required",
       lensRequired: "Device lens is required",
     },
-    validation: {
-      invalidMagnification: "Magnification must be a positive number",
-      magnification: {
-        tooSmall: "Magnification must be at least 0.1",
-        tooLarge: "Magnification cannot exceed 1000",
-      },
-      imageName: {
-        empty: "Sample ID prefix is required",
-        tooLong: "Sample ID prefix is too long",
-      },
-      description: {
-        empty: "Sample description is required",
-        tooLong: "Sample description is too long",
-      },
-    },
-  },
-
-  // Shared validation messages used across popup components (see useZodFieldValidation)
-  validation: {
-    invalidMagnification: "Magnification must be a positive number",
-    magnification: {
-      tooSmall: "Magnification must be at least 0.1",
-      tooLarge: "Magnification cannot exceed 1000",
-    },
-    imageName: {
-      empty: "Sample ID prefix is required",
-      tooLong: "Sample ID prefix is too long",
-    },
-    description: {
-      empty: "Sample description is required",
-      tooLong: "Sample description is too long",
-    },
   },
 
   // Image Metadata Popup
@@ -233,18 +201,6 @@ const popups = {
       speciesRequired: "Species is required",
       filesRequired: "Please select at least one file",
       invalidMagnification: "Magnification must be a positive number",
-      magnification: {
-        tooSmall: "Magnification must be at least 0.1",
-        tooLarge: "Magnification cannot exceed 1000",
-      },
-      imageName: {
-        empty: "Sample ID prefix is required",
-        tooLong: "Sample ID prefix is too long",
-      },
-      description: {
-        empty: "Sample description is required",
-        tooLong: "Sample description is too long",
-      },
     },
   },
 
@@ -347,6 +303,38 @@ const popups = {
     minutesAgo: "{{count}} minute(s) ago",
     hoursAgo: "{{count}} hour(s) ago",
     daysAgo: "{{count}} day(s) ago",
+  },
+
+  // Popup Validation Messages
+  validation: {
+    invalidMagnification: "Magnification must be a positive number",
+    magnification: {
+      tooSmall: "Magnification must be at least 0.1",
+      tooLarge: "Magnification cannot exceed 1000",
+    },
+    imageName: {
+      empty: "Sample ID prefix is required",
+      tooLong: "Sample ID prefix is too long",
+    },
+    description: {
+      empty: "Sample description is required",
+      tooLong: "Sample description is too long",
+    },
+    // Fallback Zod issues messages
+    generic: {
+      required: "This field is required",
+      invalid: "Invalid value",
+      invalidType: "Expected {{expected}}, received {{received}}",
+      tooSmall: "Must be at least {{minimum}}",
+      tooLarge: "Must be at most {{maximum}}",
+      tooSmallString: "Must be at least {{minimum}} characters",
+      tooLargeString: "Must be at most {{maximum}} characters",
+      notInteger: "Must be a whole number",
+      notNumber: "Must be a number",
+      invalidString: "Invalid format",
+      invalidEnum: "Invalid selection",
+      custom: "Validation error",
+    },
   },
 } as const;
 

--- a/frontend/src/locales/en/popups.ts
+++ b/frontend/src/locales/en/popups.ts
@@ -83,6 +83,23 @@ const popups = {
     },
   },
 
+  // Shared validation messages used across popup components (see useZodFieldValidation)
+  validation: {
+    invalidMagnification: "Magnification must be a positive number",
+    magnification: {
+      tooSmall: "Magnification must be at least 0.1",
+      tooLarge: "Magnification cannot exceed 1000",
+    },
+    imageName: {
+      empty: "Sample ID prefix is required",
+      tooLong: "Sample ID prefix is too long",
+    },
+    description: {
+      empty: "Sample description is required",
+      tooLong: "Sample description is too long",
+    },
+  },
+
   // Image Metadata Popup
   imageMetadata: {
     title: "Edit Image Metadata",

--- a/frontend/src/locales/en/popups.ts
+++ b/frontend/src/locales/en/popups.ts
@@ -60,10 +60,26 @@ const popups = {
     selectBrand: "Select a brand",
     selectModel: "Select a model",
     selectLens: "Select a lens",
+    none: "None",
     errors: {
       brandRequired: "Device brand is required",
       modelRequired: "Device model is required",
       lensRequired: "Device lens is required",
+    },
+    validation: {
+      invalidMagnification: "Magnification must be a positive number",
+      magnification: {
+        tooSmall: "Magnification must be at least 0.1",
+        tooLarge: "Magnification cannot exceed 1000",
+      },
+      imageName: {
+        empty: "Sample ID prefix is required",
+        tooLong: "Sample ID prefix is too long",
+      },
+      description: {
+        empty: "Sample description is required",
+        tooLong: "Sample description is too long",
+      },
     },
   },
 
@@ -160,6 +176,7 @@ const popups = {
         "Only letters, numbers, periods, and spaces. No consecutive spaces or periods. Auto-normalized on blur.",
       sampleDescriptionRequired: "Sample description is required",
       magnificationRequired: "Magnification is required",
+      none: "None",
     },
     deviceSection: {
       heading: "Device Information",
@@ -201,6 +218,18 @@ const popups = {
       speciesRequired: "Species is required",
       filesRequired: "Please select at least one file",
       invalidMagnification: "Magnification must be a positive number",
+      magnification: {
+        tooSmall: "Magnification must be at least 0.1",
+        tooLarge: "Magnification cannot exceed 1000",
+      },
+      imageName: {
+        empty: "Sample ID prefix is required",
+        tooLong: "Sample ID prefix is too long",
+      },
+      description: {
+        empty: "Sample description is required",
+        tooLong: "Sample description is too long",
+      },
     },
   },
 

--- a/frontend/src/locales/en/popups.ts
+++ b/frontend/src/locales/en/popups.ts
@@ -60,7 +60,6 @@ const popups = {
     selectBrand: "Select a brand",
     selectModel: "Select a model",
     selectLens: "Select a lens",
-    none: "None",
     errors: {
       brandRequired: "Device brand is required",
       modelRequired: "Device model is required",
@@ -193,7 +192,6 @@ const popups = {
         "Only letters, numbers, periods, and spaces. No consecutive spaces or periods. Auto-normalized on blur.",
       sampleDescriptionRequired: "Sample description is required",
       magnificationRequired: "Magnification is required",
-      none: "None",
     },
     deviceSection: {
       heading: "Device Information",

--- a/frontend/src/locales/fr/popups.ts
+++ b/frontend/src/locales/fr/popups.ts
@@ -83,6 +83,23 @@ const popups = {
     },
   },
 
+  // Messages de validation partagés utilisés par les popups (voir useZodFieldValidation)
+  validation: {
+    invalidMagnification: "Le grossissement doit être un nombre positif",
+    magnification: {
+      tooSmall: "Le grossissement doit être d'au moins 0,1",
+      tooLarge: "Le grossissement ne peut pas dépasser 1000",
+    },
+    imageName: {
+      empty: "Le préfixe d'identifiant d'échantillon est requis",
+      tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
+    },
+    description: {
+      empty: "La description de l'échantillon est requise",
+      tooLong: "La description de l'échantillon est trop longue",
+    },
+  },
+
   // Fenêtre de métadonnées d'image
   imageMetadata: {
     title: "Modifier les métadonnées de l'image",

--- a/frontend/src/locales/fr/popups.ts
+++ b/frontend/src/locales/fr/popups.ts
@@ -65,38 +65,6 @@ const popups = {
       modelRequired: "Le modèle de l'appareil est requis",
       lensRequired: "La lentille de l'appareil est requise",
     },
-    validation: {
-      invalidMagnification: "Le grossissement doit être un nombre positif",
-      magnification: {
-        tooSmall: "Le grossissement doit être d'au moins 0,1",
-        tooLarge: "Le grossissement ne peut pas dépasser 1000",
-      },
-      imageName: {
-        empty: "Le préfixe d'identifiant d'échantillon est requis",
-        tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
-      },
-      description: {
-        empty: "La description de l'échantillon est requise",
-        tooLong: "La description de l'échantillon est trop longue",
-      },
-    },
-  },
-
-  // Messages de validation partagés utilisés par les popups (voir useZodFieldValidation)
-  validation: {
-    invalidMagnification: "Le grossissement doit être un nombre positif",
-    magnification: {
-      tooSmall: "Le grossissement doit être d'au moins 0,1",
-      tooLarge: "Le grossissement ne peut pas dépasser 1000",
-    },
-    imageName: {
-      empty: "Le préfixe d'identifiant d'échantillon est requis",
-      tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
-    },
-    description: {
-      empty: "La description de l'échantillon est requise",
-      tooLong: "La description de l'échantillon est trop longue",
-    },
   },
 
   // Fenêtre de métadonnées d'image
@@ -235,18 +203,6 @@ const popups = {
       speciesRequired: "L'espèce est requise",
       filesRequired: "Veuillez sélectionner au moins un fichier",
       invalidMagnification: "Le grossissement doit être un nombre positif",
-      magnification: {
-        tooSmall: "Le grossissement doit être d'au moins 0,1",
-        tooLarge: "Le grossissement ne peut pas dépasser 1000",
-      },
-      imageName: {
-        empty: "Le préfixe d'identifiant d'échantillon est requis",
-        tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
-      },
-      description: {
-        empty: "La description de l'échantillon est requise",
-        tooLong: "La description de l'échantillon est trop longue",
-      },
     },
   },
 
@@ -354,6 +310,38 @@ const popups = {
     minutesAgo: "Il y a {{count}} minute(s)",
     hoursAgo: "Il y a {{count}} heure(s)",
     daysAgo: "Il y a {{count}} jour(s)",
+  },
+
+  // Messages de validation
+  validation: {
+    invalidMagnification: "Le grossissement doit être un nombre positif",
+    magnification: {
+      tooSmall: "Le grossissement doit être d'au moins 0,1",
+      tooLarge: "Le grossissement ne peut pas dépasser 1000",
+    },
+    imageName: {
+      empty: "Le préfixe d'identifiant d'échantillon est requis",
+      tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
+    },
+    description: {
+      empty: "La description de l'échantillon est requise",
+      tooLong: "La description de l'échantillon est trop longue",
+    },
+    // Messages de repli pour les erreurs Zod non mappées
+    generic: {
+      required: "Ce champ est requis",
+      invalid: "Valeur invalide",
+      invalidType: "Type attendu {{expected}}, reçu {{received}}",
+      tooSmall: "Doit être au moins {{minimum}}",
+      tooLarge: "Doit être au maximum {{maximum}}",
+      tooSmallString: "Doit contenir au moins {{minimum}} caractères",
+      tooLargeString: "Doit contenir au maximum {{maximum}} caractères",
+      notInteger: "Doit être un nombre entier",
+      notNumber: "Doit être un nombre",
+      invalidString: "Format invalide",
+      invalidEnum: "Sélection invalide",
+      custom: "Erreur de validation",
+    },
   },
 } as const;
 

--- a/frontend/src/locales/fr/popups.ts
+++ b/frontend/src/locales/fr/popups.ts
@@ -60,7 +60,6 @@ const popups = {
     selectBrand: "Sélectionner une marque",
     selectModel: "Sélectionner un modèle",
     selectLens: "Sélectionner une lentille",
-    none: "Aucun",
     errors: {
       brandRequired: "La marque de l'appareil est requise",
       modelRequired: "Le modèle de l'appareil est requis",
@@ -195,7 +194,6 @@ const popups = {
         "Seulement lettres, chiffres, points et espaces. Pas d'espaces ou de points consécutifs. Auto-normalisé en perdant le focus.",
       sampleDescriptionRequired: "La description de l'échantillon est requise",
       magnificationRequired: "Le grossissement est requis",
-      none: "Aucun",
     },
     deviceSection: {
       heading: "Informations sur l'appareil",

--- a/frontend/src/locales/fr/popups.ts
+++ b/frontend/src/locales/fr/popups.ts
@@ -60,10 +60,26 @@ const popups = {
     selectBrand: "Sélectionner une marque",
     selectModel: "Sélectionner un modèle",
     selectLens: "Sélectionner une lentille",
+    none: "Aucun",
     errors: {
       brandRequired: "La marque de l'appareil est requise",
       modelRequired: "Le modèle de l'appareil est requis",
       lensRequired: "La lentille de l'appareil est requise",
+    },
+    validation: {
+      invalidMagnification: "Le grossissement doit être un nombre positif",
+      magnification: {
+        tooSmall: "Le grossissement doit être d'au moins 0,1",
+        tooLarge: "Le grossissement ne peut pas dépasser 1000",
+      },
+      imageName: {
+        empty: "Le préfixe d'identifiant d'échantillon est requis",
+        tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
+      },
+      description: {
+        empty: "La description de l'échantillon est requise",
+        tooLong: "La description de l'échantillon est trop longue",
+      },
     },
   },
 
@@ -162,6 +178,7 @@ const popups = {
         "Seulement lettres, chiffres, points et espaces. Pas d'espaces ou de points consécutifs. Auto-normalisé en perdant le focus.",
       sampleDescriptionRequired: "La description de l'échantillon est requise",
       magnificationRequired: "Le grossissement est requis",
+      none: "Aucun",
     },
     deviceSection: {
       heading: "Informations sur l'appareil",
@@ -203,6 +220,18 @@ const popups = {
       speciesRequired: "L'espèce est requise",
       filesRequired: "Veuillez sélectionner au moins un fichier",
       invalidMagnification: "Le grossissement doit être un nombre positif",
+      magnification: {
+        tooSmall: "Le grossissement doit être d'au moins 0,1",
+        tooLarge: "Le grossissement ne peut pas dépasser 1000",
+      },
+      imageName: {
+        empty: "Le préfixe d'identifiant d'échantillon est requis",
+        tooLong: "Le préfixe d'identifiant d'échantillon est trop long",
+      },
+      description: {
+        empty: "La description de l'échantillon est requise",
+        tooLong: "La description de l'échantillon est trop longue",
+      },
     },
   },
 

--- a/frontend/src/stores/tests/useDeviceStore.test.ts
+++ b/frontend/src/stores/tests/useDeviceStore.test.ts
@@ -317,7 +317,7 @@ describe("useDeviceStore", () => {
 
       const { sampleMetadata } = useDeviceStore.getState();
       expect(sampleMetadata.trayCode).toBe("");
-      expect(sampleMetadata.magnification).toBe(0.1);
+      expect(sampleMetadata.magnification).toBe(1);
       expect(sampleMetadata.sampleIdPrefix).toBe("");
       expect(sampleMetadata.sampleDescription).toBe("");
     });

--- a/frontend/src/stores/tests/useDeviceStore.test.ts
+++ b/frontend/src/stores/tests/useDeviceStore.test.ts
@@ -576,7 +576,7 @@ describe("useDeviceStore", () => {
 
       expect(useDeviceStore.getState().isDeviceInfoSet()).toBe(false);
       expect(useDeviceStore.getState().isSampleMetadataComplete()).toBe(false);
-      expect(useDeviceStore.getState().getMissingMetadataCount()).toBe(7);
+      expect(useDeviceStore.getState().getMissingMetadataCount()).toBe(6);
     });
 
     it("should handle empty device data", () => {

--- a/frontend/src/stores/tests/useDeviceStore.test.ts
+++ b/frontend/src/stores/tests/useDeviceStore.test.ts
@@ -317,7 +317,7 @@ describe("useDeviceStore", () => {
 
       const { sampleMetadata } = useDeviceStore.getState();
       expect(sampleMetadata.trayCode).toBe("");
-      expect(sampleMetadata.magnification).toBe(0);
+      expect(sampleMetadata.magnification).toBe(0.1);
       expect(sampleMetadata.sampleIdPrefix).toBe("");
       expect(sampleMetadata.sampleDescription).toBe("");
     });

--- a/frontend/src/stores/useDeviceStore.ts
+++ b/frontend/src/stores/useDeviceStore.ts
@@ -70,7 +70,7 @@ export const useDeviceStore = create<DeviceState>()(
         set({
           sampleMetadata: {
             trayCode: "",
-            magnification: 0,
+            magnification: 0.1,
             sampleIdPrefix: "",
             sampleDescription: "",
           },

--- a/frontend/src/stores/useDeviceStore.ts
+++ b/frontend/src/stores/useDeviceStore.ts
@@ -47,7 +47,7 @@ export const useDeviceStore = create<DeviceState>()(
       },
       sampleMetadata: {
         trayCode: "",
-        magnification: 0.1,
+        magnification: 1,
         sampleIdPrefix: "",
         sampleDescription: "",
       },
@@ -70,7 +70,7 @@ export const useDeviceStore = create<DeviceState>()(
         set({
           sampleMetadata: {
             trayCode: "",
-            magnification: 0.1,
+            magnification: 1,
             sampleIdPrefix: "",
             sampleDescription: "",
           },

--- a/frontend/src/stores/useDeviceStore.ts
+++ b/frontend/src/stores/useDeviceStore.ts
@@ -47,7 +47,7 @@ export const useDeviceStore = create<DeviceState>()(
       },
       sampleMetadata: {
         trayCode: "",
-        magnification: 0,
+        magnification: 0.1,
         sampleIdPrefix: "",
         sampleDescription: "",
       },


### PR DESCRIPTION
## Summary

Add "None" options to the sample metadata popup so samples can be analysed without a known capture device.

Device brand, model, and lens can now be set to "None" for cases where the image's originating device is unknown. Selecting "None" as the brand cascades down, forcing model and lens to "None" as well. The "None" selection sends the nil UUID (`00000000-0000-0000-0000-000000000000`), which passes device validation and resolves to seeded "None" device rows on the backend rather than being rejected as an unknown device.

The magnification field now defaults to its schema minimum of `0.1` instead of `0`, which was being rejected as too small on open. The stale persisted store value was the root cause of the field rendering empty; the store default, component state default, and the number input's `min` attribute are now aligned at `0.1`.

Missing translation keys are added to the `popups` namespace (EN/FR): `deviceInfo.none` and the previously-unresolved `validation.magnification.*`, `validation.imageName.*`, and `validation.description.*` strings that were rendering as raw key paths.

## Database

A database refresh is required. The "None" device brand, model, and lens rows are seeded through `db_setup_local.py`, so existing local databases must be re-seeded (or the rows added manually) for "None" selections to resolve. Without the refresh, inference submissions with "None" devices will 404 on the device lookup.

## Testing

- Confirmed "None" selectable for brand, model, and lens, and that saving with "None" values passes validation

- Confirmed brand "None" cascades model and lens to "None"

- Confirmed magnification shows `0.1` on open (after clearing stale persisted store state) and saves without a "too small" error

- Confirmed all validation messages render translated text in EN and FR

- Ran a classification with "None" devices end to end against a freshly seeded database

Closes #860