### PR TITLE
Run PR checks after Renovate version bumps

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
   nachet-pyproject-version-bump:
-    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
+    if: ${{ github.actor != 'renovate[bot]' }}
     name: nachet-backend-pyproject-version-bump
     uses: ai-cfia/github-workflows/.github/workflows/workflow-version-bump-python-mono.yml@main
     secrets: inherit

--- a/.github/workflows/backend-renovate-bump.yml
+++ b/.github/workflows/backend-renovate-bump.yml
@@ -2,6 +2,7 @@
 name: Backend Renovate
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 
@@ -30,7 +31,8 @@ jobs:
     if: ${{ github.actor == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      actions: read
+      contents: read
       pull-requests: read
     steps:
       - name: Checkout PR branch
@@ -94,6 +96,8 @@ jobs:
 
       - name: Commit & push changes
         if: steps.check.outputs.changed == 'true'
+        permissions:
+          contents: write
         uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
         with:
           message: "chore: bump backend version for Renovate PRs"
@@ -101,3 +105,9 @@ jobs:
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run backend checks
+        run: |
+          gh workflow run backend-lint.yml --ref "${{ github.head_ref }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/backend-renovate-bump.yml
+++ b/.github/workflows/backend-renovate-bump.yml
@@ -2,7 +2,6 @@
 name: Backend Renovate
 
 permissions:
-  actions: read
   contents: read
   pull-requests: read
 
@@ -28,11 +27,10 @@ defaults:
 jobs:
   bump-version:
     name: Bump version
-    if: ${{ (github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.actor == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
+      contents: write
       pull-requests: read
     steps:
       - name: Checkout PR branch
@@ -96,8 +94,6 @@ jobs:
 
       - name: Commit & push changes
         if: steps.check.outputs.changed == 'true'
-        permissions:
-          contents: write
         uses: EndBug/add-and-commit@ebe9b51bb11d033d228e1a1c3f23ad5bd4110c81
         with:
           message: "chore: bump backend version for Renovate PRs"
@@ -105,9 +101,3 @@ jobs:
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
-
-      - name: Run backend checks
-        run: |
-          gh workflow run backend-lint.yml --ref "${{ github.head_ref }}"
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -39,7 +39,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
+    if: ${{ github.actor != 'renovate[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: frontend

--- a/.github/workflows/frontend-renovate-bump.yml
+++ b/.github/workflows/frontend-renovate-bump.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -128,3 +129,10 @@ jobs:
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run frontend checks
+        if: steps.check.outputs.changed == 'true'
+        run: gh workflow run frontend-lint.yml --ref "$PR_HEAD_REF"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/frontend-renovate-bump.yml
+++ b/.github/workflows/frontend-renovate-bump.yml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]' }}
+    if: ${{ github.actor == 'renovate[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: frontend
@@ -40,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -129,10 +128,3 @@ jobs:
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
-
-      - name: Run frontend checks
-        if: steps.check.outputs.changed == 'true'
-        run: gh workflow run frontend-lint.yml --ref "$PR_HEAD_REF"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/nachet-mini-lint.yml
+++ b/.github/workflows/nachet-mini-lint.yml
@@ -37,7 +37,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
+    if: ${{ github.actor != 'renovate[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: nachet-mini

--- a/.github/workflows/nachet-mini-renovate.yml
+++ b/.github/workflows/nachet-mini-renovate.yml
@@ -1,7 +1,6 @@
 name: Nachet Mini Renovate
 
 permissions:
-  actions: write
   contents: write
   pull-requests: read
 
@@ -26,7 +25,7 @@ defaults:
 
 jobs:
   versions:
-    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'github-actions[bot]' }}
+    if: ${{ github.actor == 'renovate[bot]' }}
     uses: ./.github/workflows/reusable-frontend-versions.yml
     with:
       working-directory: nachet-mini
@@ -126,9 +125,3 @@ jobs:
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
-
-      - name: Run nachet-mini checks
-        run: |
-          gh workflow run nachet-mini-lint.yml --ref "${{ github.head_ref }}"
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nachet-mini-renovate.yml
+++ b/.github/workflows/nachet-mini-renovate.yml
@@ -1,6 +1,7 @@
 name: Nachet Mini Renovate
 
 permissions:
+  actions: write
   contents: write
   pull-requests: read
 
@@ -125,3 +126,9 @@ jobs:
           pull: "--rebase --autostash"
           author_name: "github-actions[bot]"
           author_email: "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run nachet-mini checks
+        run: |
+          gh workflow run nachet-mini-lint.yml --ref "${{ github.head_ref }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Use the workflow actor instead of the PR author in the Renovate bump and lint conditions.

The PR author always remains Renovate, including after GitHub Actions pushes the version commit. The new conditions distinguish those events: Renovate runs the bump, while the pull-request run created by the bump skips another version update and runs the normal checks after approval.

The existing dispatched lint runs are unchanged. This applies to the frontend, backend, and Nachet Mini.

## Testing

- Ran `actionlint` on the three lint workflows and the frontend Renovate workflow
- Ran `git diff origin/main --check`
- Confirmed the actor values against the workflow history from #869

The backend and Nachet Mini Renovate workflows still report pre-existing `actionlint` findings that are unchanged by this PR. The post-bump approval flow still needs to be confirmed on a Renovate PR after merge.

Closes #884