### PR TITLE
Add an example Argo approval workflow

### DIFF
--- a/mlops/README.md
+++ b/mlops/README.md
@@ -1,16 +1,16 @@
 # Example approval workflow
 
-`example-workflow-template.yaml` is a small workflow used to verify Nachet's
-Argo Workflows setup before model-training steps are added. It accepts a
-`dataset-name` parameter and runs three steps:
+`example-workflow-template.yaml` is a small control-flow example used to verify
+Nachet's Argo Workflows setup before model-training steps are added. It accepts
+a `dataset-name` parameter and runs three steps:
 
-1. `prepare` prints the supplied dataset name.
+1. `validate-input` checks the dataset name and publishes it as an output.
 2. `await-approval` pauses the workflow.
-3. `complete` runs after the workflow is resumed.
+3. `record-approval` consumes the validated output after the workflow resumes.
 
 The example does not process a dataset or train a model. It checks that a
-parameter reaches the run and that the run can stop for review before it
-continues.
+parameter reaches the run, that one step can pass an output to another, and
+that the run can stop for review before it continues.
 
 ## Deployment
 
@@ -33,7 +33,7 @@ kubectl apply --filename mlops/example-workflow-template.yaml
 In the Argo Workflows UI:
 
 1. Open **Workflow Templates**.
-2. Select `nachet-mlops-example`.
+2. Select `nachet-workflow-control-example`.
 3. Submit the template, using either the default dataset name or a test value.
 4. Wait for the run to stop at `await-approval`.
 5. Review the completed step, then select **Resume** to continue.
@@ -46,6 +46,6 @@ The same workflow can be submitted from the command line:
 ```bash
 argo submit \
   --namespace argo-workflows \
-  --from workflowtemplate/nachet-mlops-example \
+  --from workflowtemplate/nachet-workflow-control-example \
   --parameter dataset-name=my-dataset
 ```

--- a/mlops/README.md
+++ b/mlops/README.md
@@ -1,8 +1,8 @@
 # Example approval workflow
 
-`example-workflow-template.yaml` is a small control-flow example used to verify
-Nachet's Argo Workflows setup before model-training steps are added. It accepts
-a `dataset-name` parameter and runs three steps:
+`workflows/example-workflow-template.yaml` is a small control-flow example used
+to verify Nachet's Argo Workflows setup before model-training steps are added.
+It accepts a `dataset-name` parameter and runs three steps:
 
 1. `validate-input` checks the dataset name and publishes it as an output.
 2. `await-approval` pauses the workflow.
@@ -15,8 +15,11 @@ that the run can stop for review before it continues.
 ## Deployment
 
 The template is deployed from Git. Howard's `nachet-mlops` Argo CD application
-watches this directory on Nachet's `main` branch and synchronizes its YAML files
-to the `argo-workflows` namespace.
+watches the `mlops/workflows` directory on Nachet's `main` branch and
+synchronizes its rendered resources to the `argo-workflows` namespace.
+Kustomize packages the tested `scripts/record-stage.sh` file into a ConfigMap
+that the example mounts read-only. The ConfigMap keeps a stable name because the
+`WorkflowTemplate` refers to that name directly.
 
 Merging a change updates the template in Howard; it does not start a workflow
 run. Do not apply the template manually in Howard because Argo CD owns the
@@ -25,7 +28,13 @@ deployed copy.
 For local testing outside Howard, apply it with:
 
 ```bash
-kubectl apply --filename mlops/example-workflow-template.yaml
+kubectl apply --kustomize mlops/workflows
+```
+
+Run the script checks independently with:
+
+```bash
+mlops/workflows/tests/record-stage-test.sh
 ```
 
 ## Run the workflow

