### PR TITLE
Implement quick frontend patching

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -760,7 +760,7 @@ At this point you will have the full stack, you will be able to test integration
 ## Frontend changes
 
 - When making changes to the frontend, ensure that you test the application in different browsers for compatibility.
-- the first step should be to bump the version in the `frontend/package.json` file.
+- the first step should be to bump the version in the `frontend/package.json` and the `frontend/src/_version.ts` file. Simply run `nachet/frontend $ npm version patch`.
 - run the sbom generation script to update the software bill of materials `nachet $ ./generate-sbom.sh frontend`
 - run `npm run prestart`
 - ensure you have .env.config.local in frontend/ and .env.local in backend/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nachet-frontend",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nachet-frontend",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "dependencies": {
         "@azure/msal-browser": "^4.22.1",
         "@azure/msal-react": "^3.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
     "test": "vitest",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
-    "playwright:install-deps": "npx playwright install-deps"
+    "playwright:install-deps": "npx playwright install-deps",
+    "version": "node scripts/gen-version.mjs"
   },
   "dependencies": {
     "@azure/msal-browser": "^4.22.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nachet-frontend",
   "private": true,
-  "version": "3.0.3",
+  "version": "3.0.4",
   "acia-cfia": {
     "backend-version": "2.9.4"
   },

--- a/frontend/scripts/gen-version.mjs
+++ b/frontend/scripts/gen-version.mjs
@@ -18,8 +18,6 @@ const git = (cmd) => {
   }
 };
 
-const hash = git("git rev-parse --short HEAD");
-
 const fields = {
   version: pkg.version,
   name: pkg.name,

--- a/frontend/scripts/gen-version.mjs
+++ b/frontend/scripts/gen-version.mjs
@@ -6,18 +6,6 @@ const OUT = "src/_versions.ts";
 
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 
-const git = (cmd) => {
-  try {
-    return (
-      execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] })
-        .toString()
-        .trim() || undefined
-    );
-  } catch {
-    return undefined;
-  }
-};
-
 const fields = {
   version: pkg.version,
   name: pkg.name,

--- a/frontend/scripts/gen-version.mjs
+++ b/frontend/scripts/gen-version.mjs
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 

--- a/frontend/scripts/gen-version.mjs
+++ b/frontend/scripts/gen-version.mjs
@@ -1,0 +1,50 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const OUT = "src/_versions.ts";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+
+const git = (cmd) => {
+  try {
+    return (
+      execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] })
+        .toString()
+        .trim() || undefined
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+const hash = git("git rev-parse --short HEAD");
+
+const fields = {
+  version: pkg.version,
+  name: pkg.name,
+//   description: pkg.description,
+  versionDate: new Date().toISOString(),
+};
+
+const body = Object.entries(fields)
+  .filter(([, v]) => v !== undefined)
+  .map(([k, v]) => `    ${k}: ${JSON.stringify(v)},`)
+  .join("\n");
+
+const out = `// generated file, do not edit
+export interface TsAppVersion {
+    version: string;
+    name: string;
+    versionDate: string;
+}
+
+export const versions: TsAppVersion = {
+${body}
+};
+
+export default versions;
+`;
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, out);

--- a/frontend/src/_versions.ts
+++ b/frontend/src/_versions.ts
@@ -1,16 +1,14 @@
+// generated file, do not edit
 export interface TsAppVersion {
     version: string;
     name: string;
-    description?: string;
-    versionLong?: string;
     versionDate: string;
-    gitCommitHash?: string;
-    gitCommitDate?: string;
-    gitTag?: string;
-};
+}
+
 export const versions: TsAppVersion = {
-    version: '3.0.3',
-    name: 'nachet-frontend',
-    versionDate: '2026-07-14T19:30:00.000Z',
+    version: "3.0.4",
+    name: "nachet-frontend",
+    versionDate: "2026-07-27T16:36:52.800Z",
 };
+
 export default versions;


### PR DESCRIPTION
## Summary

Automate the frontend version bump so `npm version <major|minor|patch>` keeps `src/_version.ts` in sync.

Adds a `version` lifecycle script to `package.json` that regenerates the version metadata file whenever `npm version` runs. Because npm fires the `version` script after bumping `package.json` but before committing, the regenerated file is picked up in the same version commit, so `package.json` and `src/_version.ts` never drift.

Previously the version file had to be updated by hand alongside the `package.json` bump, which was easy to forget and left the two out of sync on release commits.

## Usage

- `npm version patch` (or `minor` / `major`) bumps `package.json` and regenerates `src/_version.ts` in one step
- The regenerated file is staged automatically and included in the version commit npm creates

## Testing

- Ran `npm version patch` and confirmed `src/_version.ts` updated to the new version in the resulting commit
- Confirmed `package.json` and `src/_version.ts` report the same version afterward
- Confirmed a clean working tree before and after (no stray unstaged changes)