--- a/mlops/README.md
+++ b/mlops/README.md
@@ -1,0 +1,51 @@
+# Example approval workflow
+
+`example-workflow-template.yaml` is a small workflow used to verify Nachet's
+Argo Workflows setup before model-training steps are added. It accepts a
+`dataset-name` parameter and runs three steps:
+
+1. `prepare` prints the supplied dataset name.
+2. `await-approval` pauses the workflow.
+3. `complete` runs after the workflow is resumed.
+
+The example does not process a dataset or train a model. It checks that a
+parameter reaches the run and that the run can stop for review before it
+continues.
+
+## Deployment
+
+The template is deployed from Git. Howard's `nachet-mlops` Argo CD application
+watches this directory on Nachet's `main` branch and synchronizes its YAML files
+to the `argo-workflows` namespace.
+
+Merging a change updates the template in Howard; it does not start a workflow
+run. Do not apply the template manually in Howard because Argo CD owns the
+deployed copy.
+
+For local testing outside Howard, apply it with:
+
+```bash
+kubectl apply --filename mlops/example-workflow-template.yaml
+```
+
+## Run the workflow
+
+In the Argo Workflows UI:
+
+1. Open **Workflow Templates**.
+2. Select `nachet-mlops-example`.
+3. Submit the template, using either the default dataset name or a test value.
+4. Wait for the run to stop at `await-approval`.
+5. Review the completed step, then select **Resume** to continue.
+
+For this example, resuming the workflow means approving it. Terminate the run
+if it should not continue. There is no separate approve/reject record yet.
+
+The same workflow can be submitted from the command line:
+
+```bash
+argo submit \
+  --namespace argo-workflows \
+  --from workflowtemplate/nachet-mlops-example \
+  --parameter dataset-name=my-dataset
+```

--- a/mlops/example-workflow-template.yaml
+++ b/mlops/example-workflow-template.yaml
@@ -2,10 +2,10 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: nachet-mlops-example
+  name: nachet-workflow-control-example
   namespace: argo-workflows
   labels:
-    app.kubernetes.io/name: nachet-mlops-example
+    app.kubernetes.io/name: nachet-workflow-control-example
     app.kubernetes.io/part-of: nachet
 spec:
   entrypoint: example-pipeline
@@ -17,42 +17,64 @@ spec:
   templates:
     - name: example-pipeline
       steps:
-        - - name: prepare
-            template: log-stage
+        - - name: validate-input
+            template: record-stage
             arguments:
               parameters:
                 - name: stage
-                  value: prepare
+                  value: input-validated
                 - name: dataset-name
                   value: "{{workflow.parameters.dataset-name}}"
         - - name: await-approval
             template: approval
-        - - name: complete
-            template: log-stage
+        - - name: record-approval
+            template: record-stage
             arguments:
               parameters:
                 - name: stage
-                  value: complete
+                  value: approval-recorded
                 - name: dataset-name
-                  value: "{{workflow.parameters.dataset-name}}"
+                  value: >-
+                    {{steps.validate-input.outputs.parameters.dataset-name}}
 
     - name: approval
       suspend: {}
 
-    - name: log-stage
+    - name: record-stage
       inputs:
         parameters:
           - name: stage
           - name: dataset-name
+      outputs:
+        parameters:
+          - name: dataset-name
+            valueFrom:
+              path: /tmp/dataset-name
       container:
-        image: alpine:3.22.1
+        image: >-
+          alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
         command:
           - /bin/sh
           - -c
         args:
-          - printf 'stage=%s dataset=%s\n' "$STAGE" "$DATASET_NAME"
+          - |
+            set -eu
+            : > /tmp/dataset-name
+            if [ -z "$(printf '%s' "$DATASET_NAME" | tr -d '[:space:]')" ]; then
+              printf 'dataset-name must not be empty\n' >&2
+              exit 1
+            fi
+            printf '%s' "$DATASET_NAME" > /tmp/dataset-name
+            printf 'stage=%s dataset=%s\n' "$STAGE" "$DATASET_NAME"
         env:
           - name: STAGE
             value: "{{inputs.parameters.stage}}"
           - name: DATASET_NAME
             value: "{{inputs.parameters.dataset-name}}"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi

--- a/mlops/example-workflow-template.yaml
+++ b/mlops/example-workflow-template.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: nachet-mlops-example
+  namespace: argo-workflows
+  labels:
+    app.kubernetes.io/name: nachet-mlops-example
+    app.kubernetes.io/part-of: nachet
+spec:
+  entrypoint: example-pipeline
+  serviceAccountName: argo-workflow
+  arguments:
+    parameters:
+      - name: dataset-name
+        value: example-dataset
+  templates:
+    - name: example-pipeline
+      steps:
+        - - name: prepare
+            template: log-stage
+            arguments:
+              parameters:
+                - name: stage
+                  value: prepare
+                - name: dataset-name
+                  value: "{{workflow.parameters.dataset-name}}"
+        - - name: await-approval
+            template: approval
+        - - name: complete
+            template: log-stage
+            arguments:
+              parameters:
+                - name: stage
+                  value: complete
+                - name: dataset-name
+                  value: "{{workflow.parameters.dataset-name}}"
+
+    - name: approval
+      suspend: {}
+
+    - name: log-stage
+      inputs:
+        parameters:
+          - name: stage
+          - name: dataset-name
+      container:
+        image: alpine:3.22.1
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - printf 'stage=%s dataset=%s\n' "$STAGE" "$DATASET_NAME"
+        env:
+          - name: STAGE
+            value: "{{inputs.parameters.stage}}"
+          - name: DATASET_NAME
+            value: "{{inputs.parameters.dataset-name}}"

--- a/mlops/workflows/example-workflow-template.yaml
+++ b/mlops/workflows/example-workflow-template.yaml
@@ -54,18 +54,7 @@ spec:
         image: >-
           alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
         command:
-          - /bin/sh
-          - -c
-        args:
-          - |
-            set -eu
-            : > /tmp/dataset-name
-            if [ -z "$(printf '%s' "$DATASET_NAME" | tr -d '[:space:]')" ]; then
-              printf 'dataset-name must not be empty\n' >&2
-              exit 1
-            fi
-            printf '%s' "$DATASET_NAME" > /tmp/dataset-name
-            printf 'stage=%s dataset=%s\n' "$STAGE" "$DATASET_NAME"
+          - /scripts/record-stage.sh
         env:
           - name: STAGE
             value: "{{inputs.parameters.stage}}"
@@ -78,3 +67,12 @@ spec:
           limits:
             cpu: 100m
             memory: 64Mi
+        volumeMounts:
+          - name: scripts
+            mountPath: /scripts
+            readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            name: nachet-workflow-control-scripts
+            defaultMode: 0555

--- a/mlops/workflows/kustomization.yaml
+++ b/mlops/workflows/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argo-workflows
+
+resources:
+  - example-workflow-template.yaml
+
+configMapGenerator:
+  - name: nachet-workflow-control-scripts
+    files:
+      - record-stage.sh=scripts/record-stage.sh
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/mlops/workflows/scripts/record-stage.sh
+++ b/mlops/workflows/scripts/record-stage.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+output_path="${OUTPUT_PATH:-/tmp/dataset-name}"
+
+if [ -z "$(printf '%s' "${DATASET_NAME:-}" | tr -d '[:space:]')" ]; then
+  printf 'dataset-name must not be empty\n' >&2
+  exit 1
+fi
+
+printf '%s' "$DATASET_NAME" > "$output_path"
+printf 'stage=%s dataset=%s\n' "$STAGE" "$DATASET_NAME"

--- a/mlops/workflows/tests/record-stage-test.sh
+++ b/mlops/workflows/tests/record-stage-test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+test_directory="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+script="$test_directory/../scripts/record-stage.sh"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
+
+valid_output="$temporary_directory/dataset-name"
+valid_log="$temporary_directory/valid.log"
+OUTPUT_PATH="$valid_output" \
+  STAGE="input-validated" \
+  DATASET_NAME="seed-lab-batch-1" \
+  "$script" > "$valid_log"
+
+test "$(cat "$valid_output")" = "seed-lab-batch-1"
+grep -Fx \
+  "stage=input-validated dataset=seed-lab-batch-1" \
+  "$valid_log" > /dev/null
+
+invalid_error="$temporary_directory/invalid.err"
+if OUTPUT_PATH="$temporary_directory/invalid-output" \
+  STAGE="input-validated" \
+  DATASET_NAME="   " \
+  "$script" 2> "$invalid_error"; then
+  printf 'expected an empty dataset name to fail\n' >&2
+  exit 1
+fi
+
+grep -Fx "dataset-name must not be empty" "$invalid_error" > /dev/null
+test ! -e "$temporary_directory/invalid-output"


### PR DESCRIPTION
## Summary

Adds a lightweight `WorkflowTemplate` that demonstrates the control flow needed
for the Nachet model-training pipeline.

The example validates a dataset name, passes it between workflow steps, pauses
for manual approval, and records completion after the workflow is resumed. It
does not access a dataset or train a model; those stages will be added
separately once their inputs, outputs, and storage requirements are defined.

## Validation

- [x] Passed strict offline Argo linting and Yamllint.
- [x] Passed Markdownlint and `git diff --check`.
- [x] Confirmed that a valid dataset name is published and consumed as an output.
- [x] Confirmed that the workflow pauses and completes after being resumed.
- [x] Confirmed that an empty dataset name fails before the approval step.

Related to #893.